### PR TITLE
release: spec-520 — the AC-emission path stops paying for a history it deletes

### DIFF
--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -277,8 +277,19 @@ DB_URL="postgresql://${DB_USER}:${DB_PASS_ENC}@localhost:${PROXY_PORT}/${DB_NAME
 
 # Runtime credentials for Cloud Run (spec-199 t-14). Migrations ALWAYS use the
 # superuser path (DB_USER/DB_PASS) — RUNTIME_DB_* is the restricted memex_app
-# role that RLS enforces on. Defaults to DB_USER/DB_PASS until t-14 is rolled
-# out per environment via RUNTIME_DB_USER/RUNTIME_DB_PASS in the deploy-env secret.
+# role that RLS enforces on.
+#
+# ⚠ THE ROLLOUT HAS HAPPENED. This comment used to end "Defaults to DB_USER/DB_PASS until
+# t-14 is rolled out per environment", which read as if the cutover were still pending.
+# Verified 2026-08-31: BOTH memex-int-deploy-env and memex-prod-deploy-env set
+# RUNTIME_DB_USER=memex_app, so the fallback below never fires in either environment and
+# spec-199 t-14's acceptance criteria hold.
+#
+# The stale wording cost real time: it was read as evidence that the request path still ran
+# as the owner, and that conclusion was repeated into a migration comment, a test, and a
+# Spec record before anyone checked the secret. The fallback stays as a safety net for a
+# NEW environment whose secret has not been populated yet — not as a description of int or
+# prod.
 RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"
 RUNTIME_DB_PASS="${RUNTIME_DB_PASS:-$DB_PASS}"
 RUNTIME_DB_PASS_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${RUNTIME_DB_PASS}")
@@ -316,6 +327,23 @@ DATABASE_URL="${DB_URL}" pnpm db:migrate
 
 echo "  1b. hand-written migrations..."
 DATABASE_URL="${DB_URL}" bash "${PKG_DIR}/scripts/apply-hand-migrations.sh"
+
+# spec-520 t-12: create the days ahead, drop the days past the retention window.
+#
+# ⚠ HERE, AND NOT IN THE SERVER. DROP TABLE requires ownership, and the request path's role
+# must not have it [per std-36]. This runs on DB_URL — the owner connection already open for
+# migrations — never on RUNTIME_DB_*. It is deliberately not the in-process setInterval
+# shape used by activity-log-sweep, which runs inside the API server as the runtime role.
+#
+# Idempotent and safe on a schema that predates 0142: it exits quietly if test_events is not
+# partitioned yet. A failure here is NOT fatal to the deploy — 60 days of partitions are
+# created ahead, so a skipped run costs nothing until the horizon is nearly reached, and
+# aborting a deploy over housekeeping would be the wrong trade.
+echo "  1c. test_events partition maintenance..."
+if ! DATABASE_URL="${DB_URL}" node "${PKG_DIR}/scripts/maintain-test-events-partitions.mjs"; then
+  echo "  WARNING: partition maintenance failed — deploy continues (60-day horizon absorbs it)."
+  echo "           Investigate before the horizon runs out, or inserts will start failing."
+fi
 
 # NOTE (spec-417 dec-6): the data backfills/generation that used to run here (1c–1f)
 # now run in Step 5, AFTER the Cloud Run cutover. The cloud-sql-proxy started above

--- a/packages/server/drizzle/0136_spec520_first_verified_tenancy.sql
+++ b/packages/server/drizzle/0136_spec520_first_verified_tenancy.sql
@@ -1,0 +1,71 @@
+-- spec-520 dec-7 option C (ac-23 amended) — give ac_first_verified the tenancy column it
+-- has never had, so it can be isolated like every other tenant table.
+--
+-- WHY THE TABLE STAYS. t-10 planned to fold this into the per-day rollup and drop it. It
+-- cannot be folded: the fact is per (memex_id, subject_ref) — "when did this subject first
+-- go green" — while the rollup's grain is (memex_id, subject_ref, test_identifier, day).
+-- Storing a date at a finer grain than it has forces either a sentinel row with an invented
+-- test_identifier and day, or the date duplicated across every row for that subject and
+-- rewritten daily. Both are worse than a second small table. dec-7 has the full reasoning.
+--
+-- WHAT WAS ACTUALLY WRONG WITH IT — and it is not the storage, it is the tenancy.
+-- `ac_first_verified` is subject_ref PK + first_verified_at, with NO memex_id at all. So it
+-- cannot carry an RLS policy even once spec-399 lands, and its only reader (acsOverTime's
+-- first_pass CTE, services/analytics.ts) scopes by `subject_ref LIKE 'ns/mx/%'` — tenancy
+-- carried by a STRING. That is the spec-396 leak pattern: a real cross-org bleed of ~1.5M
+-- rows across 137 memexes, whose fix was to stop parsing tenancy out of ref strings at read
+-- time. This table never adopted it. That is what this migration closes.
+--
+-- NO DATA MOVES. Every existing row stays exactly where it is with its date untouched —
+-- which matters more here than anywhere: this table exists ONLY because retention destroyed
+-- the first-green date once already, and losing it again while "improving" it would be a
+-- particularly bad repeat.
+--
+-- memex_id IS NULLABLE, DELIBERATELY. The backfill resolves it from test_event_latest,
+-- which carries memex_id for each subject_ref and is never trimmed by retention. A ref with
+-- no surviving summary row — a discontinued AC, a deleted Spec — cannot be resolved, and
+-- the rule from dec-7 is that such a row is ENUMERATED, never silently discarded. Leaving
+-- the column nullable keeps the row and its date: under RLS a NULL memex_id matches no
+-- tenant, so it is invisible to the product but fully visible to the owner role for
+-- inspection. A NOT NULL here would have forced the migration to either fail or delete.
+--
+-- Count what is left behind after applying:
+--   SELECT count(*) FROM ac_first_verified WHERE memex_id IS NULL;
+
+ALTER TABLE ac_first_verified ADD COLUMN IF NOT EXISTS memex_id uuid;
+
+-- Backfill from the summary tier. DISTINCT because test_event_latest is keyed
+-- (subject_ref, test_identifier) — one subject can have many test identifiers, but they all
+-- belong to the same memex, so any one of them answers the question.
+UPDATE ac_first_verified a
+   SET memex_id = l.memex_id
+  FROM (SELECT DISTINCT subject_ref, memex_id FROM test_event_latest) l
+ WHERE a.subject_ref = l.subject_ref
+   AND a.memex_id IS NULL;
+
+-- Index the tenancy column: the read is now `WHERE memex_id = $1` and this table is small
+-- but read on every Insights page load. Cheap to add now, awkward once it is hot.
+CREATE INDEX IF NOT EXISTS ac_first_verified_memex_id_idx ON ac_first_verified (memex_id);
+
+-- ENABLE, never FORCE [per std-36]. FORCE would apply RLS to the table OWNER too, and on
+-- Cloud SQL the migration/deploy role is `postgres`, which is not a real superuser and lacks
+-- BYPASSRLS — under FORCE every migration and admin query here would be filtered to nothing.
+-- 0081 shipped FORCE and 0093 had to undo it; the dynamic guard in
+-- db/spec-199-rls-schema.test.ts fails CI on any forced tenant table.
+ALTER TABLE ac_first_verified ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ac_first_verified_memex_isolation ON ac_first_verified;
+CREATE POLICY ac_first_verified_memex_isolation ON ac_first_verified
+  USING (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  )
+  WITH CHECK (
+    nullif(current_setting('app.memex_id', true), '') IS NOT NULL
+    AND memex_id = current_setting('app.memex_id', true)::uuid
+  );
+
+-- Byte-identical to every other tenant policy on purpose. A table whose isolation reads
+-- differently is a table someone has to reason about separately, and this one has no reason
+-- to be special.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ac_first_verified TO memex_app;

--- a/packages/server/drizzle/0137_spec520_summary_provenance.sql
+++ b/packages/server/drizzle/0137_spec520_summary_provenance.sql
@@ -1,0 +1,43 @@
+-- spec-520 dec-8 option A — carry the emission's PROVENANCE on the summary row, so the
+-- CI-origin audit survives t-12's retention window.
+--
+-- WHAT BREAKS WITHOUT THIS. `auditCiEmissionForBrief` answers "which of your GREEN criteria
+-- were last verified by something other than CI". It reads run_id and metadata from the RAW
+-- log, and it reads them for an AC that is ALREADY verified — so the row can be arbitrarily
+-- old. Today retention keeps 10 rows per pair, which for a rarely-run test spans months.
+-- t-12 replaces that with a short TIME window, and then the row is gone and the code's
+-- `if (!latest) continue` reports "no local-only ACs" — telling the reader the evidence is
+-- STRONGER than it is.
+--
+-- That output is not decorative. It reaches the `assess_spec` MCP tool, which every agent is
+-- instructed to call before every forward phase move, and renders as: "N verified acceptance
+-- criteria's latest emission came from a laptop, not CI ... 'Verified' here rests on a
+-- local-only run the deploy signal can't trust." An audit that quietly starts saying "all
+-- clear" at a phase decision is worse than no audit.
+--
+-- WHY THE RAW COLUMNS AND NOT A BOOLEAN. "CI-originated" is whatever
+-- emissionIsCiOriginated({run_id, metadata}) currently decides — a run_id, or a run_id /
+-- run_url inside metadata. Storing the VERDICT would freeze today's rule into the row and
+-- make any later change unappliable to the past. Storing the inputs keeps it derivable.
+--
+-- ⚠ NULL METADATA MEANS "NEVER OBSERVED", NOT "NOT CI". Rows written before this migration
+-- have no provenance to recover, and there is nothing to backfill from — the raw rows that
+-- knew are the ones retention deletes. Read naively, emissionIsCiOriginated({null, null})
+-- returns FALSE, which would report every pre-existing AC as laptop-verified: a false
+-- POSITIVE, the mirror of the false negative this migration exists to prevent.
+--
+-- The discriminator costs nothing extra: applyEmissionToSummary writes metadata as `{}` when
+-- an emission carries none, so from here on the column is always non-NULL. NULL therefore
+-- means exactly one thing — this row predates provenance being recorded — and the audit
+-- treats it as UNKNOWN and skips it, which is what it does today for a missing row.
+--
+-- NEITHER COLUMN IS INDEXED [per std-39 cl-7]. This row is updated on every emission for its
+-- pair; an indexed jsonb column would defeat HOT updates and hand autovacuum the difference.
+-- The audit reads by subject_ref, which the primary key already covers.
+
+ALTER TABLE test_event_latest ADD COLUMN IF NOT EXISTS latest_run_id text;
+ALTER TABLE test_event_latest ADD COLUMN IF NOT EXISTS latest_metadata jsonb;
+
+-- No backfill, deliberately. See the NULL-means-unknown note above: inventing a value here
+-- would be inventing provenance, and provenance is the one thing this column exists to be
+-- honest about.

--- a/packages/server/drizzle/0139_spec520_rollup_tenant_fk.sql
+++ b/packages/server/drizzle/0139_spec520_rollup_tenant_fk.sql
@@ -1,0 +1,80 @@
+-- spec-520 t-13 (ac-30) — give test_run_daily the cascading tenant FK that migration
+-- 0134 should have declared, so workspace deletion reaches it BY CONSTRUCTION.
+--
+-- THE DEFECT THIS CLOSES, AND WHOSE IT IS. 0134 declared `memex_id uuid NOT NULL` with no
+-- REFERENCES clause. Every other tenant table in this database is reached automatically
+-- when a memex row goes: 16 carry an ON DELETE CASCADE foreign key to `memexes`, and
+-- others (acs, issues) inherit it transitively through `documents`. The emission family —
+-- test_events, test_event_latest, ac_first_verified and, as shipped, test_run_daily —
+-- carries NO foreign key at all, direct or transitive. It sits outside the cascade graph.
+--
+-- WHY IT NEVER BIT BEFORE. Retention was the de facto eraser on this path: the trim capped
+-- test_events, so a deleted tenant's rows aged out on their own. test_run_daily is
+-- PERMANENT by design — it exists so history survives retention — and grows per tenant,
+-- per subject, per test, per day, forever. Nothing would ever remove it. And t-12 is about
+-- to stop retention erasing test_events too.
+--
+-- ⚠ THE LEAK IS LATENT, NOT LIVE. There is no production tenant-deletion path today: the
+-- only DELETE against memexes/orgs/namespaces in the entire server is the env-gated test
+-- surface, no route deletes a memex, and there is no soft-delete column. So nothing is
+-- orphaned yet. This constraint is what makes the guarantee true in advance of that path
+-- being built, rather than a line someone must remember to add to an enumeration — which
+-- is exactly the distinction t-13 draws. The three sibling tables are recorded as a
+-- separate finding; they predate this Spec and fixing them is not its scope.
+--
+-- LOCKS [per std-39 cl-2/cl-3]. Adding a foreign key normally takes ACCESS EXCLUSIVE and
+-- then scans the whole table to validate — on a continuously-written table that is the
+-- shape that deadlocked and rolled back a prod deploy during spec-398 (std-39 cl-9). So
+-- it is split in two:
+--
+--   * THIS FILE adds the constraint NOT VALID. That takes ACCESS EXCLUSIVE but performs NO
+--     scan, so the exclusive window is O(1) rather than O(rows). New writes are checked
+--     from this moment on.
+--   * 0140 validates it, under SHARE UPDATE EXCLUSIVE, which does not block reads OR
+--     writes.
+--
+-- The split is load-bearing because the migration runner wraps each FILE in its own
+-- transaction (scripts/apply-hand-migrations.mjs). Putting both statements here would hold
+-- the ACCESS EXCLUSIVE lock from the ADD until the VALIDATE finished, and the weaker lock
+-- would buy nothing.
+--
+-- lock_timeout is SET LOCAL so it dies with this transaction and cannot leak into the
+-- migrations that follow on the same connection. Failing fast is correct here: a deploy
+-- that cannot get the lock in three seconds should retry on the next one, not queue behind
+-- the emission path and stall it.
+--
+-- WRITE COST [per std-39 cl-7], MEASURED — not reasoned. The first draft of this comment
+-- claimed the referential check fires only on genuinely new rows, because the rollup's
+-- writes are `INSERT ... ON CONFLICT DO UPDATE` and the DO UPDATE branch never touches
+-- memex_id. THAT CLAIM IS WRONG, and the benchmark said so.
+--
+-- 20,000 all-conflicting upserts, arms interleaved with a VACUUM before each timing so
+-- accumulating dead tuples could not favour whichever arm ran first (local pg16,
+-- 2026-08-30):
+--
+--     with FK     272 ms   262 ms   244 ms      (mean ~259)
+--     without FK  216 ms   215 ms   222 ms      (mean ~218)
+--
+-- A consistent ~41 ms per 20k, i.e. **~2 µs per upsert**, ~19% on this microbenchmark.
+-- The RI trigger fires on the UPDATE path too and pays for the comparison even when the
+-- referencing column is unchanged. (EXPLAIN ANALYZE cannot settle this — it surfaced no
+-- "Trigger for constraint" line for RI checks on this version, which is what sent the
+-- first draft down the reasoning-instead-of-measuring path.)
+--
+-- WHY THAT IS STILL FINE. 2 µs sits against an emission transaction that already does an
+-- insert, two upserts and a first-verified write. At the measured production rate of
+-- ~31 events/s that is ~62 µs of CPU per second — 0.006% of one core — to buy a tenancy
+-- guarantee that holds without anyone maintaining a list. A 19% figure on a synthetic
+-- single-statement loop is not a 19% figure on the emission path.
+--
+-- NO NEW INDEX. A cascading delete needs to find the child rows by memex_id; the table's
+-- PRIMARY KEY is (memex_id, subject_ref, test_identifier, day), so its leading column
+-- already serves that. Adding one would put another index tuple on every increment for no
+-- gain (cl-7).
+
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE test_run_daily
+  ADD CONSTRAINT test_run_daily_memex_id_fkey
+  FOREIGN KEY (memex_id) REFERENCES memexes(id) ON DELETE CASCADE
+  NOT VALID;

--- a/packages/server/drizzle/0140_spec520_rollup_tenant_fk_validate.sql
+++ b/packages/server/drizzle/0140_spec520_rollup_tenant_fk_validate.sql
@@ -1,0 +1,17 @@
+-- spec-520 t-13 (ac-30) — validate the tenant FK added NOT VALID in 0139.
+--
+-- Separate FILE, therefore a separate transaction (the runner wraps each file in its own
+-- sql.begin), which is the whole point: VALIDATE CONSTRAINT takes SHARE UPDATE EXCLUSIVE
+-- and blocks neither reads nor writes, so the emission path keeps running while the scan
+-- proceeds. Merged into 0139 it would have inherited that file's ACCESS EXCLUSIVE lock for
+-- the duration of the scan.
+--
+-- The scan can only fail on an orphan row — a rollup row whose memex_id names no memex.
+-- None can exist: the column has always been written from the resolved emitting Memex
+-- (std-32, never parsed from subject_ref), and there is no tenant-deletion path in
+-- production that could have stranded one. A failure here would therefore be real news
+-- about the write path, not migration noise, and it should stop the deploy.
+
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE test_run_daily VALIDATE CONSTRAINT test_run_daily_memex_id_fkey;

--- a/packages/server/drizzle/0142_spec520_partition_test_events.sql
+++ b/packages/server/drizzle/0142_spec520_partition_test_events.sql
@@ -1,0 +1,209 @@
+-- spec-520 t-12, STEP 2 of 2 — test_events becomes time-partitioned; the per-pair trim dies.
+--
+-- ⚠ RUN drizzle/out-of-band/0141_..._prep.sql FIRST, and confirm its index is VALID.
+-- Without it this migration builds a 1.4M-row unique index inside its exclusive window.
+--
+-- WHAT THIS BUYS. `trimTestEventsForPair` deleted the oldest rows of a pair inside every
+-- emission transaction: 13.4% of all database time, 11.24M deletes against 11.87M inserts,
+-- and autovacuum running near-continuously behind it. Retention becomes a property of
+-- WHICH PARTITION a row landed in. Rows leave only when an aged-out partition is dropped —
+-- a catalogue operation. No deletes, no dead tuples, nothing to vacuum. The 13.4% does not
+-- shrink; it goes to zero.
+--
+-- ── HOW THIS AVOIDS REPEATING 0111 ──────────────────────────────────────────────────────
+--
+-- spec-398's migration 0111 restructured this same table by copying every row into a new
+-- one, holding ACCESS EXCLUSIVE for ~80 s — and its first prod release DEADLOCKED against
+-- live traffic (40P01) and rolled the whole file back. That is std-39 cl-9's worked
+-- example, and it is this table.
+--
+-- This migration COPIES NOTHING. The existing table is renamed and ATTACHed as the first
+-- partition of a new parent, which is a catalogue operation plus one validation scan.
+--
+-- MEASURED at production scale (local pg16, 1.4M rows, 2026-08-30): the entire exclusive
+-- window below — create parent, adopt the PK, attach 1.4M rows, create the parent
+-- indexes — is **~150 ms**. Not an estimate; the probe ran.
+--
+-- ⚠ WHY 150 ms MATTERS AND 80 s DOES NOT MERELY "COST LATENCY". The AC emitter has a 5 s
+-- client timeout and NEVER retries (std-48 — a retry storm against a saturated server is
+-- worse than a dropped event). So a blocked emission is not delayed, it is DISCARDED, with
+-- only a warning in someone's CI log. At ~31 events/s an 80 s window silently drops ~2,500
+-- emissions and leaves their ACs on a stale verdict. 150 ms drops none.
+--
+-- ── LOCK ORDER (std-39 cl-2/cl-3) ───────────────────────────────────────────────────────
+--
+-- Live emissions take test_events then test_event_latest, in that order
+-- (routes/test-events.ts). This migration takes BOTH up front in the SAME order, so no
+-- lock-order cycle can form: it either wins a clean window or fails fast on lock_timeout
+-- and retries on the next deploy. It can never deadlock.
+--
+-- The LOCK is wrapped in a DO block because this file is applied two ways: the hand-runner
+-- wraps it in one transaction (a bare LOCK is fine there), while the e2e-cold template
+-- build pipes it through `psql -f` in AUTOCOMMIT, where a bare LOCK errors with "can only
+-- be used in transaction blocks". A DO block runs its body in an implicit transaction in
+-- both paths. That lesson is 0111's too.
+--
+-- ── WHAT THIS MIGRATION DELIBERATELY DOES NOT DO ────────────────────────────────────────
+--
+-- IT DELETES NO DATA. Every existing row is carried into the legacy partition, whatever its
+-- age. Retention is applied afterwards, by maintenance, from configuration — so the
+-- irreversible moment is a separate, config-driven step that can be paused, not a side
+-- effect of a schema change. A 3-day window would otherwise have discarded 1,046,386 of
+-- the 1,404,630 rows here, at the exact moment the schema was also changing.
+--
+-- IT ADDS NO RLS. spec-398 ac-10 asserts test_events carries none and that spec-399 owns
+-- it; verified against the live catalogue 2026-08-30 (relrowsecurity = false). ⚠ FOR
+-- spec-399: a policy created on this parent is INHERITED by every partition, including ones
+-- maintenance creates later — so the policy belongs on the PARENT and must never be written
+-- per-partition. Designing that is spec-399's call, not an assumption to inherit from here.
+
+-- ── 0. Deadlock guard — both locks up front, in the emission path's order ────────────────
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '10s';
+  -- ONE statement, listing them in the emission path's order — the same form 0111 settled
+  -- on after its deadlock, so the two migrations read identically and the discipline is
+  -- copyable rather than reconstructed each time.
+  LOCK TABLE test_events, test_event_latest IN ACCESS EXCLUSIVE MODE;
+END $$;
+
+-- ── 1. The whole swap, in one dynamic block ─────────────────────────────────────────────
+--
+-- Dynamic because the partition boundary is computed AT RUN TIME. Hardcoding a date would
+-- force this file and the deploy calendar to agree; a deploy that slipped past it would
+-- start rejecting inserts. `date_trunc('day', now()) + 1 day` means the legacy partition
+-- absorbs everything up to the next UTC midnight and the daily partitions take over
+-- cleanly from there, whenever the deploy actually happens.
+DO $$
+DECLARE
+  boundary   timestamptz := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + interval '1 day';
+  view_def   text;
+  part_start timestamptz;
+  horizon    int := 60;   -- keep in step with PARTITION_HORIZON_DAYS in test-event-retention.ts
+BEGIN
+  -- The activity_view test_events arm would silently follow the table through the rename
+  -- and end up reading the LEGACY PARTITION instead of the parent — seeing old rows only,
+  -- with no error anywhere. It is captured and replayed rather than re-typed here: a
+  -- hardcoded copy would be a snapshot of the view as it was the day this was written, and
+  -- 0119 already renamed a column inside it once since 0111.
+  SELECT pg_get_viewdef('activity_view'::regclass, true) INTO view_def;
+  DROP VIEW activity_view;
+
+  -- The old PK is on (id) alone. A partitioned parent keyed (id, created_at) requires each
+  -- partition to carry an equivalent unique index; 0141 built it CONCURRENTLY.
+  ALTER TABLE test_events RENAME TO test_events_legacy;
+
+  -- ⚠ SELF-SUFFICIENT ON PURPOSE. 0141 builds this index CONCURRENTLY so production never
+  -- pays for the build inside the exclusive window — but every FRESH database (each
+  -- per-worker test DB, the e2e cold-template build, a new dev machine) applies migrations
+  -- through the runner, which never sees out-of-band/. Depending on 0141 made
+  -- `pnpm db:migrate` fail everywhere except prod. On prod the index already exists and
+  -- follows the rename, so IF NOT EXISTS skips it; on a fresh database the table is empty
+  -- and the build is instant. 0141 is now an optimisation, not a prerequisite.
+  CREATE UNIQUE INDEX IF NOT EXISTS test_events_id_created_at_key
+    ON test_events_legacy (id, created_at);
+
+  ALTER TABLE test_events_legacy DROP CONSTRAINT test_events_new_pkey;
+  ALTER TABLE test_events_legacy ADD PRIMARY KEY USING INDEX test_events_id_created_at_key;
+
+  CREATE TABLE test_events (
+    id              uuid        NOT NULL DEFAULT gen_random_uuid(),
+    subject_ref     text        NOT NULL,
+    memex_id        uuid        NOT NULL,
+    status          text        NOT NULL,
+    test_identifier text,
+    duration_ms     integer,
+    commit_sha      text,
+    run_id          text,
+    actor           text,
+    hidden          boolean     NOT NULL DEFAULT false,
+    metadata        jsonb,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT test_events_pkey PRIMARY KEY (id, created_at),
+    CONSTRAINT test_events_status_valid CHECK (status = ANY (ARRAY['pass'::text, 'fail'::text, 'error'::text]))
+  ) PARTITION BY RANGE (created_at);
+
+  -- ⚠ NO DEFAULT PARTITION, and that was measured rather than reasoned. Once rows for a day
+  -- land in a DEFAULT partition, creating that day's real partition FAILS outright:
+  --   ERROR: updated partition constraint for default partition would be violated by some row
+  -- A default would turn a quiet gap between deploys into a migration that cannot apply
+  -- until someone drains it by hand. A missing partition is instead a loud, immediate
+  -- insert error, and the 60-day horizon exists so it is never reached.
+  EXECUTE format(
+    'ALTER TABLE test_events ATTACH PARTITION test_events_legacy FOR VALUES FROM (%L) TO (%L)',
+    '2000-01-01'::timestamptz, boundary);
+
+  -- ⚠ BOUNDS ARE timestamptz, NEVER date. A `date` used as a partition bound is
+  -- interpreted in the SESSION's timezone, not UTC. This migration was first written with
+  -- `boundary::date` and failed immediately on a machine running Europe/Lisbon:
+  --
+  --   ERROR: partition "test_events_20260831" would overlap partition "test_events_legacy"
+  --
+  -- because boundary was 2026-08-31 00:00 UTC while the date literal '2026-08-31' resolved
+  -- to 2026-08-30 23:00 UTC — the daily partition started an hour before the legacy one
+  -- ended. Cloud SQL runs UTC, so this would have passed in production and lain in wait
+  -- for the first developer or restore on a non-UTC server. %L on a timestamptz emits a
+  -- literal carrying its offset, so no session can reinterpret it.
+  part_start := boundary;
+  WHILE part_start < boundary + (horizon || ' days')::interval LOOP
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS test_events_%s PARTITION OF test_events FOR VALUES FROM (%L) TO (%L)',
+      to_char(part_start AT TIME ZONE 'UTC', 'YYYYMMDD'), part_start, part_start + interval '1 day');
+    part_start := part_start + interval '1 day';
+  END LOOP;
+
+  -- ⚠ THE LEGACY PARTITION'S INDEXES ARE RENAMED FIRST, AND THAT IS LOAD-BEARING.
+  --
+  -- After the table rename its indexes keep their original names, so they still occupy
+  -- `test_events_retention_idx` and friends. The first version of this migration used
+  -- CREATE INDEX **IF NOT EXISTS** with those same names — which found the names taken and
+  -- silently created NOTHING on the parent. The rehearsal under load caught it: the parent
+  -- ended up with only its primary key, so every FORWARD partition had only a PK too, and
+  -- from the first daily partition onward the matrix, the digest, the Pulse and the
+  -- activity feed would all have sequential-scanned ~2.7M rows a day. A NOTICE is the only
+  -- thing that would have said so, and it scrolled past.
+  --
+  -- Renaming frees the canonical names, and IF NOT EXISTS is gone: at this point in the
+  -- migration a name collision is a bug, and it must stop the deploy rather than disarm the
+  -- statement.
+  --
+  -- Creating an index on the parent then REUSES the (renamed) matching index on the legacy
+  -- partition rather than rebuilding it — verified on pg16 — so the 1.4M legacy rows cost
+  -- nothing and only the empty forward partitions are built.
+  --
+  -- Index inventory, checked with EXPLAIN against every surviving reader on develop
+  -- 2026-08-30 rather than assumed from the names:
+  --   retention_idx (subject_ref, test_identifier, created_at)
+  --       KEPT. Named for the trim being deleted, but it is the workhorse: it serves the
+  --       AC matrix's row_number() read, BOTH of the digest's CTEs, and the targeted
+  --       discontinue delete. Dropping it "with the trim" would have been a plausible,
+  --       measurable mistake.
+  --   memex_id_created_at_idx  KEPT — the activity_view arm.
+  --   created_at_idx           KEPT — testSignalPulse's window. Partition pruning narrows
+  --                            it to a day, but a day holds ~2.7M rows.
+  -- Two more exist today and were chosen by NO reader in that sweep:
+  -- ac_uid_created_at_idx (subject_ref, created_at) and test_identifier_idx. They are NOT
+  -- dropped here — a local EXPLAIN sweep is not proof about prod, and pg_stat_user_indexes
+  -- on prod settles it. Carried forward unchanged; retiring them is a separate, evidenced
+  -- change. Every index carried costs a tuple per insert on every partition (cl-7), so
+  -- this is a real cost being consciously deferred, not overlooked.
+  ALTER INDEX test_events_retention_idx           RENAME TO test_events_legacy_retention_idx;
+  ALTER INDEX test_events_memex_id_created_at_idx RENAME TO test_events_legacy_memex_created_idx;
+  ALTER INDEX test_events_created_at_idx          RENAME TO test_events_legacy_created_at_idx;
+  ALTER INDEX test_events_ac_uid_created_at_idx   RENAME TO test_events_legacy_subject_created_idx;
+  ALTER INDEX test_events_test_identifier_idx     RENAME TO test_events_legacy_test_ident_idx;
+
+  CREATE INDEX test_events_retention_idx           ON test_events (subject_ref, test_identifier, created_at);
+  CREATE INDEX test_events_memex_id_created_at_idx ON test_events (memex_id, created_at);
+  CREATE INDEX test_events_created_at_idx          ON test_events (created_at);
+  CREATE INDEX test_events_ac_uid_created_at_idx   ON test_events (subject_ref, created_at);
+  CREATE INDEX test_events_test_identifier_idx     ON test_events (test_identifier, created_at);
+
+  -- 0081's GRANT ... ON ALL TABLES was a one-time statement; it does not reach a table
+  -- created today. Every table added since carries its own explicit grant, and omitting it
+  -- here would 401 nothing and 500 everything: the runtime role would lose the emission
+  -- path entirely.
+  GRANT SELECT, INSERT, UPDATE, DELETE ON test_events TO memex_app;
+
+  EXECUTE format('CREATE VIEW activity_view WITH (security_invoker = true) AS %s', view_def);
+END $$;

--- a/packages/server/drizzle/out-of-band/0138_spec520_ac_health_index.sql
+++ b/packages/server/drizzle/out-of-band/0138_spec520_ac_health_index.sql
@@ -1,0 +1,50 @@
+-- spec-520 t-4 (ac-9) — the (memex_id, subject_ref) index on test_event_latest.
+--
+-- ⚠ THIS FILE IS NOT APPLIED BY `pnpm db:migrate`, AND THAT IS THE POINT.
+--
+-- `scripts/apply-hand-migrations.mjs` wraps EVERY migration in `sql.begin()`, and
+-- `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block — Postgres refuses it
+-- outright. The runner reads `drizzle/` with a NON-recursive readdirSync, so this
+-- subdirectory is invisible to it by construction rather than by anyone remembering.
+-- `out-of-band-migrations.regression.test.ts` pins both halves of that.
+--
+-- 0131 hit the same wall and chose a plain inline CREATE INDEX, correctly: `documents` is
+-- in the low hundreds of rows per Memex, a build measured in milliseconds. It also wrote
+-- down when that stops being the right call — "if it ever grows to the point where this
+-- stops being true, a future index on it belongs out-of-band". test_event_latest is that
+-- case: 182,634 rows and 64MB of heap on prod, continuously written by the emission path.
+--
+-- HOW TO APPLY (prod, and int first):
+--   1. PAM grant `memex-prod-deploy-server`, then cloud-sql-proxy — the
+--      `prod-analytics-readonly-access` recipe, minus the read-only transaction setting.
+--   2. Run the statement below. CONCURRENTLY takes no ACCESS EXCLUSIVE lock, so emissions
+--      keep writing throughout; it is slower and can fail leaving an INVALID index.
+--   3. Verify: the query at the bottom must report indisvalid = true. If it is false, DROP
+--      the index and re-run — an invalid index is never used but is still maintained on
+--      every write, which is the worst of both.
+--
+-- ⚠ DO NOT EXPECT THIS TO FIX THE 642 ms READ, and do not let anyone size it that way.
+-- s-4 §3 EXPLAINed the tenant that generates the load: ONE Memex holds 81.0% of this table
+-- (147,989 of 182,634 rows). For it, `memex_id = $1` selects four rows in five, and Postgres
+-- will correctly prefer a SEQUENTIAL SCAN — an index scan touching four rows in five is
+-- slower. This index helps the many small tenants and will be declined for the big one.
+-- spec-520 ac-8 expects an index scan and is wrong for exactly that reason (see c-4).
+--
+-- The win t-4 actually delivers is in the code, not here: 1,223 statement fingerprints
+-- collapse to 1, and planning time goes 7.564 ms -> 0.037 ms.
+--
+-- WRITE COST (cl-19): low, and worth checking rather than assuming. test_event_latest's PK
+-- is (subject_ref, test_identifier); every emission UPDATEs latest_status / latest_run_at /
+-- run_count / latest_run_id / latest_metadata. None of those is in this index, and neither
+-- memex_id nor subject_ref changes on update — so HOT updates still apply and the ~23.5M
+-- lifetime updates pay nothing for it. The cost falls on INSERTs only (~195k lifetime).
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS test_event_latest_memex_subject_idx
+  ON test_event_latest (memex_id, subject_ref);
+
+-- Verify the build actually completed. An interrupted CONCURRENTLY build leaves the index
+-- present but INVALID: never used by the planner, still maintained on every write.
+--
+--   SELECT c.relname, i.indisvalid
+--     FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+--    WHERE c.relname = 'test_event_latest_memex_subject_idx';

--- a/packages/server/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql
+++ b/packages/server/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql
@@ -1,0 +1,49 @@
+-- spec-520 t-12 — OUT OF BAND. An OPTIMISATION for production, not a prerequisite.
+--
+-- ⚠ THIS FILE IS DELIBERATELY OUTSIDE THE MIGRATION RUNNER. apply-hand-migrations.mjs
+-- wraps every file in one transaction, and CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction block. Same posture as 0138. The runner's readdirSync is non-recursive, so a
+-- file in out-of-band/ is never picked up automatically.
+--
+-- ⚠ 0142 DOES NOT DEPEND ON THIS FILE. It creates the same index itself with IF NOT
+-- EXISTS, because every fresh database — each per-worker test DB, the e2e cold-template
+-- build, a new dev machine — applies migrations through a runner that never sees
+-- out-of-band/. Running this file first is what keeps PRODUCTION's build out of the
+-- exclusive window; skipping it does not break anything, it just makes the window as long
+-- as the index build.
+--
+-- WHY IT EXISTS. 0142 converts test_events into a partitioned table by ATTACHing the
+-- existing table as its first partition. A partitioned parent whose PRIMARY KEY is
+-- (id, created_at) requires each partition to carry an equivalent unique index. The
+-- existing PK is on (id) alone, so a new one has to be built — and building it inside the
+-- migration would hold ACCESS EXCLUSIVE for the length of the build on the hottest table
+-- in the system.
+--
+-- Built CONCURRENTLY here, it blocks no writes at all. 0142 then adopts it with
+-- ADD PRIMARY KEY USING INDEX, which is a catalogue operation.
+--
+-- MEASURED (local pg16, 2026-08-30, 1.4M rows — production scale): with this index already
+-- in place, 0142's entire exclusive window is ~150 ms. Without it, the build lands inside
+-- that window. For comparison, spec-398's migration 0111 held ACCESS EXCLUSIVE for ~80 s
+-- to copy 1.9M rows, and deadlocked a prod deploy on its first attempt (std-39 cl-9).
+--
+-- ⚠ 150 ms VERSUS 80 s IS NOT A TIDINESS ARGUMENT. The AC emitter has a 5 s client timeout
+-- and NEVER retries (std-48): a blocked emission is not delayed, it is DROPPED, silently,
+-- with only a warning in the CI log. At the measured ~31 events/s, an 80 s window discards
+-- roughly 2,500 emissions and the ACs they carried keep a stale verdict. A 150 ms window
+-- discards none.
+--
+-- RUN IT LIKE THIS (int first, then prod), with the deploy proxy up:
+--
+--     psql "$DB_URL" -f packages/server/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql
+--
+-- THEN CONFIRM IT IS VALID before deploying 0142. A CONCURRENTLY build that fails leaves an
+-- INVALID index behind, which 0142 would happily adopt as a primary key that enforces
+-- nothing:
+--
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'test_events_id_created_at_key'::regclass;
+--
+-- If it returns false: DROP INDEX test_events_id_created_at_key; and run this file again.
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS test_events_id_created_at_key
+  ON test_events (id, created_at);

--- a/packages/server/drizzle/reverts/0142_spec520_partition_test_events.revert.sql
+++ b/packages/server/drizzle/reverts/0142_spec520_partition_test_events.revert.sql
@@ -1,0 +1,96 @@
+-- Manual rollback for 0142_spec520_partition_test_events.sql. The hand-migration runner has
+-- no revert mode; this file lives outside `drizzle/*.sql` (in `drizzle/reverts/`) so the
+-- runner won't auto-apply it. Operators run it via psql when an explicit rollback is
+-- required.
+--
+--   psql "$DATABASE_URL" -f drizzle/reverts/0142_spec520_partition_test_events.revert.sql
+--   psql "$DATABASE_URL" -c "DELETE FROM manual_migrations WHERE filename = '0142_spec520_partition_test_events';"
+--
+-- ══ READ THIS BEFORE RUNNING IT ══════════════════════════════════════════════════════════
+--
+-- ⚠ YOU ALMOST CERTAINLY DO NOT NEED THIS FILE. The previous application code runs
+-- UNCHANGED against the partitioned table — verified: the old per-pair trim's
+-- `DELETE ... WHERE id IN (SELECT ... OFFSET 10)` executes normally against a partitioned
+-- parent and produced exactly its old behaviour (15 rows trimmed to 10). Nothing in the
+-- pre-0142 code depends on the table being unpartitioned, and nothing looks a test_event up
+-- by `id` alone, so widening the PK to (id, created_at) breaks no query.
+--
+-- So the FIRST rollback move is to redeploy the previous revision and leave the schema
+-- alone. The trim simply starts deleting again — wasteful, not wrong. Reverting an
+-- application deploy is a routine, reversible act; unpicking a schema on a table taking
+-- ~31 writes/second is not. Reach for this file only if the PARTITIONING ITSELF is the
+-- problem.
+--
+-- ⚠ THE IRREVERSIBLE MOMENT IS NOT THIS MIGRATION — IT IS THE FIRST PARTITION DROP.
+-- 0142 copies and deletes nothing: every pre-existing row stays in `test_events_legacy`,
+-- physically the same rows in the same table, merely renamed and attached. Data starts
+-- disappearing only when `scripts/maintain-test-events-partitions.mjs` drops an aged-out
+-- partition, and the legacy partition is dropped once its upper bound (the midnight after
+-- the migration) is older than TEST_EVENTS_RETENTION_DAYS.
+--
+-- With the default 3-day window that is roughly FOUR DAYS after the migration — and only on
+-- a deploy, because maintenance runs from deploy.sh and nowhere else. No deploy, no drop.
+-- Check before assuming you still have a clean window:
+--
+--   SELECT count(*) FROM pg_class c JOIN pg_inherits i ON i.inhrelid = c.oid
+--    WHERE i.inhparent = 'test_events'::regclass AND c.relname = 'test_events_legacy';
+--
+-- 1 = the pre-migration history is intact and this file restores everything.
+-- 0 = it has been dropped. This file will still run and still preserve every row that
+--     remains, but the days already dropped are gone and only a backup brings them back.
+--
+-- ⚠ ROWS WRITTEN AFTER THE CUTOVER ARE PRESERVED, and that is the part a naive revert gets
+-- wrong. They live in the daily partitions, not in legacy, so detaching legacy and dropping
+-- the parent would silently discard every emission since the migration. This file detaches
+-- legacy FIRST (while attached, its range bound forbids post-cutover timestamps), copies the
+-- remaining rows back into it, and only then drops the parent.
+--
+-- REHEARSED, not reasoned: run against a probe database holding rows on both sides of the
+-- boundary (10 legacy + 4 in daily partitions), it returned a plain table with all 14 rows,
+-- a queryable activity_view, and the memex_app grant intact.
+--
+-- LOCKS: same discipline as 0142 and for the same reason — both taken up front in the
+-- emission path's order (test_events, then test_event_latest), bounded by lock_timeout, so
+-- this can fail fast but never deadlock against live traffic. That is spec-398 migration
+-- 0111's lesson (std-39 cl-9) and it applies just as much on the way back.
+
+-- ⚠ THE LOCK LIVES INSIDE THE DO BLOCK, and this is not style. Operators run this file with
+-- `psql -f`, which is AUTOCOMMIT: a bare `LOCK TABLE` there fails outright with "can only be
+-- used in transaction blocks", and a bare `SET LOCAL` silently does nothing. A DO block runs
+-- its body in an implicit transaction, so both hold. 0142 carries the same note for the same
+-- reason — the first draft of this file got it wrong and was caught by running the file
+-- rather than the statements.
+DO $$
+DECLARE view_def text;
+BEGIN
+  SET LOCAL lock_timeout = '10s';
+  LOCK TABLE test_events, test_event_latest IN ACCESS EXCLUSIVE MODE;
+
+  -- activity_view depends on test_events and would follow the rename to the wrong relation.
+  -- Captured and replayed rather than re-typed, so a rollback cannot ship a stale copy of a
+  -- view that has been edited since.
+  SELECT pg_get_viewdef('activity_view'::regclass, true) INTO view_def;
+  DROP VIEW activity_view;
+
+  -- Detach FIRST. While attached, legacy's range bound rejects any post-cutover row.
+  ALTER TABLE test_events DETACH PARTITION test_events_legacy;
+
+  -- Carry every emission written since the cutover back in. Nothing is discarded.
+  INSERT INTO test_events_legacy SELECT * FROM test_events;
+
+  DROP TABLE test_events;                      -- takes the daily partitions with it
+  ALTER TABLE test_events_legacy RENAME TO test_events;
+
+  -- Give the canonical names back to the indexes the partitioned parent had claimed.
+  ALTER INDEX test_events_legacy_retention_idx       RENAME TO test_events_retention_idx;
+  ALTER INDEX test_events_legacy_memex_created_idx   RENAME TO test_events_memex_id_created_at_idx;
+  ALTER INDEX test_events_legacy_created_at_idx      RENAME TO test_events_created_at_idx;
+  ALTER INDEX test_events_legacy_subject_created_idx RENAME TO test_events_ac_uid_created_at_idx;
+  ALTER INDEX test_events_legacy_test_ident_idx      RENAME TO test_events_test_identifier_idx;
+
+  -- The PK stays (id, created_at). Narrowing it back to (id) buys nothing — no query looks
+  -- a test_event up by id alone — and would mean rebuilding a unique index on the whole
+  -- table inside this lock.
+  GRANT SELECT, INSERT, UPDATE, DELETE ON test_events TO memex_app;
+  EXECUTE format('CREATE VIEW activity_view WITH (security_invoker = true) AS %s', view_def);
+END $$;

--- a/packages/server/scripts/maintain-test-events-partitions.mjs
+++ b/packages/server/scripts/maintain-test-events-partitions.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// spec-520 t-12 — partition maintenance for test_events. Creates the days ahead, drops the
+// days past the retention window.
+//
+// ⚠ RUNS AS THE OWNING ROLE, FROM DEPLOY — NEVER FROM THE REQUEST PATH.
+// DROP TABLE requires ownership, and the request path's role must not have it [per
+// std-36]. deploy.sh already holds an owner connection for migrations (DB_URL); this hooks
+// in beside them. It is deliberately NOT the in-process setInterval shape used by
+// activity-log-sweep: that runs inside the API server, as the runtime role, which is
+// exactly the role this must not be.
+//
+// FAILURE DIRECTION, ON PURPOSE. If no deploy happens for a long time:
+//   • no new partitions are created — but 60 days of horizon were pre-created, so inserts
+//     keep working;
+//   • no old partitions are dropped — so the table GROWS.
+// Growing is the safe failure. The alternative (a DEFAULT partition as a catch-all) was
+// measured and rejected: once rows land in a default, creating that day's real partition
+// fails outright, so the next deploy's migration cannot apply until someone drains it.
+//
+// IDEMPOTENT. Creating is IF NOT EXISTS; dropping only touches partitions whose entire
+// range is already outside the window. Re-running changes nothing.
+
+import postgres from "postgres";
+
+const RETENTION_DAYS = clampInt(process.env.TEST_EVENTS_RETENTION_DAYS, 3, 1, 90);
+const HORIZON_DAYS = 60; // keep in step with PARTITION_HORIZON_DAYS in test-event-retention.ts
+
+function clampInt(raw, fallback, min, max) {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min) return fallback;
+  return Math.min(n, max);
+}
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error("[partitions] DATABASE_URL is required");
+  process.exit(1);
+}
+
+const sql = postgres(url, { max: 1 });
+
+try {
+  // Bail out quietly if the table is not partitioned yet — this script ships with 0142 but
+  // deploy.sh calls it unconditionally, and a deploy of an older schema must not fail here.
+  const [{ kind } = {}] = await sql`
+    SELECT relkind AS kind FROM pg_class WHERE relname = 'test_events'
+  `;
+  if (kind !== "p") {
+    console.log("[partitions] test_events is not partitioned yet — nothing to do");
+    process.exit(0);
+  }
+
+  // ── create ahead ────────────────────────────────────────────────────────────────────
+  // The day list and the cutoff are computed in JS from ONE reading of the database clock.
+  // Deriving them in SQL meant parameterising intervals inside a tagged template, which
+  // postgres.js cannot type ("could not determine data type of parameter $1"). One clock
+  // read also means every decision below shares a single instant — a loop that re-read
+  // now() could straddle midnight and create or drop the wrong day.
+  const [{ now: dbNow }] = await sql`SELECT now() AS now`;
+  const nowMs = new Date(dbNow).getTime();
+  const DAY_MS = 86_400_000;
+  // Midnight UTC of the current day, so bounds never depend on the session timezone —
+  // a `date` bound is resolved in the SESSION's zone, which silently shifts every boundary
+  // on a non-UTC server. 0142 hit exactly that.
+  const todayUtc = Date.UTC(
+    new Date(nowMs).getUTCFullYear(),
+    new Date(nowMs).getUTCMonth(),
+    new Date(nowMs).getUTCDate(),
+  );
+
+  const nameFor = (ms) => `test_events_${new Date(ms).toISOString().slice(0, 10).replace(/-/g, "")}`;
+
+  // Read every existing partition's REAL range once, and use it for both halves below.
+  //
+  // ⚠ COVERAGE, NOT NAMES. The first version skipped a day when a table of that NAME
+  // existed — which let it try to create test_events_20260830 while `test_events_legacy`
+  // already covered that day, and Postgres refused with "would overlap". The legacy
+  // partition is the whole point of the attach-based migration and it is not named for a
+  // day, so any name-based reasoning is wrong here by construction.
+  const partitions = (
+    await sql`
+      SELECT c.relname AS name, pg_get_expr(c.relpartbound, c.oid) AS bound
+      FROM pg_class c
+      JOIN pg_inherits i ON i.inhrelid = c.oid
+      WHERE i.inhparent = 'test_events'::regclass
+    `
+  ).map((row) => {
+    const m = /FROM \('([^']+)'\) TO \('([^']+)'\)/.exec(row.bound ?? "");
+    return {
+      name: row.name,
+      from: m ? new Date(m[1]).getTime() : null,
+      to: m ? new Date(m[2]).getTime() : null, // null for a DEFAULT partition
+    };
+  });
+
+  const covered = (from, to) =>
+    partitions.some((p) => p.from !== null && p.to !== null && p.from < to && p.to > from);
+
+  let madeCount = 0;
+  for (let i = 0; i <= HORIZON_DAYS; i++) {
+    const from = todayUtc + i * DAY_MS;
+    const to = from + DAY_MS;
+    if (covered(from, to)) continue;
+    const name = nameFor(from);
+    await sql.unsafe(
+      `CREATE TABLE IF NOT EXISTS ${name} PARTITION OF test_events ` +
+        `FOR VALUES FROM ('${new Date(from).toISOString()}') TO ('${new Date(to).toISOString()}')`,
+    );
+    partitions.push({ name, from, to });
+    madeCount += 1;
+  }
+
+  // ── drop what is entirely past the window ───────────────────────────────────────────
+  // The partition's UPPER bound is read from the catalogue rather than parsed out of its
+  // name: a partition whose name and bounds disagree (a hand-made one, a restore) would
+  // otherwise be dropped on the strength of its name. This also covers `test_events_legacy`
+  // with no special case — it is dropped once its whole range, which ends at the
+  // migration's boundary, has aged out.
+  const cutoffMs = nowMs - RETENTION_DAYS * DAY_MS;
+
+  let droppedCount = 0;
+  for (const row of partitions) {
+    if (row.to === null) continue; // a DEFAULT partition has no TO bound — never dropped here
+    if (!Number.isFinite(row.to) || row.to > cutoffMs) continue;
+    // DETACH first, then DROP. Detaching takes a brief lock on the parent and leaves a
+    // standalone table; dropping that table then touches nothing the emission path uses.
+    // A bare DROP of an attached partition holds its lock on the parent for the whole drop.
+    await sql.unsafe(`ALTER TABLE test_events DETACH PARTITION ${row.name}`);
+    await sql.unsafe(`DROP TABLE ${row.name}`);
+    droppedCount += 1;
+    console.log(`[partitions] dropped ${row.name} (ended ${new Date(row.to).toISOString()}, window ${RETENTION_DAYS}d)`);
+  }
+
+  console.log(
+    `[partitions] created ${madeCount} ahead (horizon ${HORIZON_DAYS}d), dropped ${droppedCount} past the ${RETENTION_DAYS}d window`,
+  );
+} catch (err) {
+  console.error("[partitions] FAILED", err);
+  process.exitCode = 1;
+} finally {
+  await sql.end({ timeout: 5 });
+}

--- a/packages/server/scripts/rehearse-test-events-partition.sh
+++ b/packages/server/scripts/rehearse-test-events-partition.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# spec-520 t-12 — rehearse migration 0142 against a realistic-volume copy UNDER CONCURRENT
+# WRITE LOAD, and record the result. This is the AC an agent cannot satisfy alone; it needs
+# a database the agent must not touch.
+#
+# WHY THIS EXISTS AND WHY IT IS NOT OPTIONAL. spec-398's migration 0111 restructured this
+# same table and its first production release DEADLOCKED against live traffic (40P01) and
+# rolled back — std-39 cl-9's worked example. 0142 is designed so that cannot recur (both
+# locks taken up front in the emission path's order, and no row copy at all), and the design
+# was measured: ~150 ms of ACCESS EXCLUSIVE at 1.4M rows. But "measured on an idle local
+# database" is not "measured under load", and the difference is exactly where 0111 failed.
+#
+# WHAT IT DOES
+#   1. Builds a throwaway database at realistic volume (default 1.5M rows, ~prod).
+#   2. Starts N writers hammering the emission shape — INSERT + summary UPSERT in one
+#      transaction, in the SAME lock order as routes/test-events.ts.
+#   3. Applies 0141 (out-of-band) then 0142 while they run.
+#   4. Reports: how long the exclusive window actually took, whether any writer saw a
+#      deadlock or a lock timeout, and how many writes were lost.
+#
+# WHAT TO RECORD ON t-12 AFTERWARDS: the exclusive-window duration, the writer error count
+# by SQLSTATE, and the row counts before/after. A rehearsal whose result is not written down
+# has not been rehearsed.
+#
+#   ./scripts/rehearse-test-events-partition.sh [ROWS] [WRITERS] [SECONDS]
+#
+# Defaults: 1500000 rows, 8 writers, load running throughout the migration.
+set -euo pipefail
+
+ROWS="${1:-1500000}"
+WRITERS="${2:-8}"
+PGPORT_LOCAL="${PGPORT_LOCAL:-5433}"
+DB="memex_t12_rehearsal"
+PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export PGPASSWORD="${PGPASSWORD:-postgres}"
+PSQL="psql -h localhost -p ${PGPORT_LOCAL} -U postgres"
+URL="postgresql://postgres:postgres@localhost:${PGPORT_LOCAL}/${DB}"
+
+echo "── building a ${ROWS}-row copy in ${DB} ─────────────────────────────────────"
+$PSQL -q -c "DROP DATABASE IF EXISTS ${DB}" postgres
+$PSQL -q -c "CREATE DATABASE ${DB}" postgres
+for f in "${PKG_DIR}"/drizzle/*.sql; do
+  # Stop before the migration under rehearsal — it is applied later, under load.
+  case "$f" in *0142_spec520_partition_test_events.sql) break;; esac
+  psql -v ON_ERROR_STOP=1 "$URL" -f "$f" >/dev/null
+done
+
+psql -q "$URL" <<SQL
+INSERT INTO namespaces (slug, kind) VALUES ('reh', 'org') ON CONFLICT DO NOTHING;
+INSERT INTO memexes (namespace_id, slug, name)
+  SELECT id, 'mx', 'rehearsal' FROM namespaces WHERE slug='reh' ON CONFLICT DO NOTHING;
+INSERT INTO test_events (subject_ref, memex_id, status, test_identifier, created_at)
+SELECT 'reh/mx/specs/spec-' || (g % 500) || '/acs/ac-' || (g % 40),
+       (SELECT m.id FROM memexes m JOIN namespaces n ON n.id=m.namespace_id WHERE n.slug='reh'),
+       (ARRAY['pass','fail','error'])[1 + (g % 3)],
+       'file' || (g % 200) || '.test.ts::it',
+       now() - ((g % 90) || ' days')::interval - ((g % 86400) || ' seconds')::interval
+FROM generate_series(1, ${ROWS}) g;
+ANALYZE test_events;
+SQL
+echo "rows: $(psql -t -A "$URL" -c 'SELECT count(*) FROM test_events')"
+
+echo "── starting ${WRITERS} writers in the emission's lock order ─────────────────"
+ERRLOG="$(mktemp)"
+for i in $(seq 1 "$WRITERS"); do
+  (
+    while [ ! -f /tmp/t12_rehearsal_stop ]; do
+      psql -v ON_ERROR_STOP=1 "$URL" -q >>"$ERRLOG" 2>&1 <<SQL || true
+BEGIN;
+INSERT INTO test_events (subject_ref, memex_id, status, test_identifier)
+  VALUES ('reh/mx/specs/spec-1/acs/ac-1',
+          (SELECT m.id FROM memexes m JOIN namespaces n ON n.id=m.namespace_id WHERE n.slug='reh'),
+          'pass', 'load::w${i}');
+INSERT INTO test_event_latest (subject_ref, test_identifier, latest_status, latest_run_at, memex_id, run_count)
+  VALUES ('reh/mx/specs/spec-1/acs/ac-1', 'load::w${i}', 'pass', now(),
+          (SELECT m.id FROM memexes m JOIN namespaces n ON n.id=m.namespace_id WHERE n.slug='reh'), 1)
+  ON CONFLICT (subject_ref, test_identifier) DO UPDATE SET run_count = test_event_latest.run_count + 1;
+COMMIT;
+SQL
+    done
+  ) &
+done
+rm -f /tmp/t12_rehearsal_stop
+sleep 3
+
+echo "── applying 0141 (out-of-band) UNDER LOAD ──────────────────────────────────"
+/usr/bin/time -f "  0141 wall: %e s" psql -v ON_ERROR_STOP=1 "$URL" \
+  -f "${PKG_DIR}/drizzle/out-of-band/0141_spec520_test_events_partition_prep.sql" 2>&1 | tail -2
+
+echo "── applying 0142 UNDER LOAD — this is the exclusive window ─────────────────"
+START=$(date +%s.%N)
+psql -v ON_ERROR_STOP=1 "$URL" -f "${PKG_DIR}/drizzle/0142_spec520_partition_test_events.sql" 2>&1 | tail -3
+END=$(date +%s.%N)
+
+touch /tmp/t12_rehearsal_stop
+sleep 2
+wait 2>/dev/null || true
+
+echo ""
+echo "══ RESULT ══════════════════════════════════════════════════════════════════"
+echo "  exclusive window (0142 wall clock): $(echo "$END - $START" | bc) s"
+echo "  partitioned:  $(psql -t -A "$URL" -c "SELECT relkind FROM pg_class WHERE relname='test_events'")  (want p)"
+echo "  rows after:   $(psql -t -A "$URL" -c 'SELECT count(*) FROM test_events')"
+echo "  partitions:   $(psql -t -A "$URL" -c "SELECT count(*) FROM pg_inherits WHERE inhparent='test_events'::regclass")"
+echo ""
+echo "  writer errors by kind (empty = no writer was refused):"
+grep -oE 'ERROR:[^\"]*' "$ERRLOG" | sort | uniq -c | sed 's/^/    /' || echo "    none"
+echo ""
+echo "  ⚠ A deadlock (40P01) or a lock timeout (55P03) here is the 0111 failure repeating."
+echo "    Record this whole block on spec-520 t-12 before promoting past int."
+rm -f "$ERRLOG" /tmp/t12_rehearsal_stop

--- a/packages/server/src/__regression__/ac-health-bind-shape.regression.test.ts
+++ b/packages/server/src/__regression__/ac-health-bind-shape.regression.test.ts
@@ -1,0 +1,82 @@
+// spec-520 t-4 (ac-7 / ac-11) — no hot-path read binds one parameter per AC ref.
+//
+// ⚠ THIS IS A SOURCE SCAN, and it is worth saying so rather than dressing it as behavioural.
+// The claim is about the SHAPE of the generated SQL, and the honest behavioural test would
+// compare pg_stat_statements queryids across two runs with different ref counts — identical
+// under the fix, different before it. pg_stat_statements is not loaded on the local cluster
+// (it needs shared_preload_libraries and a restart), so that test cannot run here. What CAN
+// be pinned locally is that the offending construct does not come back, which is the
+// regression that actually threatens this fix. Correctness is covered separately and
+// behaviourally by ac-health-parity.spec-520.test.ts.
+//
+// THE COST BEING PREVENTED. `inArray(testEventLatest.subjectRef, refs)` emits
+// `subject_ref IN ($1, $2, … $n)`. Each distinct n is its own prepared statement, plan-cache
+// entry and pg_stat_statements row. Measured on prod: 1,098 fingerprints on 2026-08-18 and
+// 1,223 on 2026-08-28 — ~12/day, ~24.5% of the instance's 5,000-entry cap, which is 98.6%
+// full and already evicting (issue-10). Planning time for the 1,800-literal form was 7.564 ms
+// against 0.037 ms for the simple one.
+//
+// The two replacements are deliberately DIFFERENT, and neither is a stylistic preference:
+//   • aggregateAcHealthForBriefs -> `memex_id = $1`. It already read every row of the tenant
+//     (the seq scan touches them all), so scoping tenant-wide costs nothing and makes
+//     tenancy an explicit predicate instead of an inference from ref-string uniqueness.
+//   • listAcsForBriefWithVerification and the clause-coverage read -> `= ANY($1::text[])`.
+//     These serve ONE Spec / one standard, so a tenant-wide read would fetch ~148k rows for
+//     the largest Memex to filter down to a handful. ANY is one parameter regardless of ref
+//     count, which removes the fragmentation without the over-fetch.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_SCOPED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-7";
+const AC_NO_WIDE_IN = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-11";
+
+const src = (rel: string) =>
+  readFileSync(resolve(import.meta.dirname, "..", rel), "utf8");
+
+describe("spec-520 ac-7 / ac-11: no read binds one parameter per AC ref", () => {
+  it("no hot-path read passes a ref ARRAY to inArray against test_event_latest.subject_ref", () => {
+    tagAc(AC_NO_WIDE_IN);
+    // Located by construct, not by line — this Spec's line references have drifted between
+    // grounding passes, and the task says so explicitly.
+    const offenders: string[] = [];
+    for (const rel of ["services/acs.ts", "services/clause-coverage.ts"]) {
+      const text = src(rel);
+      if (/inArray\(\s*testEventLatest\.subjectRef/.test(text)) offenders.push(rel);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("aggregateAcHealthForBriefs scopes the summary read on memex_id", () => {
+    tagAc(AC_SCOPED);
+    const text = src("services/acs.ts");
+    // The whole function, isolated so a match elsewhere in this large file cannot pass it.
+    const start = text.indexOf("export async function aggregateAcHealthForBriefs");
+    expect(start).toBeGreaterThan(-1);
+    const body = text.slice(start, start + 6000);
+    expect(body).toMatch(/eq\(testEventLatest\.memexId, memexId\)/);
+  });
+
+  it("the single-Spec reads bind the ref list as ONE array parameter", () => {
+    tagAc(AC_NO_WIDE_IN);
+    for (const rel of ["services/acs.ts", "services/clause-coverage.ts"]) {
+      const text = src(rel);
+      // sql.param() is the load-bearing half: a bare `${refs}` makes drizzle interpolate the
+      // array as a LIST of parameters — the very fragmentation being removed — and fails
+      // against `= ANY(…)` outright. That is not hypothetical; it happened while building
+      // this, and the query errored with the array flattened into separate params.
+      expect(text).toMatch(/ANY\(\$\{sql\.param\(allRefs\)\}::text\[\]\)/);
+    }
+  });
+
+  it("both single-Spec reads also carry an explicit memex_id predicate", () => {
+    tagAc(AC_SCOPED);
+    // Tenancy stops being an inference from ref-string uniqueness (the spec-396 posture),
+    // and it is what makes the (memex_id, subject_ref) index usable for these reads at all.
+    for (const rel of ["services/acs.ts", "services/clause-coverage.ts"]) {
+      expect(src(rel)).toMatch(/eq\(testEventLatest\.memexId, memexId\)/);
+    }
+  });
+});

--- a/packages/server/src/__regression__/no-hidden-migration.regression.test.ts
+++ b/packages/server/src/__regression__/no-hidden-migration.regression.test.ts
@@ -76,6 +76,13 @@ describe("spec-358: no migration un-hides, deletes, or rewrites historical test_
       // re-hides, or recomputes it — spec-358's hidden-integrity invariant holds
       // (the retention drop is a separate, deliberate concern, not a hidden mutation).
       "0111_test_events_retention_and_memex_id.sql",
+      // spec-520 t-12: the partitioning swap declares `hidden` in the new parent table's
+      // column list. It is a STRUCTURAL reference only, and a stronger case than 0111's:
+      // where 0111 copied each surviving row's hidden value into a new table, this
+      // migration copies nothing at all — the existing table is ATTACHed as the first
+      // partition, so every historical row is physically the same row it always was and
+      // its hidden value is not read, written, or recomputed.
+      "0142_spec520_partition_test_events.sql",
     ]);
   });
 });

--- a/packages/server/src/__regression__/out-of-band-migrations.regression.test.ts
+++ b/packages/server/src/__regression__/out-of-band-migrations.regression.test.ts
@@ -1,0 +1,66 @@
+// spec-520 t-4 (ac-9) — CREATE INDEX CONCURRENTLY must never reach the migration runner.
+//
+// The runner (`scripts/apply-hand-migrations.mjs`) wraps every migration in `sql.begin()`,
+// and CONCURRENTLY cannot run inside a transaction block. A file that needs it therefore
+// lives in `drizzle/out-of-band/`, which the runner's NON-recursive readdirSync cannot see.
+//
+// Both halves are pinned here because both are easy to undo by accident: someone adds
+// CONCURRENTLY to a normal migration (fails at deploy, loudly), or someone makes the runner
+// recursive to "pick up everything" (fails at deploy, also loudly, but after the recursive
+// change looks like a tidy-up in review).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const AC_OUT_OF_BAND = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-39";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const drizzleDir = resolve(import.meta.dirname, "../../drizzle");
+
+describe("spec-520 ac-39: out-of-band index builds stay out of the transactional runner", () => {
+  it("no migration the runner picks up contains CREATE INDEX CONCURRENTLY", () => {
+    tagAc(AC_OUT_OF_BAND);
+    // Exactly the runner's own glob: readdirSync (non-recursive) filtered to .sql.
+    const applied = readdirSync(drizzleDir).filter((f) => f.endsWith(".sql"));
+    const offenders = applied.filter((f) => {
+      // STRIP `--` COMMENT LINES FIRST. 0125 and 0131 both DISCUSS CONCURRENTLY at length —
+      // explaining why they correctly chose a plain inline CREATE INDEX instead — and that
+      // prose is exactly what we want future migrations to keep writing. A check that fails
+      // on files for reasoning about the constraint would punish the documentation it
+      // depends on. The first draft of this test did precisely that.
+      const sqlOnly = readFileSync(resolve(drizzleDir, f), "utf8")
+        .split("\n")
+        .filter((l) => !l.trim().startsWith("--"))
+        .join("\n");
+      return /CREATE\s+INDEX\s+CONCURRENTLY/i.test(sqlOnly);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("the runner's directory read is NOT recursive, so out-of-band/ stays invisible", () => {
+    tagAc(AC_OUT_OF_BAND);
+    const runner = readFileSync(
+      resolve(import.meta.dirname, "../../scripts/apply-hand-migrations.mjs"),
+      "utf8",
+    );
+    // A `recursive: true` here would silently pull out-of-band files into a transaction and
+    // break the deploy — after a change that reads as harmless tidying.
+    expect(runner).toMatch(/readdirSync\(drizzleDir\)/);
+    expect(runner).not.toMatch(/readdirSync\(drizzleDir,\s*\{[^}]*recursive/);
+  });
+
+  it("the out-of-band file exists and carries its apply + verify instructions", () => {
+    tagAc(AC_OUT_OF_BAND);
+    // A statement nobody knows how to run is not a migration, it is a note. The file has to
+    // say how to apply it AND how to confirm the build did not leave an INVALID index —
+    // invalid means never used by the planner but still maintained on every write.
+    const oob = readFileSync(
+      resolve(drizzleDir, "out-of-band/0138_spec520_ac_health_index.sql"),
+      "utf8",
+    );
+    expect(oob).toMatch(/CREATE INDEX CONCURRENTLY/);
+    expect(oob).toMatch(/indisvalid/);
+    expect(oob).toMatch(/HOW TO APPLY/);
+  });
+});

--- a/packages/server/src/__regression__/test-events-migration-lock-discipline.regression.test.ts
+++ b/packages/server/src/__regression__/test-events-migration-lock-discipline.regression.test.ts
@@ -1,0 +1,109 @@
+// spec-520 t-12 (ac-13) — EVERY migration that locks test_events must do it the way 0111
+// eventually learned to, not just the one that learned it.
+//
+// WHY THIS EXISTS SEPARATELY FROM spec-398's GUARD. That guard is hardcoded to
+// `0111_test_events_retention_and_memex_id.sql`. It was written the day 0111's lock
+// discipline was fixed and it pins exactly that file — so 0142, which restructures the same
+// table and carries exactly the same hazard, shipped with no guard at all. The next one
+// would too.
+//
+// THE HAZARD IT GUARDS. 0111's first production release deadlocked (Postgres 40P01) against
+// live traffic and rolled the whole file back — std-39 cl-9's worked example. The cause was
+// lock ORDER: the migration took test_event_latest before test_events, while every live
+// emission takes them the other way round (routes/test-events.ts). Two parties, two locks,
+// opposite orders.
+//
+// This scans EVERY migration that takes ACCESS EXCLUSIVE on test_events and holds each to
+// the same four rules, so the discipline is a property of the table rather than a property
+// of one file someone remembered to pin.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+const DIR = join(__dirname, "..", "..", "drizzle");
+
+/** Strip line comments so prose ABOUT locking cannot satisfy — or trip — the scan. */
+function stripComments(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("--"))
+    .join("\n");
+}
+
+/** Every migration that actually takes ACCESS EXCLUSIVE on test_events. */
+function lockingMigrations(): Array<{ file: string; sql: string }> {
+  return readdirSync(DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .map((f) => ({ file: f, sql: stripComments(readFileSync(join(DIR, f), "utf-8")).toLowerCase() }))
+    .filter(({ sql }) => /lock\s+table[^;]*test_events[^;]*access\s+exclusive/s.test(sql));
+}
+
+describe("spec-520 ac-13 — lock discipline on every test_events migration", () => {
+  it("finds the migrations to hold to the rule (a scan that matches nothing proves nothing)", () => {
+    tagAc(AC_PARTITIONED);
+    const files = lockingMigrations().map((m) => m.file);
+    // Without this, a regex that silently stopped matching would leave every assertion
+    // below vacuously green — the failure mode of every allowlist-shaped guard.
+    expect(files).toContain("0111_test_events_retention_and_memex_id.sql");
+    expect(files).toContain("0142_spec520_partition_test_events.sql");
+  });
+
+  for (const { file, sql } of lockingMigrations()) {
+    describe(file, () => {
+      it("locks in the APP's emission order — test_events BEFORE test_event_latest", () => {
+        tagAc(AC_PARTITIONED);
+        // Order of ACQUISITION, not of syntax. Both forms are legitimate and both appear in
+        // this directory: 0111 uses one combined `LOCK TABLE a, b`, 0142 uses two separate
+        // statements. A guard that only understood one form would have passed the other
+        // vacuously — which is how a lock-order guard silently stops guarding.
+        const stmts = [...sql.matchAll(/lock\s+table([^;]*)in\s+access\s+exclusive\s+mode/gs)]
+          .map((m) => m[1]);
+        const acquisition = stmts.join(" | ");
+        // THE ACTUAL 0111 BUG. Reversing these two is what deadlocked production.
+        expect(acquisition).toContain("test_events");
+        expect(acquisition).toContain("test_event_latest");
+        expect(acquisition.indexOf("test_events")).toBeLessThan(
+          acquisition.indexOf("test_event_latest"),
+        );
+      });
+
+      it("bounds the wait with a lock_timeout set BEFORE the lock", () => {
+        tagAc(AC_PARTITIONED);
+        expect(sql).toMatch(/set\s+(local\s+)?lock_timeout\s*=\s*'[^']+'/);
+        const setIdx = sql.search(/set\s+(local\s+)?lock_timeout/);
+        const lockIdx = sql.search(/lock\s+table/);
+        // Set afterwards it protects nothing: the migration would already be queued behind
+        // live traffic on the hottest table in the system, holding the deploy open.
+        expect(setIdx).toBeGreaterThanOrEqual(0);
+        expect(lockIdx).toBeGreaterThan(setIdx);
+      });
+
+      it("wraps the LOCK in a DO block, so it survives the transactional runner AND autocommit psql -f", () => {
+        tagAc(AC_PARTITIONED);
+        // These files are applied two ways: apply-hand-migrations wraps each in ONE
+        // transaction, while the e2e-cold template build pipes them through `psql -f` in
+        // AUTOCOMMIT — where a bare LOCK TABLE errors with "can only be used in transaction
+        // blocks". A DO block runs its body in an implicit transaction in both.
+        const lockIdx = sql.search(/lock\s+table/);
+        const doIdx = sql.lastIndexOf("do $$", lockIdx);
+        expect(doIdx).toBeGreaterThanOrEqual(0);
+        expect(doIdx).toBeLessThan(lockIdx);
+      });
+
+      it("acquires the locks BEFORE any schema or data statement", () => {
+        tagAc(AC_PARTITIONED);
+        const lockIdx = sql.search(/lock\s+table/);
+        const firstDdl = sql.search(
+          /\b(create\s+table|alter\s+table|create\s+index|drop\s+table|drop\s+view|insert\s+into|update\s+|delete\s+from)/,
+        );
+        expect(lockIdx).toBeGreaterThanOrEqual(0);
+        // A statement that runs before the lock runs unlocked — it can take its own lock in
+        // the wrong order and reopen the exact cycle the up-front LOCK exists to close.
+        if (firstDdl >= 0) expect(lockIdx).toBeLessThan(firstDdl);
+      });
+    });
+  }
+});

--- a/packages/server/src/db/rls-tables.ts
+++ b/packages/server/src/db/rls-tables.ts
@@ -20,6 +20,9 @@
 // is an identity-establishment table read BEFORE any tenant context exists, so
 // it must stay RLS-free (pinned by __regression__/emission-key-contextless-verify).
 export const RLS_TENANT_TABLES: ReadonlySet<string> = new Set([
+  // spec-520 dec-7 option C — gated by migration 0136. Registering it here also arms
+  // spec-440's context guard for it.
+  "ac_first_verified",
   "acs",
   "clause_refs",
   "comment_mentions",

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1113,6 +1113,16 @@ export const testEventLatest = pgTable(
     // spec-398 dec-4 (ac-8): tenancy column mirroring test_events [per std-32],
     // backfilled in the rewrite-and-swap migration. RLS is spec-399's (ac-9).
     memexId: uuid("memex_id").notNull(),
+    // spec-520 dec-8 option A (migration 0137): the latest emission's PROVENANCE, so the
+    // CI-origin audit survives t-12's retention window. The raw inputs rather than a
+    // computed boolean, so the "is this CI" rule stays derivable if it ever changes.
+    //
+    // ⚠ latestMetadata NULL means "never observed", NOT "not CI". Rows predating 0137 have
+    // no provenance to recover. From 0137 on, applyEmissionToSummary writes `{}` when an
+    // emission carries no metadata, so NULL is unambiguous — and the audit must treat it as
+    // UNKNOWN and skip, or every pre-existing AC reads as laptop-verified.
+    latestRunId: text("latest_run_id"),
+    latestMetadata: jsonb("latest_metadata").$type<Record<string, string> | null>(),
   },
   (table) => [
     primaryKey({ columns: [table.subjectRef, table.testIdentifier] }),

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1138,6 +1138,19 @@ export const acFirstVerified = pgTable("ac_first_verified", {
   // spec-151 dec-3: renamed ac_uid → subject_ref (AC ref OR clause ref).
   subjectRef: text("subject_ref").primaryKey(),
   firstVerifiedAt: timestamp("first_verified_at", { withTimezone: true }).notNull(),
+  // spec-520 dec-7 option C (migration 0136): the tenancy column this table never had.
+  //
+  // Without it the table could not carry an RLS policy at all, and its only reader scoped
+  // by `subject_ref LIKE 'ns/mx/%'` — tenancy carried by a STRING, the spec-396 leak
+  // pattern this Spec closes elsewhere. That, not the storage cost, was what was actually
+  // wrong with this table.
+  //
+  // NULLABLE on purpose. Backfilled from test_event_latest; a subject_ref with no surviving
+  // summary row (a discontinued AC, a deleted Spec) cannot be resolved, and dec-7's rule is
+  // that such a row is ENUMERATED, never discarded — this table exists because first-green
+  // dates were lost once already. Under RLS a NULL memex_id matches no tenant, so the row is
+  // invisible to the product and fully visible to the owner role for inspection.
+  memexId: uuid("memex_id"),
 });
 
 // ══════════════════════════════════════

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1209,7 +1209,12 @@ export const acFirstVerified = pgTable("ac_first_verified", {
 export const testRunDaily = pgTable(
   "test_run_daily",
   {
-    memexId: uuid("memex_id").notNull(),
+    // spec-520 t-13 (ac-30): the cascading tenant FK migration 0134 omitted. Workspace
+    // deletion reaches this table BY CONSTRUCTION, not by an enumeration someone
+    // maintains — see drizzle/0139.
+    memexId: uuid("memex_id")
+      .notNull()
+      .references(() => memexes.id, { onDelete: "cascade" }),
     subjectRef: text("subject_ref").notNull(),
     testIdentifier: text("test_identifier").notNull().default(""),
     // UTC calendar day the runs fall on. Derived from the event's own

--- a/packages/server/src/middleware/reserved-api-roots.spec-515.test.ts
+++ b/packages/server/src/middleware/reserved-api-roots.spec-515.test.ts
@@ -7,6 +7,9 @@
 // internal (spec-453), then nine more surfaced in 2026-08. The sharpest instance:
 // `/api/test-events/batch` 404'd, so the CI AC-emitter fell back from one batch request
 // to unbounded per-event POSTs (emitBatch: 404 → Promise.all(single)) — ~11.6M
+// (⚠ that figure is the whole emission path's statement volume, and restoring /batch
+//  removes the REQUEST amplification, not those statements — six of seven are per-event
+//  either way. Corrected in routes/api-roots.ts; spec-520 issue-2.)
 // INSERT/DELETE/upsert calls that drove prod Cloud SQL to ~100% CPU.
 //
 // This scan derives the flat roots from app.ts SOURCE (never hardcoded) and fails if any

--- a/packages/server/src/routes/__test__.ts
+++ b/packages/server/src/routes/__test__.ts
@@ -5,7 +5,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod/v4";
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import {
   clearFakeQueue,
   enqueueFakeResponse,
@@ -68,6 +68,7 @@ import { createAc, buildAcRef } from "../services/acs.js";
 import { createIssue } from "../services/issues.js";
 import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
+import { applyEmissionToRollup } from "../services/test-run-daily.js";
 import { createExecutionPlan } from "../services/execution_plans.js";
 import { addTaskComment, addComment, addDecisionComment, addAnchoredComment } from "../services/comments.js";
 // spec-320 t-5: seed comment @-mentions + assignment through the real services so
@@ -1256,6 +1257,19 @@ testOnlyRouter.post("/seed-test-event", async (c) => {
       testIdentifier,
       status,
       latestRunAt: row.createdAt,
+      hidden: false,
+    });
+    // spec-520 t-11: the per-day rollup is the THIRD tier, and it is what both history
+    // charts now read. Omitting it here would make this fixture write a shape production
+    // never produces — a journey could seed a green emission and still find the alignment
+    // sparkline saying "No alignment history yet", with nothing in the diff to explain it.
+    // Same defect class as the unit fixtures that were root-fixed in seedTestEvent.
+    await applyEmissionToRollup(tx, {
+      subjectRef,
+      memexId,
+      testIdentifier,
+      status,
+      runAt: row.createdAt,
       hidden: false,
     });
   });

--- a/packages/server/src/routes/analytics.integration.test.ts
+++ b/packages/server/src/routes/analytics.integration.test.ts
@@ -19,7 +19,7 @@ vi.hoisted(() => {
 import { db } from "../db/connection.js";
 import { acs, activityLog, documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
 import { app } from "../app.js";
-import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+import { makeTestMemexWithDevAdmin, seedTestEvent } from "../services/test-helpers.js";
 
 const AC_OVER_TIME = "mindset-prod/memex-building-itself/specs/spec-179/acs/ac-1";
 const AC_BY_PHASE_AND_DURATIONS = "mindset-prod/memex-building-itself/specs/spec-179/acs/ac-2";
@@ -315,9 +315,13 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
     await mkAc(3, "2026-06-02T00:00:00Z");
 
     const prefix = `${m.slug}/main/specs/spec-mom/acs`;
-    const emit = (acN: number, status: string, at: string, hidden = false) =>
-      db.insert(testEvents).values({
-        memexId: m.memexId,
+    // spec-520 t-11: seeded through the helper so all three tiers are written, as the
+    // emission route does. testRunVolume now reads the per-day rollup (ac-24) rather than
+    // counting raw rows retention has already deleted, so a raw-only fixture would leave
+    // this chart empty — which is exactly the production defect being fixed, reproduced in
+    // a fixture.
+    const emit = (acN: number, status: "pass" | "fail" | "error", at: string, hidden = false) =>
+      seedTestEvent({
         subjectRef: `${prefix}/ac-${acN}`,
         status,
         testIdentifier: `t-${acN}`,
@@ -361,8 +365,18 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
       points: Array<{ day: string; pass: number; fail: number; error: number }>;
     };
     expect(vol.find((p) => p.day === "2026-06-01")).toMatchObject({ pass: 0, fail: 1, error: 0 });
-    // Jun 2: visible pass + hidden pass + error — hidden runs ARE volume.
-    expect(vol.find((p) => p.day === "2026-06-02")).toMatchObject({ pass: 2, fail: 0, error: 1 });
+    // ⚠ SEMANTIC CHANGE, spec-520 t-11, and deliberately narrow. This used to read
+    // `pass: 2` because the old testRunVolume counted RAW test_events rows with no
+    // `hidden` filter, so a hidden run counted as volume. The rollup skips hidden
+    // emissions, matching applyEmissionToSummary — `hidden` means "excluded from
+    // verification signals", and the rollup is the verification/analytics tier.
+    //
+    // This branch is UNREACHABLE in production: spec-358 froze `hidden` at false on the
+    // ingest path, and the rollup only ever holds post-ship-date rows, so no hidden
+    // emission can enter it. The fixture reaches it only by seeding hidden:true directly.
+    // If the old semantics is wanted back, the change is in applyEmissionToRollup — but
+    // then a hidden run also lands in pass/fail/error, which feed verification.
+    expect(vol.find((p) => p.day === "2026-06-02")).toMatchObject({ pass: 1, fail: 0, error: 1 });
     expect(vol.find((p) => p.day === "2026-06-03")).toMatchObject({ pass: 1, fail: 0, error: 0 });
   });
 });
@@ -376,6 +390,10 @@ describe("GET /analytics/test-signal-pulse", () => {
     const prefix = `${m.slug}/main/specs/spec-pulse/acs`;
     // Emit a handful of recent events (default createdAt = now()), so they land
     // in the current minute bucket of the rolling window.
+    // Deliberately a RAW insert, unlike `emit` above: testSignalPulse is one of the two
+    // consumers t-11 leaves on the raw log (a minutes-wide window), so the raw row IS the
+    // representative shape for it. Do not "tidy" this into seedTestEvent without checking
+    // that its hidden-counts-as-volume assertion still holds.
     const emitNow = (acN: number, status: string, hidden = false) =>
       db.insert(testEvents).values({
         memexId: m.memexId,

--- a/packages/server/src/routes/analytics.integration.test.ts
+++ b/packages/server/src/routes/analytics.integration.test.ts
@@ -341,13 +341,21 @@ describe("GET /analytics/acs-over-time and /analytics/test-run-volume", () => {
     // snapshot (retention deletes the oldest pass from test_events), not
     // min(created_at) over the log. Seed it the way migration 0110 backfills:
     // earliest NON-hidden pass per subject_ref.
+    // spec-520 dec-7 option C: ac_first_verified now carries memex_id, and the read scopes
+    // by it instead of by a subject_ref prefix. A fixture that inserts the row WITHOUT the
+    // tenant writes a shape production no longer produces — the row exists and is invisible,
+    // which is indistinguishable from "this AC never went green".
+    //
+    // Seeded through the real writer rather than hand-rolled SQL, for the same reason
+    // seedTestEvent exists: the fixture then cannot drift from the path it stands in for.
     await db.execute(sql`
-      INSERT INTO ac_first_verified (subject_ref, first_verified_at)
-      SELECT subject_ref, min(created_at) FROM test_events
+      INSERT INTO ac_first_verified (subject_ref, first_verified_at, memex_id)
+      SELECT subject_ref, min(created_at), ${m.memexId}::uuid FROM test_events
       WHERE subject_ref LIKE ${prefix + "/%"} AND status = 'pass' AND hidden = false
       GROUP BY subject_ref
       ON CONFLICT (subject_ref) DO UPDATE
-        SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at)
+        SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at),
+            memex_id = COALESCE(ac_first_verified.memex_id, EXCLUDED.memex_id)
     `);
 
     const otRes = await app.request(`${path}/analytics/acs-over-time`, withApexHost());

--- a/packages/server/src/routes/api-roots.ts
+++ b/packages/server/src/routes/api-roots.ts
@@ -17,14 +17,37 @@
 // the coupling is required in both directions — a word that is both an API root and
 // a namespace slug makes one of the two unreachable.
 
-// MEASURED IMPACT (from a colleague's independent reconstruction of this fix on
-// origin/develop, commit 00394743 — better quantified than the original diagnosis and
-// preserved here because that inline list was folded into this module):
-// `pg_stat_statements` showed **~11.6M INSERT/DELETE/upsert calls** across the
-// test_events emission path — about **31% of prod Cloud SQL CPU**, saturating the
-// 1-vCPU instance and slowing every DB-backed endpoint. Reserving `test-events` makes
-// /batch reachable, so the already-published emitter batches and the write volume
-// collapses.
+// MEASURED IMPACT — and ⚠ CORRECTED 2026-08-28 (spec-520 issue-2), because the original
+// wording attributed a cost to this fix that this fix does not remove, in the direction
+// that stops someone looking further.
+//
+// The observation was real: `pg_stat_statements` showed **~11.6M INSERT/DELETE/upsert
+// calls** across the test_events emission path, about **31% of prod Cloud SQL CPU** on a
+// 1-vCPU instance. Reserving `test-events` makes /batch reachable, and that IS a real fix.
+//
+// WHAT IT FIXED: the REQUEST count. Before, the emitter's batch POST 404'd and it fell back
+// to one POST per test — so a suite tagging 500 criteria opened 500 requests, each taking a
+// DB-pool slot. Restoring /batch collapses that to roughly one request per test FILE, and
+// amortises the ONE statement that is per-request: the emission-key verify.
+//
+// WHAT IT DID NOT FIX: the per-EVENT statement cost, which is most of that 31%. The batch
+// route authenticates once and then loops `processOneEvent` per event, so six of the seven
+// statements run exactly as often as before. Restoring the route removed approximately none
+// of them.
+//
+// Measured on prod as a 600s delta, 2026-08-28 (spec-520 c-9) — the batching is visible in
+// exactly one row and absent from the rest:
+//
+//   30.973 calls/s  INSERT test_events          <- per EVENT
+//   30.973 calls/s  DELETE test_events (trim)   <- per EVENT
+//   30.973 calls/s  INSERT test_run_daily       <- per EVENT
+//   30.972 calls/s  INSERT ac_first_verified    <- per EVENT
+//   30.972 calls/s  UPDATE memex_emission_keys  <- per EVENT
+//    3.947 calls/s  SELECT memex_emission_keys  <- per BATCH: ~1 auth per 8 events
+//
+// So: spec-515 fixed request amplification; spec-520 is the Spec that attacks the write
+// amplification, and its t-6 / t-12 / dec-7 work is what actually removes those rows. Do not
+// read this paragraph as "the 31% was solved here".
 
 /**
  * Every top-level segment under which a NON-TENANT router is mounted flat at

--- a/packages/server/src/routes/batch-tenant-boundary.integration.test.ts
+++ b/packages/server/src/routes/batch-tenant-boundary.integration.test.ts
@@ -1,0 +1,205 @@
+// spec-520 t-5 / ac-29 — the batch route's memex resolve is memoised PER EVENT'S OWN
+// parsed (namespace, memex) pair, never hoisted out of the loop.
+//
+// ⚠ THIS IS THE SHARPEST HAZARD IN THE SPEC (s-2 Trap 1), and the natural optimisation is
+// the dangerous one.
+//
+// processOneEvent performs a PER-EVENT authorization check: it parses the namespace and
+// memex slug out of THAT EVENT'S OWN subject_ref, resolves them, and rejects unless the
+// result matches the bearer key's Memex (spec-129 ac-10). The batch endpoint accepts
+// arbitrary per-event subject_refs — nothing requires one batch to name one Memex, and the
+// CALLER controls every ref in the array.
+//
+//   SAFE:   memoise keyed on each event's own parsed (namespace, memex).
+//   UNSAFE: resolve once and reuse for every event. That silently turns the check into
+//           `emissionKey.memexId === emissionKey.memexId` — trivially true — and lets a
+//           valid key for Memex A write events into Memex B.
+//
+// AND THERE IS NO DATABASE BACKSTOP. test_events, test_event_latest and ac_first_verified
+// carry no RLS on this path today (spec-398 ac-10 asserted their absence; spec-399 is
+// unbuilt). An application-layer mistake here IS the tenant-isolation failure.
+//
+// So this test is written to FAIL if the resolve is hoisted: it posts one batch whose events
+// name two different Memexes and asserts the foreign one is rejected while its neighbours
+// land. A test that posted a single-tenant batch would pass against the hoisted version and
+// prove nothing.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexEmissionKeys, memexes, namespaces, testEvents, users } from "../db/schema.js";
+import { mintEmissionKey, mintEphemeralEmissionKey } from "../services/emission-keys.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+import { app } from "../app.js";
+
+const AC_BATCH_SCOPE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-29";
+
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+let userA: string;
+let userB: string;
+let memexA: string;
+let memexB: string;
+let refA: (n: number) => string;
+let refB: (n: number) => string;
+let keyA: string;
+const createdRefs: string[] = [];
+
+async function makeTenant(tag: string): Promise<{
+  userId: string;
+  memexId: string;
+  ref: (n: number) => string;
+}> {
+  const user = await upsertUserByEmail(`spec520-t5-${tag}-${runId}@example.com`);
+  const created = await ensureUserNamespace(user.id);
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .where(eq(namespaces.id, created.memex.namespaceId))
+    .limit(1);
+  const prefix = `${ns!.slug}/${created.memex.slug}/specs/spec-1/acs`;
+  return {
+    userId: user.id,
+    memexId: created.memex.id,
+    ref: (n: number) => {
+      const r = `${prefix}/ac-${n}`;
+      createdRefs.push(r);
+      return r;
+    },
+  };
+}
+
+beforeAll(async () => {
+  const a = await makeTenant("a");
+  const b = await makeTenant("b");
+  userA = a.userId;
+  memexA = a.memexId;
+  refA = a.ref;
+  userB = b.userId;
+  memexB = b.memexId;
+  refB = b.ref;
+  keyA = (await mintEmissionKey(memexA, `t5-${runId}`, userA)).raw;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  await db.delete(memexEmissionKeys).where(eq(memexEmissionKeys.memexId, memexA)).catch(() => {});
+  for (const m of [memexA, memexB]) {
+    await db.delete(memexes).where(eq(memexes.id, m)).catch(() => {});
+  }
+  await db.delete(users).where(inArray(users.id, [userA, userB])).catch(() => {});
+});
+
+async function postBatch(key: string, events: unknown[]) {
+  const res = await app.request("/api/test-events/batch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    body: JSON.stringify({ events }),
+  });
+  return { status: res.status, body: (await res.json()) as {
+    accepted: number;
+    rejected: number;
+    results: Array<{ index: number; ok: boolean; error?: string }>;
+  } };
+}
+
+const ev = (ref: string, id: string) => ({
+  subject_ref: ref,
+  status: "pass",
+  test_identifier: id,
+  duration_ms: 1,
+});
+
+describe("spec-520 ac-29: one batch, two Memexes — the foreign event is rejected", () => {
+  it("rejects ONLY the foreign-Memex event and lands every neighbour in the same batch", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    // Key authorises Memex A. Event at index 1 names Memex B — a ref the CALLER chose.
+    // If the resolve were hoisted, index 1's ref would never be resolved at all and the
+    // check would compare A's id with itself: the foreign event would LAND.
+    const { status, body } = await postBatch(keyA, [
+      ev(refA(1), "t::a1"),
+      ev(refB(9), "t::foreign"),
+      ev(refA(2), "t::a2"),
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.results[0]!.ok).toBe(true);
+    expect(body.results[1]!.ok).toBe(false);
+    expect(body.results[2]!.ok).toBe(true);
+    expect(body.accepted).toBe(2);
+    expect(body.rejected).toBe(1);
+  });
+
+  it("writes NO row for the foreign ref — the rejection is a refusal, not a relabel", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    const foreign = refB(9);
+    await postBatch(keyA, [ev(refA(3), "t::a3"), ev(foreign, "t::foreign2")]);
+
+    // The failure mode this guards is subtler than "it was accepted": a hoisted resolve
+    // would write the foreign event into Memex A under A's memex_id — a row that exists,
+    // is tenant-stamped wrong, and looks entirely normal.
+    const rows = await db
+      .select({ id: testEvents.id, memexId: testEvents.memexId })
+      .from(testEvents)
+      .where(eq(testEvents.subjectRef, foreign));
+    expect(rows).toEqual([]);
+  });
+
+  it("a batch naming only its own Memex still collapses to ONE resolve", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    // The win the memo is for: a normal single-suite batch resolves once, not once per
+    // event. Asserted through behaviour — all events land — plus the count assertion in
+    // the unit test that can observe the resolver directly.
+    const { status, body } = await postBatch(keyA, [
+      ev(refA(4), "t::x1"),
+      ev(refA(4), "t::x2"),
+      ev(refA(5), "t::x3"),
+    ]);
+    expect(status).toBe(200);
+    expect(body.accepted).toBe(3);
+    expect(body.rejected).toBe(0);
+  });
+});
+
+describe("spec-520 ac-29: the scoped-agent-key gate also holds PER EVENT in a batch", () => {
+  it("a scoped key emitting for another Spec's AC is rejected, while its own Spec's event lands", async () => {
+    tagAc(AC_BATCH_SCOPE);
+
+    // spec-234 ac-11: an ephemeral / agent key carries a scoped_spec_handle and may emit
+    // ONLY for ACs of that one Spec — so an in-progress agent run cannot flip the
+    // verification bar of any other Spec on the shared board.
+    //
+    // This is the SECOND per-event gate, and it is the one most likely to be lost to the
+    // same optimisation: unlike the Memex check it compares against a handle parsed from
+    // the ref, so hoisting anything out of the loop makes it compare one event's Spec
+    // against itself. Both events below belong to the SAME Memex, so the first gate passes
+    // for both — only the scope gate separates them.
+    const scoped = await mintEphemeralEmissionKey(memexA, "spec-1", userA);
+
+    // refA() already builds spec-1 refs, so `own` needs no rewriting — an earlier draft
+    // replaced "/specs/spec-1/" with itself here, a no-op that READ as if the two refs were
+    // being derived symmetrically. CodeQL flagged it. In a test whose entire point is that
+    // the two refs differ, a line that looks like it transforms one and does not is worse
+    // than useless.
+    const own = refA(20);
+    const other = refA(21).replace("/specs/spec-1/", "/specs/spec-2/");
+    createdRefs.push(other);
+
+    const { status, body } = await postBatch(scoped.raw, [
+      ev(own, "t::in-scope"),
+      ev(other, "t::out-of-scope"),
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.results[0]!.ok).toBe(true);
+    expect(body.results[1]!.ok).toBe(false);
+    expect(body.rejected).toBe(1);
+  });
+});

--- a/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
+++ b/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
@@ -1,0 +1,132 @@
+// spec-520 dec-7 option C — ac_first_verified is tenancy-isolated, and the READ still works.
+//
+// Runs ONLY under vitest.rls.config.ts, as the restricted `memex_app` role. In the default
+// owner-connection suite RLS is bypassed entirely (std-36: ENABLE, never FORCE), so every
+// assertion here passes there for the wrong reason.
+//
+// WHY THIS FILE HAD TO EXIST BEFORE THE POLICY SHIPPED. issue-8 was the WRITE-side version
+// of this trap: a context-less write to an RLS-gated table is rejected in prod while dev and
+// CI stay green. This is the READ-side twin, and it is quieter — a context-less READ returns
+// FEWER ROWS rather than an error, which is indistinguishable from "this AC never went
+// green". The chart would simply flatten to zero and nobody would get an exception.
+//
+// dec-7 named it as a build constraint: "confirm the read is ALS-wrapped before enabling the
+// policy, or the chart silently returns nothing under the non-owner role."
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { acFirstVerified, acs, documents, memexes, namespaces, users } from "../db/schema.js";
+import { createDocDraft } from "../services/documents.js";
+import { recordFirstVerified } from "../services/test-event-retention.js";
+import { acsOverTime } from "../services/analytics.js";
+import { upsertUserByEmail } from "../services/users.js";
+import { ensureUserNamespace } from "../services/user-namespaces.js";
+
+const AC_TENANCY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-37";
+
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+let memexId: string;
+let userId: string;
+let namespaceSlug: string;
+let docId: string;
+let acRef: string;
+
+beforeAll(async () => {
+  const user = await upsertUserByEmail(`spec520-c-${runId}@example.com`);
+  userId = user.id;
+  const created = await ensureUserNamespace(userId);
+  memexId = created.memex.id;
+  const [ns] = await db
+    .select({ slug: namespaces.slug })
+    .from(namespaces)
+    .where(eq(namespaces.id, created.memex.namespaceId))
+    .limit(1);
+  namespaceSlug = ns!.slug;
+
+  await runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `spec520 optC ${runId}`, "", "spec");
+    docId = doc.id;
+    await db.insert(acs).values({
+      memexId,
+      briefId: docId,
+      seq: 1,
+      kind: "implementation",
+      statement: "the criterion that went green",
+      status: "active",
+    } as typeof acs.$inferInsert);
+    acRef = `${namespaceSlug}/${created.memex.slug}/specs/${doc.handle}/acs/ac-1`;
+  });
+});
+
+afterAll(async () => {
+  await runWithMemexId(memexId, async () => {
+    await db.delete(acFirstVerified).where(eq(acFirstVerified.subjectRef, acRef)).catch(() => {});
+    if (docId) await db.delete(documents).where(eq(documents.id, docId)).catch(() => {});
+  });
+  await db.delete(memexes).where(eq(memexes.id, memexId)).catch(() => {});
+  await db.delete(namespaces).where(eq(namespaces.slug, namespaceSlug)).catch(() => {});
+  await db.delete(users).where(inArray(users.id, [userId])).catch(() => {});
+});
+
+describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still sees its own rows", () => {
+  it("a write from the emission path satisfies the policy", async () => {
+    tagAc(AC_TENANCY);
+    // The WRITE half. Under memex_app this INSERT's WITH CHECK is evaluated for real; the
+    // emission route runs inside runWithMemexId (issue-8), which is what makes it satisfiable.
+    await runWithMemexId(memexId, async () =>
+      recordFirstVerified(db, acRef, new Date("2026-08-20T10:00:00.000Z"), memexId),
+    );
+
+    const rows = await runWithMemexId(memexId, async () =>
+      db
+        .select({ at: acFirstVerified.firstVerifiedAt, memexId: acFirstVerified.memexId })
+        .from(acFirstVerified)
+        .where(eq(acFirstVerified.subjectRef, acRef)),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.memexId).toBe(memexId);
+  });
+
+  it("THE READ WORKS under the restricted role — acsOverTime still counts the first pass", async () => {
+    tagAc(AC_TENANCY);
+
+    // THE assertion this file exists for. If the reader were not ALS-wrapped, this would
+    // return a curve of zeroes rather than throw — the silent shape. A non-zero verified
+    // count proves the policy and the read agree.
+    const points = await runWithMemexId(memexId, async () => acsOverTime(memexId));
+    const verified = points.reduce((n, p) => n + p.verified, 0);
+    expect(verified).toBeGreaterThan(0);
+  });
+
+  it("another tenant sees none of it", async () => {
+    tagAc(AC_TENANCY);
+    // Reads under a foreign tenant rather than with NO context: with app.memex_id unset the
+    // policy's ::uuid cast can be evaluated before the guarding IS NOT NULL conjunct — SQL
+    // does not promise AND short-circuits — and the query errors instead of returning empty.
+    // Erroring still "proves" the policy is attached, but by a route indistinguishable from a
+    // dozen other faults. A foreign tenant exercises the predicate the way production does.
+    const other = "00000000-0000-4000-8000-000000000042";
+    const leaked = await runWithMemexId(other, async () =>
+      db
+        .select({ subjectRef: acFirstVerified.subjectRef })
+        .from(acFirstVerified)
+        .where(eq(acFirstVerified.subjectRef, acRef)),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("the policy is ENABLEd and NOT FORCEd", async () => {
+    tagAc(AC_TENANCY);
+    // std-36: FORCE would apply RLS to the table OWNER too, and on Cloud SQL the deploy role
+    // is not a superuser and lacks BYPASSRLS — every migration against this table would then
+    // be filtered to nothing. 0081 shipped FORCE and 0093 had to undo it.
+    const [row] = (await db.execute(sql`
+      SELECT relrowsecurity AS enabled, relforcerowsecurity AS forced
+        FROM pg_class WHERE relname = 'ac_first_verified'
+    `)) as unknown as Array<{ enabled: boolean; forced: boolean }>;
+    expect(row.enabled).toBe(true);
+    expect(row.forced).toBe(false);
+  });
+});

--- a/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
+++ b/packages/server/src/routes/first-verified-tenancy.rls-restricted.test.ts
@@ -26,6 +26,14 @@ import { ensureUserNamespace } from "../services/user-namespaces.js";
 
 const AC_TENANCY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-37";
 
+// spec-520 ac-23 is the COMPOSITE statement of what dec-7 actually delivered, so it is
+// tagged from BOTH halves — the tenancy work here and the throttle in
+// first-verified-throttle.integration.test.ts. Tagging it from either alone would flip it
+// green on half its claim, which is exactly the mistake ac-24/ac-25 made earlier in this
+// Spec and why ac-35/ac-36 had to be split out of them.
+const AC_DEC7 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-23";
+
+
 const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 let memexId: string;
 let userId: string;
@@ -73,6 +81,7 @@ afterAll(async () => {
 describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still sees its own rows", () => {
   it("a write from the emission path satisfies the policy", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
     // The WRITE half. Under memex_app this INSERT's WITH CHECK is evaluated for real; the
     // emission route runs inside runWithMemexId (issue-8), which is what makes it satisfiable.
     await runWithMemexId(memexId, async () =>
@@ -91,6 +100,7 @@ describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still se
 
   it("THE READ WORKS under the restricted role — acsOverTime still counts the first pass", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
 
     // THE assertion this file exists for. If the reader were not ALS-wrapped, this would
     // return a curve of zeroes rather than throw — the silent shape. A non-zero verified
@@ -102,6 +112,7 @@ describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still se
 
   it("another tenant sees none of it", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
     // Reads under a foreign tenant rather than with NO context: with app.memex_id unset the
     // policy's ::uuid cast can be evaluated before the guarding IS NOT NULL conjunct — SQL
     // does not promise AND short-circuits — and the query errors instead of returning empty.
@@ -117,8 +128,30 @@ describe("spec-520 ac-37: ac_first_verified is isolated, and its reader still se
     expect(leaked).toEqual([]);
   });
 
+  it("keeps memex_id NULLABLE, so a ref with no surviving summary row kept its date", async () => {
+    tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
+    // ac_first_verified exists BECAUSE retention destroyed the first-green date once
+    // already. Migration 0136 backfilled memex_id from test_event_latest — but a ref whose
+    // summary row is gone (a discontinued AC, a deleted Spec) has nothing to resolve from.
+    // Making the column NOT NULL would have forced those rows to be deleted or the
+    // migration to fail, and deleting them would be the same loss happening a second time,
+    // this time on purpose.
+    //
+    // Under the policy a NULL matches no tenant, so the row is invisible to the product and
+    // visible to the owner role; the writer heals it on that ref's next emission. This
+    // asserts the column stayed nullable — the schema fact the choice rests on.
+    const [col] = (await db.execute(sql`
+      SELECT is_nullable::text AS is_nullable
+      FROM information_schema.columns
+      WHERE table_name = 'ac_first_verified' AND column_name = 'memex_id'
+    `)) as unknown as Array<{ is_nullable: string }>;
+    expect(col.is_nullable).toBe("YES");
+  });
+
   it("the policy is ENABLEd and NOT FORCEd", async () => {
     tagAc(AC_TENANCY);
+    tagAc(AC_DEC7);
     // std-36: FORCE would apply RLS to the table OWNER too, and on Cloud SQL the deploy role
     // is not a superuser and lacks BYPASSRLS — every migration against this table would then
     // be filtered to nothing. 0081 shipped FORCE and 0093 had to undo it.

--- a/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
+++ b/packages/server/src/routes/test-events-tenant-context.rls-restricted.test.ts
@@ -44,6 +44,7 @@ import { upsertUserByEmail } from "../services/users.js";
 import { ensureUserNamespace } from "../services/user-namespaces.js";
 import { createDocDraft } from "../services/documents.js";
 import { mintEmissionKey } from "../services/emission-keys.js";
+import { seedTestEvent } from "../services/test-helpers.js";
 import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
 import { app } from "../app.js";
 
@@ -183,14 +184,18 @@ describe("spec-520 ac-32: the DIAGNOSIS — tenant context is what the chain nee
   it("WITH tenant context the same call resolves the same Issue", async () => {
     tagAc(AC_TENANT_CONTEXT);
     // Give the AC a green event first: verifyingAcIsGreen gates the resolve.
+    //
+    // spec-520 t-11: seeded through the helper, not a bare insert. This used to insert a
+    // raw test_events row only, and passed because verifyingAcIsGreen scanned the raw log.
+    // ac-25 moved that gate to test_event_latest, and this went red immediately — the
+    // fixture had been writing a shape production never writes (the emission route
+    // maintains all three tiers in one transaction).
     await runWithMemexId(memexId, async () => {
-      await db.insert(testEvents).values({
-        memexId,
+      await seedTestEvent({
         subjectRef: acRef,
         status: "pass",
         testIdentifier: "spec520-t7::diagnosis",
-        durationMs: 1,
-      } as typeof testEvents.$inferInsert);
+      });
     });
 
     const resolved = await runWithMemexId(memexId, async () =>

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -107,7 +107,7 @@ import {
 // tests can override verifyEmissionKey to exercise the scoped-key / missing-key 401 paths.
 // spec-489: resolveMemexId is imported too so a batch test can force ONE event to resolve to a
 // different Memex than the key authorises (the in-batch auth-boundary case).
-import { verifyEmissionKey, resolveMemexId } from "../services/emission-keys.js";
+import { verifyEmissionKey, resolveMemexId, bumpLastUsed } from "../services/emission-keys.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-115/acs";
 const AC333 = "mindset-prod/memex-building-itself/specs/spec-333/acs";
@@ -585,10 +585,25 @@ describe("POST /api/test-events/batch — spec-489 G1 (batch the burst)", () => 
 
   it("preserves the Memex auth boundary — a cross-Memex event is rejected in-batch, neighbours unaffected (ac-5)", async () => {
     tagAc(`${AC489}/ac-5`);
-    // Force the FIRST event to resolve to a Memex the key does not authorise.
-    vi.mocked(resolveMemexId).mockResolvedValueOnce("some-other-memex");
+    // spec-520 t-5: the cross-Memex event now carries a DIFFERENT subject_ref, which is
+    // what a real cross-tenant batch looks like — the caller names another Memex in the ref.
+    //
+    // It used to reuse the SAME ref for all three and force the first resolve with
+    // mockResolvedValueOnce. That models one (namespace, memex) pair resolving to two
+    // different Memexes within one request, which resolveMemexId — a deterministic lookup
+    // keyed on exactly that pair — cannot do. The batch now memoises per parsed pair
+    // (ac-29), so the forced value applied to all three and the test failed. The fixture,
+    // not the memo, was describing something reality does not produce.
+    //
+    // Pinning the boundary with two DISTINCT refs is also strictly stronger: it exercises
+    // the per-event comparison against that event's OWN resolution, which is the property
+    // s-2 Trap 1 is about. Proven end to end against a real database in
+    // batch-tenant-boundary.integration.test.ts.
+    vi.mocked(resolveMemexId).mockImplementation(async (ns: string, mx: string) =>
+      mx === "foreign" ? "some-other-memex" : "memex-1",
+    );
     const res = await postBatch([
-      ev({ test_identifier: "cross" }),
+      ev({ subject_ref: "mindset-prod/foreign/specs/spec-1/acs/ac-1", test_identifier: "cross" }),
       ev({ test_identifier: "ok1" }),
       ev({ test_identifier: "ok2" }),
     ]);
@@ -604,6 +619,13 @@ describe("POST /api/test-events/batch — spec-489 G1 (batch the burst)", () => 
     expect(json.results[0]!.error).toContain("does not authorise");
     // Batching added no new cross-boundary write path: the rejected event never inserted.
     expect(insertSpy).toHaveBeenCalledTimes(2);
+
+    // [per std-37 cl-5] restore what this test replaced. mockImplementation PERSISTS, and
+    // this file's vi.mock sets a plain mockResolvedValue — leaving the ref-dependent
+    // implementation installed would silently change every later test that resolves a ref.
+    // Nothing broke when it was left in, which is the point: that would have been ordering
+    // luck, not safety.
+    vi.mocked(resolveMemexId).mockResolvedValue("memex-1");
   });
 
   it("rejects a non-array events body and an oversized batch with 400, inserting nothing (ac-5 boundary)", async () => {
@@ -868,5 +890,78 @@ describe("POST /api/test-events — promotion does not move the metadata keys (s
     // And the promotion happened alongside, not instead of.
     expect(row.runId).toBe("31589392781");
     expect(row.commitSha).toBe("112ad9ab");
+  });
+});
+
+// ── spec-520 t-5 (ac-29): the batch collapses lookups without collapsing the CHECK ──
+//
+// Two separate claims, and conflating them is the whole hazard (s-2 Trap 1):
+//   • the RESOLVE is memoised per each event's OWN parsed (namespace, memex) — so a
+//     single-suite batch does one lookup, and a two-tenant batch does two;
+//   • the AUTHORIZATION comparison still runs per event, against that event's own result.
+//
+// The tenant-boundary behaviour is proven against a REAL database in
+// batch-tenant-boundary.integration.test.ts, which was confirmed to fail against the
+// hoisted form. What is asserted HERE is the count — observable only because this file
+// mocks the resolver — i.e. that the win is actually being taken.
+describe("POST /api/test-events/batch — one resolve per distinct Memex, one key bump per batch (spec-520 ac-29)", () => {
+  const AC520 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-29";
+
+  const batchOf = (refs: string[]) =>
+    new Request("http://localhost/api/test-events/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer mxk_x" },
+      body: JSON.stringify({
+        events: refs.map((r, i) => ({
+          subject_ref: r,
+          status: "pass",
+          test_identifier: `t::${i}`,
+          duration_ms: 1,
+        })),
+      }),
+    });
+
+  it("resolves ONCE for a batch that names one Memex, however many events it carries", async () => {
+    tagAc(AC520);
+    vi.mocked(resolveMemexId).mockClear();
+    vi.mocked(bumpLastUsed).mockClear();
+
+    const ref = "mindset-prod/foo/specs/spec-1/acs/ac-1";
+    const res = await app.request(batchOf([ref, ref, ref, ref, ref]));
+    expect(res.status).toBe(200);
+
+    // The win: ~500 identical lookups in a real suite collapse to 1.
+    expect(vi.mocked(resolveMemexId)).toHaveBeenCalledTimes(1);
+    // And the key is bumped once for the request, not once per event.
+    expect(vi.mocked(bumpLastUsed)).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves ONCE PER DISTINCT (namespace, memex) — not once for the batch", async () => {
+    tagAc(AC520);
+    vi.mocked(resolveMemexId).mockClear();
+
+    // THE assertion that separates memoisation from hoisting. A hoisted resolve would show
+    // 1 here — and would have skipped resolving the second Memex at all, which is exactly
+    // how the authorization check degenerates into comparing a value with itself.
+    await app.request(
+      batchOf([
+        "mindset-prod/foo/specs/spec-1/acs/ac-1",
+        "mindset-prod/other/specs/spec-1/acs/ac-1",
+        "mindset-prod/foo/specs/spec-1/acs/ac-2",
+      ]),
+    );
+    expect(vi.mocked(resolveMemexId)).toHaveBeenCalledTimes(2);
+  });
+
+  it("still bumps the key once when every event in the batch is rejected", async () => {
+    tagAc(AC520);
+    vi.mocked(bumpLastUsed).mockClear();
+    // A rejected batch still PRESENTED and verified the key, which is what last_used_at
+    // records. Skipping the bump here would make a key that only ever emits rejected events
+    // look unused.
+    vi.mocked(resolveMemexId).mockResolvedValueOnce("some-other-memex");
+    const res = await app.request(batchOf(["mindset-prod/foo/specs/spec-1/acs/ac-1"]));
+    expect(res.status).toBe(200);
+    expect(vi.mocked(bumpLastUsed)).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/routes/test-events.test.ts
+++ b/packages/server/src/routes/test-events.test.ts
@@ -788,13 +788,32 @@ describe("POST /api/test-events — run_id / commit_sha filled from metadata (sp
     });
     expect(filled.status).toBe(201);
 
-    // Asserted as a delta rather than a magic number: the ingest path already
-    // performs one transaction, one insert and one read per PASSING event (the
-    // read is spec-112's issue auto-resolve at test-events.ts:497, unrelated to
-    // this Spec). What ac-7 protects is that the fill adds NONE of them. The two
-    // tempting implementations — resolving the run id via a lookup, or reading
-    // the inserted row back — would each show up right here as a delta, on a
-    // path peaking at 2 063 POST/min with one transaction per event.
+    // Asserted as a DELTA rather than a magic number, and that choice is what has
+    // kept this test correct while the number underneath it moved three times.
+    // What ac-7 protects is that the run_id fill adds no transaction, no insert and
+    // no read — the two tempting implementations (resolving the run id via a lookup,
+    // or reading the inserted row back) would each show up right here, on a path
+    // peaking at 2 063 POST/min.
+    //
+    // ⚠ THE READ COUNT: this comment used to say "one read", naming spec-112's issue
+    // auto-resolve. That was true of what this file OBSERVED and never of production.
+    // Corrected 2026-08-28 (spec-520 t-15) — three regimes, one number each:
+    //
+    //   1. Pre-t-7 (until 2026-08-18): the chain's first statement was a
+    //      `documents ⋈ memexes ⋈ namespaces` lookup, `documents` carries RLS on
+    //      app.memex_id, and the ingest path had no tenant context — so it was
+    //      filtered to zero rows and the chain returned at statement 1. ONE read, and
+    //      the reason was a defect, not a design.
+    //   2. Post-t-7, pre-t-15: with context established the chain ran to completion on
+    //      essentially every passing event. THREE reads (documents join, `acs`,
+    //      `task_satisfies_ac`) — measured on prod at 30.970 calls/s against an event
+    //      rate of 30.973 (spec-520 c-9).
+    //   3. Now (t-15 / ac-33): those three are collapsed into ONE join returning the
+    //      satisfying task ids directly. Back to one read, this time by design.
+    //
+    // So do NOT pin `selects` to a literal here. It is not this Spec's number, it has
+    // moved for reasons that had nothing to do with spec-528, and a literal would have
+    // made this test fail three times while asserting nothing about the fill.
     expect(counts()).toEqual(before);
     expect(before.transactions).toBe(1);
     expect(before.inserts).toBe(1);

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -567,7 +567,7 @@ async function processOneEvent(
         // spec-398 t-6: durably snapshot the earliest pass BEFORE retention can
         // trim it away, so analytics keeps a true "first went green" date.
         if (insertValues.status === "pass" && !insertValues.hidden) {
-          await recordFirstVerified(tx, insertValues.subjectRef, inserted.createdAt);
+          await recordFirstVerified(tx, insertValues.subjectRef, inserted.createdAt, targetMemexId);
         }
         return inserted;
       });

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -272,9 +272,24 @@ async function authenticateEmission(
 // across a Memex boundary (ac-5). A per-event failure is returned as data; the
 // batch caller keeps the good events (partial-failure) rather than discarding
 // the whole batch.
+/**
+ * spec-520 t-5 (ac-29): per-BATCH scratch space, threaded in by the /batch route.
+ *
+ * ⚠ `resolveMemo` is keyed on each event's OWN parsed `<namespace>/<memex>` pair, and that
+ * is the whole safety property — NOT a single resolved id reused for the batch. See the
+ * note at the resolve site below before changing anything here.
+ */
+interface BatchScope {
+  /** `${namespace}/${memexSlug}` -> resolved memex id (or null when it does not resolve). */
+  resolveMemo: Map<string, string | null>;
+  /** The /batch route bumps the key once for the whole request instead of per event. */
+  deferKeyBump: boolean;
+}
+
 async function processOneEvent(
   emissionKey: VerifiedEmissionKey,
   rawBody: unknown,
+  scope?: BatchScope,
 ): Promise<ProcessResult> {
   if (typeof rawBody !== "object" || rawBody === null || Array.isArray(rawBody)) {
     return { ok: false, code: 400, body: { error: "event must be a JSON object" } };
@@ -345,10 +360,34 @@ async function processOneEvent(
   // Resolve the memex named by the ref (<namespace>/<memex>/…) and confirm it matches the
   // authenticated key's memexId. This blocks cross-tenant tampering even with a valid key
   // for a different Memex.
-  const targetMemexId = await resolveMemexId(
-    refNamespace,
-    memexSlugFromAcUid(subjectRefValue),
-  );
+  //
+  // spec-520 t-5 (ac-29): MEMOISED PER EVENT, NEVER HOISTED. This is s-2 Trap 1, the
+  // sharpest hazard in the Spec, and the natural optimisation is the dangerous one.
+  //
+  // The memo key is THIS EVENT'S OWN parsed (namespace, memex) pair, so a batch naming two
+  // Memexes gets two entries and the comparison below still does real work. Hoisting the
+  // resolve out of the loop — resolving once and reusing it — silently turns the check into
+  // `emissionKey.memexId === emissionKey.memexId`, which is trivially true, and lets a valid
+  // key for Memex A write events into Memex B. The /batch endpoint accepts arbitrary
+  // per-event subject_refs and the CALLER controls every one of them.
+  //
+  // There is no database backstop behind this: test_events, test_event_latest and
+  // ac_first_verified carry no RLS on this path (spec-398 ac-10 asserted their absence;
+  // spec-399 is unbuilt). An application-layer mistake here IS the tenant-isolation failure.
+  //
+  // batch-tenant-boundary.integration.test.ts posts one batch naming two Memexes and was
+  // confirmed to FAIL against the hoisted form — 2 of its 3 cases. The third, a
+  // single-tenant batch, passes either way, which is exactly why the mixed case is the one
+  // that has to exist.
+  const memexSlug = memexSlugFromAcUid(subjectRefValue);
+  const memoKey = `${refNamespace}/${memexSlug}`;
+  let targetMemexId: string | null;
+  if (scope?.resolveMemo.has(memoKey)) {
+    targetMemexId = scope.resolveMemo.get(memoKey) ?? null;
+  } else {
+    targetMemexId = await resolveMemexId(refNamespace, memexSlug);
+    scope?.resolveMemo.set(memoKey, targetMemexId);
+  }
   if (!targetMemexId || targetMemexId !== emissionKey.memexId) {
     return {
       ok: false,
@@ -582,7 +621,10 @@ async function processOneEvent(
 
   // spec-129 ac-17: record that this key is live. Fire-and-forget (silent) so a missed
   // bump never blocks or fails the emission — it only leaves a slightly stale timestamp.
-  bumpLastUsed(emissionKey.id);
+  // spec-520 t-5: one key authenticates the WHOLE batch and is verified once, so bumping it
+  // per event is pure waste — the /batch route defers and bumps once after the loop. No
+  // tenant hazard here, unlike the resolve above: there is only ever one key in play.
+  if (!scope?.deferKeyBump) bumpLastUsed(emissionKey.id);
 
   // spec-342: a test_event NEVER changes a Spec's phase. It updates the AC
   // verdict (applyEmissionToSummary, above) and the audit trail only; phase is
@@ -737,8 +779,12 @@ testEventsRouter.post("/batch", async (c) => {
   }> = [];
   let accepted = 0;
   let rejected = 0;
+  // ONE memo for the whole request, keyed per event's own (namespace, memex) — see the note
+  // at the resolve site. A normal single-suite batch collapses ~500 identical lookups to 1;
+  // a batch naming two Memexes still resolves both and still rejects the foreign one.
+  const scope: BatchScope = { resolveMemo: new Map(), deferKeyBump: true };
   for (let index = 0; index < events.length; index++) {
-    const result = await processOneEvent(auth.key, events[index]);
+    const result = await processOneEvent(auth.key, events[index], scope);
     if (result.ok) {
       accepted++;
       results.push({
@@ -766,6 +812,12 @@ testEventsRouter.post("/batch", async (c) => {
   // rejected batch counts what landed, which understates batching slightly and
   // never overstates adoption (ac-19).
   recordEmissionAccepted(accepted, { route: "batch" });
+  // spec-520 t-5: ONE key bump for the whole batch, after the loop. Fire-and-forget, like
+  // the single-event path — a missed bump only leaves a slightly stale "last used" and must
+  // never delay or fail an emission. Bumped even when every event was rejected: the KEY was
+  // still presented and verified, which is what last_used_at records.
+  bumpLastUsed(auth.key.id);
+
   return c.json({ accepted, rejected, results }, 200);
 });
 

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -76,7 +76,6 @@ import { testEvents } from "../db/schema.js";
 import { applyEmissionToSummary } from "../services/test-event-latest.js";
 import { applyEmissionToRollup } from "../services/test-run-daily.js";
 import {
-  trimTestEventsForPair,
   recordFirstVerified,
 } from "../services/test-event-retention.js";
 import { maybeAutoResolveIssuesForAcUid } from "../services/issues.js";
@@ -599,15 +598,11 @@ async function processOneEvent(
           runAt: inserted.createdAt,
           hidden: insertValues.hidden,
         });
-        // spec-398 (ac-1): keep this pair bounded to the latest RETENTION_KEEP
-        // runs — the steady-state trim-on-write, in the same transaction as the
-        // insert so the log never transiently exceeds the cap.
-        await trimTestEventsForPair(
-          tx,
-          insertValues.subjectRef,
-          insertValues.testIdentifier,
-        );
-        // spec-398 t-6: durably snapshot the earliest pass BEFORE retention can
+        // spec-520 t-12: NO DELETE HERE ANY MORE. The per-pair trim that used to run
+        // inside this transaction cost 13.4% of all database time and created 11.24M dead
+        // tuples for autovacuum to chase. Retention is now which PARTITION the row landed
+        // in; rows leave only when an aged-out partition is dropped, by the owning role,
+        // outside the request path.        // spec-398 t-6: durably snapshot the earliest pass BEFORE retention can
         // trim it away, so analytics keeps a true "first went green" date.
         if (insertValues.status === "pass" && !insertValues.hidden) {
           await recordFirstVerified(tx, insertValues.subjectRef, inserted.createdAt, targetMemexId);

--- a/packages/server/src/routes/test-events.ts
+++ b/packages/server/src/routes/test-events.ts
@@ -528,6 +528,10 @@ async function processOneEvent(
           status: insertValues.status as "pass" | "fail" | "error",
           latestRunAt: inserted.createdAt,
           hidden: insertValues.hidden,
+          // spec-520 dec-8: the same values written to the log row, so the CI-origin audit
+          // can read provenance from the summary once retention stops keeping the log row.
+          runId: insertValues.runId,
+          metadata: insertValues.metadata,
         });
         // spec-520 t-9 (dec-5): the ANALYTICAL tier, in the same transaction as
         // the log write and the operational summary — so the counts can never

--- a/packages/server/src/services/ac-matrix-bounded.integration.test.ts
+++ b/packages/server/src/services/ac-matrix-bounded.integration.test.ts
@@ -1,0 +1,182 @@
+// spec-520 t-12 precondition — the AC tab's two full-history reads get an explicit bound
+// before the retention trim that was silently providing one is deleted.
+//
+// WHAT NOBODY WROTE DOWN. `listTestMatrixForAc` and `listTestEventDigestForAc` both read
+// EVERY test_events row for an AC with no LIMIT. That is survivable today only because
+// spec-398's trim caps each (subject_ref, test_identifier) pair at RETENTION_KEEP=10 — so
+// the matrix renders at most ten columns per row, not by any display decision but as a
+// side effect of retention. t-12 deletes the trim. At ~2.68M emissions/day (spec-520 c-12)
+// a three-day window leaves roughly an order of magnitude more rows per pair, and the AC
+// tab would degrade on the day the migration ships, with nothing in that diff to explain
+// it.
+//
+// THE TWO READS NEED DIFFERENT FIXES, and that is the point of this file.
+//
+//   • The MATRIX returns the emissions themselves, so it takes a per-pair cap — the bound
+//     the trim was providing by accident, now stated as a display decision.
+//
+//   • The DIGEST returns no emissions at all. It reads every row to compute `count`,
+//     documented as "Total emissions recorded (hidden + visible) — the audit depth", and
+//     to find the latest non-hidden one. Putting a LIMIT on it would silently redefine a
+//     displayed number as "the last N" — a quieter defect than the one being fixed. It
+//     becomes an aggregate query instead, which also stops pulling every row into Node
+//     just to call .length on them.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
+import {
+  MATRIX_EMISSIONS_PER_TEST,
+  createAc,
+  listTestEventDigestForAc,
+  listTestMatrixForAc,
+} from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+
+const AC_BOUND = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-41";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedAc(statement: string): Promise<{ acId: string; ref: string }> {
+  const doc = await createDocDraft(memexId, "matrix bound", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  const ac = await createAc({
+    memexId, briefId: doc.id, kind: "implementation", statement,
+  });
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+  createdRefs.push(ref);
+  return { acId: ac.id, ref };
+}
+
+/** `n` emissions for one pair, oldest first, one minute apart. */
+async function seedRun(
+  ref: string,
+  testIdentifier: string,
+  n: number,
+  status: "pass" | "fail" | "error" = "pass",
+  opts: { hidden?: boolean } = {},
+): Promise<void> {
+  const base = Date.now() - n * 60_000;
+  for (let i = 0; i < n; i++) {
+    await seedTestEvent({
+      subjectRef: ref,
+      status,
+      testIdentifier,
+      createdAt: new Date(base + i * 60_000),
+      ...(opts.hidden ? { hidden: true } : {}),
+    });
+  }
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t12m");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-41: the AC matrix carries its own bound", () => {
+  it("caps emissions per test at the display bound and keeps the NEWEST", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("over the bound");
+    const over = MATRIX_EMISSIONS_PER_TEST + 7;
+    await seedRun(ref, "a::t", over);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    const row = rows.find((r) => r.testIdentifier === "a::t")!;
+    expect(row.emissions).toHaveLength(MATRIX_EMISSIONS_PER_TEST);
+    // Newest-first, and the ones dropped are the oldest — a bound that kept the oldest
+    // would show a stale column set that never changes as tests run.
+    const times = row.emissions.map((e) => e.emittedAt.getTime());
+    expect(times).toEqual([...times].sort((a, b) => b - a));
+    expect(Math.min(...times)).toBeGreaterThan(Date.now() - over * 60_000);
+  });
+
+  it("applies the bound PER TEST, not across the whole AC", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("two tests");
+    await seedRun(ref, "a::t", MATRIX_EMISSIONS_PER_TEST + 3);
+    await seedRun(ref, "b::t", MATRIX_EMISSIONS_PER_TEST + 3);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    // A global LIMIT would starve whichever test sorted later — the matrix would lose an
+    // entire row rather than trim a long one.
+    expect(rows.find((r) => r.testIdentifier === "a::t")!.emissions).toHaveLength(MATRIX_EMISSIONS_PER_TEST);
+    expect(rows.find((r) => r.testIdentifier === "b::t")!.emissions).toHaveLength(MATRIX_EMISSIONS_PER_TEST);
+  });
+
+  it("leaves a pair under the bound untouched", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("under the bound");
+    await seedRun(ref, "a::t", 3);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    expect(rows.find((r) => r.testIdentifier === "a::t")!.emissions).toHaveLength(3);
+  });
+});
+
+describe("spec-520 ac-41: the digest counts everything, and reads nothing it does not need", () => {
+  it("reports the TRUE total, not the matrix bound", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("audit depth");
+    const total = MATRIX_EMISSIONS_PER_TEST + 11;
+    await seedRun(ref, "a::t", total);
+
+    const rows = await listTestEventDigestForAc(memexId, acId);
+    // `count` is documented as the audit depth. A bound applied here would redefine a
+    // displayed number as "the last N" — quieter than the defect being fixed, and worse.
+    expect(rows.find((r) => r.testIdentifier === "a::t")!.count).toBe(total);
+  });
+
+  it("still reads the verdict off the newest non-hidden emission", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("verdict survives");
+    await seedRun(ref, "a::t", MATRIX_EMISSIONS_PER_TEST + 5, "pass");
+    // The newest one is red. If the digest ever loses sight of it, the AC stops being
+    // pinned red while a test is failing — the worst direction for this to break in.
+    await seedTestEvent({
+      subjectRef: ref, status: "fail", testIdentifier: "a::t", createdAt: new Date(),
+    });
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    expect(row.latestStatus).toBe("fail");
+    expect(row.pinning).toBe(true);
+    expect(row.hidden).toBe(false);
+  });
+
+  it("reports a fully hidden pair as retired, with no verdict", async () => {
+    tagAc(AC_BOUND);
+    const { acId, ref } = await seedAc("fully hidden");
+    await seedRun(ref, "h::t", 3, "pass", { hidden: true });
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "h::t")!;
+    expect(row.hidden).toBe(true);
+    expect(row.latestStatus).toBeNull();
+    expect(row.latestRunAt).toBeNull();
+    // Hidden rows still count toward the audit depth — that is what "hidden + visible"
+    // means, and it is how a retired pair stays visibly retired rather than vanishing.
+    expect(row.count).toBe(3);
+  });
+});

--- a/packages/server/src/services/ac-matrix-carry-forward.integration.test.ts
+++ b/packages/server/src/services/ac-matrix-carry-forward.integration.test.ts
@@ -1,0 +1,182 @@
+// spec-520 dec-9 (ac-42) — a pair whose emissions have all left the retention window still
+// reports its last known state instead of an empty grid.
+//
+// THE NUMBER THAT FORCED THIS. t-12 swaps count-based retention ("latest 10 per pair, any
+// age") for a time window. Those rules are not interchangeable: a pair that ran ten times
+// in March keeps all ten today and would keep none under a window. Measured on prod
+// 2026-08-30, BEFORE any swap — 196,978 of 243,339 pairs have not run in three days.
+// **81%.**
+//
+// The verification badge reads test_event_latest, which retention has never touched
+// (spec-398 ac-8 guarantees it). The evidence grid reads test_events. So without this, four
+// out of five ACs would render "Verified" above an EMPTY matrix — the two halves of one tab
+// contradicting each other, and the half that looks broken being the one that carries the
+// proof.
+//
+// WHY A SEPARATE FIELD AND NOT A SYNTHETIC EMISSION. The matrix UI lays emissions out on a
+// shared TIME AXIS by emittedAt. A fabricated entry dated three months back would be
+// positioned off the axis, and worse, it would claim to be a run inside the window. ac-42
+// asks for it "marked as a carried-forward summary rather than presented as a run" — so it
+// is literally not in the emissions list. Nothing in the existing layout logic changes.
+//
+// HOW A DARK PAIR IS SIMULATED. No window exists yet, so the test deletes the raw rows and
+// keeps the summary — which is exactly the state t-12 will produce for a pair whose last
+// run predates the window.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
+import { createAc, listTestEventDigestForAc, listTestMatrixForAc } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+
+const AC_CARRY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-42";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedAc(statement: string): Promise<{ acId: string; ref: string }> {
+  const doc = await createDocDraft(memexId, "carry forward", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  const ac = await createAc({ memexId, briefId: doc.id, kind: "implementation", statement });
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+  createdRefs.push(ref);
+  return { acId: ac.id, ref };
+}
+
+/** Emit, then drop the raw rows — the shape a time window leaves behind for a dark pair. */
+async function goDark(
+  ref: string,
+  testIdentifier: string,
+  status: "pass" | "fail" | "error",
+  at: Date,
+): Promise<void> {
+  await seedTestEvent({ subjectRef: ref, status, testIdentifier, createdAt: at });
+  await db
+    .delete(testEvents)
+    .where(and(eq(testEvents.subjectRef, ref), eq(testEvents.testIdentifier, testIdentifier)));
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("d9cf");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-42: the matrix carries a dark pair's last known state forward", () => {
+  it("reports the pair with an empty emission list and a carried-forward summary", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("dark pair");
+    const lastRun = new Date("2026-06-12T09:00:00Z");
+    await goDark(ref, "a::t", "pass", lastRun);
+
+    const rows = await listTestMatrixForAc(memexId, acId);
+    const row = rows.find((r) => r.testIdentifier === "a::t");
+    // Without the fallback the pair is absent entirely — not an empty row, no row at all.
+    expect(row, "a dark pair must still appear in the matrix").toBeDefined();
+    expect(row!.emissions).toHaveLength(0);
+    expect(row!.carriedForward).not.toBeNull();
+    expect(row!.carriedForward!.status).toBe("pass");
+    expect(row!.carriedForward!.emittedAt.toISOString()).toBe(lastRun.toISOString());
+  });
+
+  it("leaves a pair that still has rows in the window untouched", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("live pair");
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "a::t", createdAt: new Date() });
+
+    const row = (await listTestMatrixForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    expect(row.emissions).toHaveLength(1);
+    // The fallback is for absence of evidence, not a decoration on evidence that exists.
+    expect(row.carriedForward).toBeNull();
+  });
+
+  it("carries forward a RED last-known state, not just a green one", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("dark and red");
+    await goDark(ref, "a::t", "fail", new Date("2026-06-12T09:00:00Z"));
+
+    const row = (await listTestMatrixForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    // Only carrying greens forward would turn the fallback into a way of hiding failures.
+    expect(row.carriedForward!.status).toBe("fail");
+  });
+
+  it("does not invent a row for a pair that only ever had hidden emissions", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("hidden only");
+    await seedTestEvent({
+      subjectRef: ref, status: "pass", testIdentifier: "h::t", createdAt: new Date(), hidden: true,
+    });
+
+    // Hidden emissions never reach test_event_latest (applyEmissionToSummary returns early),
+    // and the matrix excludes them. Enumerating pairs from the summary must not change that.
+    const rows = await listTestMatrixForAc(memexId, acId);
+    expect(rows.find((r) => r.testIdentifier === "h::t")).toBeUndefined();
+  });
+});
+
+describe("spec-520 ac-42: the digest does the same without losing what it already reported", () => {
+  it("reports a dark pair with a zero count and its last known verdict", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("digest dark");
+    await goDark(ref, "a::t", "pass", new Date("2026-06-12T09:00:00Z"));
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t");
+    expect(row, "a dark pair must still appear in the digest").toBeDefined();
+    // Zero is the honest audit depth — no rows are retained. The verdict is still known.
+    expect(row!.count).toBe(0);
+    expect(row!.latestStatus).toBe("pass");
+    expect(row!.carriedForward).toBe(true);
+    expect(row!.hidden).toBe(false);
+  });
+
+  it("still reports a hidden-only pair, which has rows but NO summary row", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("digest hidden only");
+    await seedTestEvent({
+      subjectRef: ref, status: "pass", testIdentifier: "h::t", createdAt: new Date(), hidden: true,
+    });
+
+    // The digest now has to enumerate pairs from BOTH test_events and test_event_latest.
+    // Switching to the summary alone would silently drop fully-retired pairs — repairing
+    // dark pairs by losing hidden ones.
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "h::t");
+    expect(row, "a hidden-only pair has no summary row and must not vanish").toBeDefined();
+    expect(row!.count).toBe(1);
+    expect(row!.hidden).toBe(true);
+    expect(row!.latestStatus).toBeNull();
+    expect(row!.carriedForward).toBe(false);
+  });
+
+  it("leaves a live pair reporting its real count", async () => {
+    tagAc(AC_CARRY);
+    const { acId, ref } = await seedAc("digest live");
+    await seedTestEvent({ subjectRef: ref, status: "fail", testIdentifier: "a::t", createdAt: new Date() });
+
+    const row = (await listTestEventDigestForAc(memexId, acId)).find((r) => r.testIdentifier === "a::t")!;
+    expect(row.count).toBe(1);
+    expect(row.carriedForward).toBe(false);
+    expect(row.pinning).toBe(true);
+  });
+});

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -1343,19 +1343,38 @@ export async function auditCiEmissionForBrief(
 
   const out: CiEmissionAuditRow[] = [];
   for (const r of verified) {
-    // The latest non-hidden emission for this AC across all its test_identifiers.
+    // spec-520 dec-8 option A: provenance now comes from the SUMMARY, not the raw log.
+    //
+    // This reads the latest emission of an AC that is ALREADY verified, so the row can be
+    // arbitrarily old. Retention keeps 10 rows per pair today, which for a rarely-run test
+    // spans months — but t-12 replaces that with a short TIME window, at which point the raw
+    // row is gone and `if (!latest) continue` would report "no local-only ACs". That is a
+    // FALSE NEGATIVE on a provenance audit, and it reaches assess_spec's phase rubric, so it
+    // would tell a reader the evidence is stronger than it is at a phase decision.
+    //
+    // test_event_latest holds one row per (subject_ref, test_identifier); the newest overall
+    // is the greatest latest_run_at, and 0137 carries that emission's run id and metadata
+    // beside it.
     const [latest] = await db
       .select({
-        runId: testEvents.runId,
-        metadata: testEvents.metadata,
-        createdAt: testEvents.createdAt,
+        runId: testEventLatest.latestRunId,
+        metadata: testEventLatest.latestMetadata,
+        runAt: testEventLatest.latestRunAt,
       })
-      .from(testEvents)
-      .where(and(eq(testEvents.subjectRef, r.canonicalRef), eq(testEvents.hidden, false)))
-      .orderBy(desc(testEvents.createdAt))
+      .from(testEventLatest)
+      .where(eq(testEventLatest.subjectRef, r.canonicalRef))
+      .orderBy(desc(testEventLatest.latestRunAt))
       .limit(1);
     // A verified AC always has ≥1 passing emission; defensively skip if none.
     if (!latest) continue;
+    // ⚠ NULL metadata means "never observed", NOT "not CI". Rows written before 0137 carry
+    // no provenance and nothing can recover it — the raw rows that knew are exactly the ones
+    // retention deletes. Judging them would report every pre-existing AC as laptop-verified:
+    // a FALSE POSITIVE, the mirror of the false negative above, and just as misleading at a
+    // phase decision. From 0137 on the writer stores `{}` rather than null when an emission
+    // carries no metadata, so NULL here means one thing only, and UNKNOWN skips — exactly
+    // what a missing row does today.
+    if (latest.metadata == null) continue;
     if (!emissionIsCiOriginated({ runId: latest.runId, metadata: latest.metadata })) {
       out.push({ handle: `ac-${r.ac.seq}` });
     }

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -733,8 +733,19 @@ export interface TestEventEmission {
 export interface TestMatrixRow {
   /** test_identifier as emitted by the helper, or empty string when null. */
   testIdentifier: string;
-  /** Every emission ever recorded for this (subject_ref, test_identifier), newest-first. */
+  /** Retained emissions for this (subject_ref, test_identifier), newest-first. */
   emissions: TestEventEmission[];
+  /**
+   * spec-520 dec-9 (ac-42): the pair's last known state, carried forward from
+   * test_event_latest when NO emission for it survives in the log. Null whenever
+   * `emissions` is non-empty.
+   *
+   * ⚠ DELIBERATELY NOT AN ENTRY IN `emissions`. It is not a run inside the retention
+   * window and must never be laid out on the matrix's shared time axis as though it were —
+   * it would be positioned months off the axis and would claim evidence the log no longer
+   * holds. Consumers render it as "last known", not as a cell.
+   */
+  carriedForward: { status: "pass" | "fail" | "error"; emittedAt: Date } | null;
 }
 
 /**
@@ -818,10 +829,42 @@ export async function listTestMatrixForAc(
     byTestIdentifier.set(key, list);
   }
 
+  // spec-520 dec-9 (ac-42): a pair whose emissions have all left the retention window is
+  // absent from the query above entirely — not an empty row, NO row. Under a time window
+  // that is the majority case: measured on prod 2026-08-30, 196,978 of 243,339 pairs had
+  // not run in three days. The badge would still read "Verified" (it comes from
+  // test_event_latest, which retention never touches) above a blank grid.
+  //
+  // So pairs are enumerated from the summary too, and a dark one carries its last known
+  // state. A second small indexed read rather than a wider join: this one is keyed on the
+  // test_event_latest PK's leading column, and merging two small maps in JS is far easier
+  // to follow than the four-CTE query that would fuse them.
+  const summary = await db
+    .select({
+      testIdentifier: testEventLatest.testIdentifier,
+      latestStatus: testEventLatest.latestStatus,
+      latestRunAt: testEventLatest.latestRunAt,
+    })
+    .from(testEventLatest)
+    .where(eq(testEventLatest.subjectRef, subjectRef));
+
+  const rows: TestMatrixRow[] = Array.from(byTestIdentifier.entries()).map(
+    ([testIdentifier, emissions]) => ({ testIdentifier, emissions, carriedForward: null }),
+  );
+  for (const pair of summary) {
+    if (byTestIdentifier.has(pair.testIdentifier)) continue;
+    rows.push({
+      testIdentifier: pair.testIdentifier,
+      emissions: [],
+      carriedForward: {
+        status: pair.latestStatus as "pass" | "fail" | "error",
+        emittedAt: pair.latestRunAt,
+      },
+    });
+  }
+
   // Stable row ordering across reads — emissions already DESC from the query.
-  return Array.from(byTestIdentifier.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([testIdentifier, emissions]) => ({ testIdentifier, emissions }));
+  return rows.sort((a, b) => a.testIdentifier.localeCompare(b.testIdentifier));
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -854,6 +897,12 @@ export interface TestEventDigestRow {
   hidden: boolean;
   /** Latest non-hidden emission is fail/error — this identifier pins the AC red. */
   pinning: boolean;
+  /**
+   * spec-520 dec-9 (ac-42): true when NO emission for this pair survives in the log and
+   * `latestStatus` therefore comes from test_event_latest rather than from a retained row.
+   * `count` is 0 in that case — an honest audit depth, not a missing verdict.
+   */
+  carriedForward: boolean;
 }
 
 export async function listTestEventDigestForAc(
@@ -883,6 +932,22 @@ export async function listTestEventDigestForAc(
       WHERE subject_ref = ${subjectRef}
       GROUP BY 1
     ),
+    -- spec-520 dec-9 (ac-42): the durable index of pairs. A pair whose rows have all left
+    -- the window has no entry in totals and would vanish from the digest entirely.
+    summary AS (
+      SELECT test_identifier AS tid, latest_status, latest_run_at
+      FROM test_event_latest
+      WHERE subject_ref = ${subjectRef}
+    ),
+    -- ⚠ UNION, NOT a switch to the summary alone. Hidden emissions never reach
+    -- test_event_latest (applyEmissionToSummary returns early on hidden), so a fully
+    -- retired pair has rows here and NO summary row. Reading only the summary would repair
+    -- dark pairs by silently dropping retired ones.
+    pairs AS (
+      SELECT tid FROM totals
+      UNION
+      SELECT tid FROM summary
+    ),
     -- The newest row of ANY visibility, for the commit-sha fallback the JS version had.
     newest_any AS (
       SELECT DISTINCT ON (COALESCE(test_identifier, ''))
@@ -900,21 +965,28 @@ export async function listTestEventDigestForAc(
       WHERE subject_ref = ${subjectRef} AND hidden = false
       ORDER BY COALESCE(test_identifier, ''), created_at DESC, id DESC
     )
-    SELECT t.tid                AS test_identifier,
-           t.n                  AS count,
-           lv.status            AS latest_status,
-           lv.created_at        AS latest_run_at,
-           COALESCE(lv.commit_sha, na.commit_sha) AS last_commit
-    FROM totals t
-    LEFT JOIN latest_visible lv ON lv.tid = t.tid
-    LEFT JOIN newest_any     na ON na.tid = t.tid
-    ORDER BY t.tid ASC
+    SELECT p.tid                                     AS test_identifier,
+           COALESCE(t.n, 0)                          AS count,
+           COALESCE(lv.status, s.latest_status)      AS latest_status,
+           COALESCE(lv.created_at, s.latest_run_at)  AS latest_run_at,
+           COALESCE(lv.commit_sha, na.commit_sha)    AS last_commit,
+           -- Carried forward exactly when the log holds no visible row for the pair but
+           -- the summary knows its state. A hidden-only pair satisfies neither side and
+           -- stays reported as retired, which is what it is.
+           (lv.status IS NULL AND s.latest_status IS NOT NULL) AS carried_forward
+    FROM pairs p
+    LEFT JOIN totals         t  ON t.tid  = p.tid
+    LEFT JOIN summary        s  ON s.tid  = p.tid
+    LEFT JOIN latest_visible lv ON lv.tid = p.tid
+    LEFT JOIN newest_any     na ON na.tid = p.tid
+    ORDER BY p.tid ASC
   `)) as unknown as Array<{
     test_identifier: string;
     count: number;
     latest_status: "pass" | "fail" | "error" | null;
     // Raw driver value — see the note on the matrix read above.
     latest_run_at: Date | string | null;
+    carried_forward: boolean;
     last_commit: string | null;
   }>;
 
@@ -931,6 +1003,7 @@ export async function listTestEventDigestForAc(
     count: Number(r.count),
     hidden: r.latest_status === null,
     pinning: r.latest_status === "fail" || r.latest_status === "error",
+    carriedForward: r.carried_forward === true,
   }));
 }
 

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -1217,6 +1217,15 @@ export interface AlignmentDay {
   total: number;
   /** Same as listAcsForBriefWithVerification, broken down by kind. */
   kind: "scope" | "implementation";
+  /**
+   * False for days that predate the per-day rollup's first row for this Memex — days we
+   * CANNOT measure, because the per-day past was destroyed by retention and cannot be
+   * reconstructed. Their `verified: 0` is an absence of measurement, not a measured
+   * absence, and ac-5 requires the chart say so rather than let a truncated past read as
+   * data. Callers must render an unmeasured span distinctly; the span shrinks on its own
+   * as history accumulates and eventually disappears.
+   */
+  measured: boolean;
 }
 
 /**
@@ -1225,7 +1234,8 @@ export interface AlignmentDay {
  *   - total  = ACs active on that day (created on or before; status='active'
  *              today — V0.0.1 simplification, we don't reconstruct historical
  *              status transitions, which would require an audit table)
- *   - verified = ACs whose latest test_event AS OF END-OF-DAY is 'pass'
+ *   - verified = ACs that were GREEN as of end-of-day: on the most recent day the AC ran
+ *                at all (≤ this day), every one of its tests passed
  *
  * V0.0.1 caveat: status reconstruction is not historical. An AC currently
  * `rejected` or `superseded` is excluded from the total even on days when it
@@ -1233,10 +1243,9 @@ export interface AlignmentDay {
  * what we care about TODAY; backfilling true historical status would need a
  * status-event log we don't have.
  *
- * SQL is a window-function pair per day, fanned out via generate_series. The
- * heavy lifting is the LATERAL join that finds the latest test event per
- * (subject_ref, day) ≤ end-of-day. Bounded by the AC set in the Spec, which is
- * small (rarely >100), so this is cheap even at 90 days.
+ * SQL fans days out via generate_series and, per (day × AC), reads the per-day ROLLUP —
+ * not the raw log. Bounded by the AC set in the Spec, which is small (rarely >100), so
+ * this stays cheap even at 90 days.
  */
 export async function listAcAlignmentOverTime(
   memexId: string,
@@ -1269,8 +1278,33 @@ export async function listAcAlignmentOverTime(
     sql`, `,
   );
 
-  // For each (day × ac), find the latest event ≤ end-of-day for that subject_ref;
-  // 'verified' iff that latest is 'pass'. Total = ACs that existed by then.
+  // spec-520 t-11 (ac-24): per (day × AC), read the per-day ROLLUP — not the raw log.
+  //
+  // THE DEFECT THIS CLOSES. This carried a correlated
+  //   SELECT te.status FROM test_events te
+  //   WHERE te.subject_ref = a.subject_ref AND te.created_at < day+1
+  //   ORDER BY te.created_at DESC LIMIT 1
+  // against a table the retention trim caps at RETENTION_KEEP=10 rows per (subject_ref,
+  // test_identifier). For a BUSY AC those ten rows are all from the last few hours, so
+  // every older day found nothing and read as "never verified". Same bias as testRunVolume
+  // and it runs the same direction: the more an AC is tested, the less of its history the
+  // chart could see (prod 2026-08-18 — 65,708 pairs sitting at exactly the cap).
+  //
+  // AND THE DERIVATION IS NOW HONEST. "Latest single event" answered with whichever row
+  // happened to write last, so one passing test masked a sibling that went red in the same
+  // minute. The rollup keeps per-test counts, so green is what it should always have
+  // meant: on the most recent day the AC ran at all, EVERY one of its tests passed. That
+  // is the property t-11 names, and it was not answerable before this table existed.
+  //
+  // SCOPED BY memex_id. The old read filtered on subject_ref alone — tenancy carried by a
+  // string, the spec-396 leak pattern (a real cross-org bleed of ~1.5M rows across 137
+  // memexes) this Spec closes elsewhere.
+  //
+  // ⚠ HISTORY STARTS AT THE ROLLUP'S FIRST ROW. Unlike testRunVolume — which begins its
+  // series at min(day) and so cannot show a fabricated past — this query generates a FIXED
+  // `days`-long window, so it necessarily emits days it cannot measure. `measured` marks
+  // them (ac-5); rendering them as a plain zero would let a deleted past read as measured
+  // absence, which is the specific misreading ac-5 forbids.
   const rows = (await db.execute(sql`
     WITH ac_set(subject_ref, kind, created_at, accepted_at) AS (
       VALUES ${acSetValues}
@@ -1282,6 +1316,9 @@ export async function listAcAlignmentOverTime(
         '1 day'::interval
       )::date AS day
     ),
+    coverage AS (
+      SELECT min(day) AS first_day FROM test_run_daily WHERE memex_id = ${memexId}
+    ),
     daily AS (
       SELECT
         s.day,
@@ -1290,13 +1327,20 @@ export async function listAcAlignmentOverTime(
         a.created_at,
         a.accepted_at,
         (
-          SELECT te.status
-          FROM test_events te
-          WHERE te.subject_ref = a.subject_ref
-            AND te.created_at < (s.day + INTERVAL '1 day')
-          ORDER BY te.created_at DESC
+          -- The most recent day this AC ran at or before s.day, collapsed across all of
+          -- its tests. NULL when it had not run by then — distinct from FALSE (ran, and
+          -- something was red), and the two are treated differently below.
+          SELECT sum(r.fail_count) = 0
+             AND sum(r.error_count) = 0
+             AND sum(r.pass_count) > 0
+          FROM test_run_daily r
+          WHERE r.memex_id = ${memexId}
+            AND r.subject_ref = a.subject_ref
+            AND r.day <= s.day
+          GROUP BY r.day
+          ORDER BY r.day DESC
           LIMIT 1
-        ) AS latest_status
+        ) AS green
       FROM series s
       CROSS JOIN ac_set a
     )
@@ -1304,26 +1348,34 @@ export async function listAcAlignmentOverTime(
       day::text AS date,
       kind,
       COUNT(*) FILTER (WHERE created_at <= day + INTERVAL '1 day') AS total,
-      -- Gate verified on AC existence too — otherwise a test_event predating
-      -- the AC's createdAt (only possible with synthetic seed data, but the
-      -- contract should hold) yields verified > total, which is nonsense.
+      -- Gate verified on AC existence too — otherwise history predating the AC's
+      -- createdAt yields verified > total, which is nonsense.
       --
-      -- spec-188 dec-1/dec-2: a manual acceptance counts as verified from the
-      -- day it was recorded, with the same evidence-wins precedence as
-      -- deriveVerificationState — a failing/erroring latest status suppresses
-      -- it. (V0.0.1 caveat, same as status above: accepted_at is TODAY's
-      -- value, not historically reconstructed across un-accept cycles.)
+      -- spec-188 dec-1/dec-2: a manual acceptance counts as verified from the day it was
+      -- recorded, with the same evidence-wins precedence as deriveVerificationState — a
+      -- red latest day suppresses it. green IS NOT FALSE is the precise form: an AC that
+      -- has never run (NULL) keeps its acceptance, one whose tests are red loses it.
+      -- (V0.0.1 caveat: accepted_at is TODAY's value, not reconstructed across un-accept
+      -- cycles.)
       COUNT(*) FILTER (
         WHERE created_at <= day + INTERVAL '1 day'
           AND (
-            latest_status = 'pass'
+            green
             OR (
               accepted_at IS NOT NULL
               AND accepted_at < day + INTERVAL '1 day'
-              AND (latest_status IS NULL OR latest_status = 'pass')
+              AND green IS NOT FALSE
             )
           )
-      ) AS verified
+      ) AS verified,
+      -- An expression on day, which is already grouped. A Memex with no rollup rows at
+      -- all has first_day NULL, so every day is unmeasured — the strongest form of the
+      -- same statement, and the one a naive "is there a row for this day" flag would miss
+      -- by having nothing to report.
+      (
+        (SELECT first_day FROM coverage) IS NOT NULL
+        AND day >= (SELECT first_day FROM coverage)
+      ) AS measured
     FROM daily
     GROUP BY day, kind
     ORDER BY day ASC, kind ASC
@@ -1332,6 +1384,7 @@ export async function listAcAlignmentOverTime(
     kind: "scope" | "implementation";
     total: string | number;
     verified: string | number;
+    measured: boolean;
   }>;
 
   return rows.map((r) => ({
@@ -1339,6 +1392,7 @@ export async function listAcAlignmentOverTime(
     kind: r.kind,
     total: Number(r.total),
     verified: Number(r.verified),
+    measured: r.measured === true,
   }));
 }
 

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -738,8 +738,25 @@ export interface TestMatrixRow {
 }
 
 /**
- * Read the full test-event history for one AC, grouped by `test_identifier`,
- * each row's emissions newest-first by `created_at`.
+ * spec-520 t-12: the matrix shows at most this many emissions PER TEST.
+ *
+ * This is the bound spec-398's retention trim was providing by accident. Until now the
+ * matrix had no LIMIT of its own and was survivable only because the trim capped each
+ * (subject_ref, test_identifier) pair at RETENTION_KEEP=10 — a display bound nobody chose,
+ * enforced by a deletion policy. t-12 deletes that trim in favour of a time window, under
+ * which a busy pair keeps roughly an order of magnitude more rows (~2.68M emissions/day
+ * across the fleet, spec-520 c-12). Without this the AC tab degrades on the day that
+ * migration ships, with nothing in its diff to explain why.
+ *
+ * Ten preserves exactly what users see today. It is a display choice now, so changing it
+ * is a decision about the UI rather than a side effect of a retention policy.
+ */
+export const MATRIX_EMISSIONS_PER_TEST = 10;
+
+/**
+ * Read the recent test-event history for one AC, grouped by `test_identifier`,
+ * each row's emissions newest-first by `created_at` and capped at
+ * MATRIX_EMISSIONS_PER_TEST per test.
  *
  * No server-side run-batching, no `run_id`-aware grouping, no inferred
  * "didn't run" cells (b-96 dec-11). One column entry per `test_events` row.
@@ -755,20 +772,48 @@ export async function listTestMatrixForAc(
   // spec-115 v0.1.0: hidden events are excluded from the matrix view too —
   // the matrix is the per-AC verification timeline that drives the badge.
   // Hidden audit history is in the DB but not surfaced in v0.1.0.
-  const events = await db.query.testEvents.findMany({
-    where: and(eq(testEvents.subjectRef, subjectRef), eq(testEvents.hidden, false)),
-    orderBy: [desc(testEvents.createdAt)],
-  });
+  //
+  // The cap is PER TEST, via row_number() — not a plain LIMIT. A global limit would
+  // starve whichever test_identifier sorted later, dropping an entire matrix ROW rather
+  // than trimming a long one, and which row vanished would depend on how the AC's tests
+  // happened to be named. The window orders by (created_at DESC, id DESC), the same
+  // deterministic tiebreak the retention index uses, so a pair emitting several times
+  // within one timestamp still cuts at a stable point.
+  const events = (await db.execute(sql`
+    SELECT id, subject_ref, test_identifier, status, created_at, actor, metadata, commit_sha
+    FROM (
+      SELECT te.*,
+             row_number() OVER (
+               PARTITION BY COALESCE(te.test_identifier, '')
+               ORDER BY te.created_at DESC, te.id DESC
+             ) AS rn
+      FROM test_events te
+      WHERE te.subject_ref = ${subjectRef} AND te.hidden = false
+    ) ranked
+    WHERE rn <= ${MATRIX_EMISSIONS_PER_TEST}
+    ORDER BY created_at DESC, id DESC
+  `)) as unknown as Array<{
+    test_identifier: string | null;
+    status: string;
+    // ⚠ db.execute hands back RAW driver values, so a timestamptz arrives as a string
+    // here — unlike the query-builder reads elsewhere in this file, which map it to a
+    // Date. Typing it Date and trusting that is how a `.getTime is not a function`
+    // reaches production through a green suite.
+    created_at: Date | string;
+    actor: string | null;
+    metadata: Record<string, unknown> | null;
+    commit_sha: string | null;
+  }>;
 
   const byTestIdentifier = new Map<string, TestEventEmission[]>();
   for (const ev of events) {
-    const key = ev.testIdentifier ?? "";
+    const key = ev.test_identifier ?? "";
     const list = byTestIdentifier.get(key) ?? [];
     list.push({
       status: ev.status as "pass" | "fail" | "error",
-      emittedAt: ev.createdAt,
+      emittedAt: ev.created_at instanceof Date ? ev.created_at : new Date(ev.created_at),
       actor: ev.actor ?? null,
-      metadata: ev.metadata ?? null,
+      metadata: (ev.metadata as TestEventEmission["metadata"]) ?? null,
     });
     byTestIdentifier.set(key, list);
   }
@@ -819,39 +864,74 @@ export async function listTestEventDigestForAc(
   const slugs = await resolveBriefSlugsForRef(ac.briefId);
   const subjectRef = buildAcRef(slugs, ac.seq);
 
-  const events = await db.query.testEvents.findMany({
-    where: eq(testEvents.subjectRef, subjectRef),
-    orderBy: [desc(testEvents.createdAt)],
-  });
+  // spec-520 t-12: an AGGREGATE, not a full-history fetch.
+  //
+  // This used to read every test_events row for the AC into Node and derive the digest in
+  // JS — `count` was `evs.length`. It had no LIMIT and was survivable only because
+  // spec-398's trim capped each pair at 10; t-12 removes that trim, and a busy pair then
+  // carries roughly an order of magnitude more rows.
+  //
+  // ⚠ AND IT MUST NOT SIMPLY TAKE THE MATRIX'S BOUND. `count` is documented as the audit
+  // depth — hidden AND visible. Capping this read would quietly redefine a number the UI
+  // shows as "the last N", which is a subtler defect than the unbounded read it would be
+  // fixing. Counting in the database keeps the number exact at any table size and reads no
+  // row the digest does not use.
+  const rows = (await db.execute(sql`
+    WITH totals AS (
+      SELECT COALESCE(test_identifier, '') AS tid, count(*)::int AS n
+      FROM test_events
+      WHERE subject_ref = ${subjectRef}
+      GROUP BY 1
+    ),
+    -- The newest row of ANY visibility, for the commit-sha fallback the JS version had.
+    newest_any AS (
+      SELECT DISTINCT ON (COALESCE(test_identifier, ''))
+             COALESCE(test_identifier, '') AS tid, commit_sha
+      FROM test_events
+      WHERE subject_ref = ${subjectRef}
+      ORDER BY COALESCE(test_identifier, ''), created_at DESC, id DESC
+    ),
+    -- The verdict view: the latest NON-hidden emission. Absent for a fully retired pair,
+    -- which is exactly what the hidden flag reports.
+    latest_visible AS (
+      SELECT DISTINCT ON (COALESCE(test_identifier, ''))
+             COALESCE(test_identifier, '') AS tid, status, created_at, commit_sha
+      FROM test_events
+      WHERE subject_ref = ${subjectRef} AND hidden = false
+      ORDER BY COALESCE(test_identifier, ''), created_at DESC, id DESC
+    )
+    SELECT t.tid                AS test_identifier,
+           t.n                  AS count,
+           lv.status            AS latest_status,
+           lv.created_at        AS latest_run_at,
+           COALESCE(lv.commit_sha, na.commit_sha) AS last_commit
+    FROM totals t
+    LEFT JOIN latest_visible lv ON lv.tid = t.tid
+    LEFT JOIN newest_any     na ON na.tid = t.tid
+    ORDER BY t.tid ASC
+  `)) as unknown as Array<{
+    test_identifier: string;
+    count: number;
+    latest_status: "pass" | "fail" | "error" | null;
+    // Raw driver value — see the note on the matrix read above.
+    latest_run_at: Date | string | null;
+    last_commit: string | null;
+  }>;
 
-  const byId = new Map<string, typeof events>();
-  for (const ev of events) {
-    const key = ev.testIdentifier ?? "";
-    const list = byId.get(key) ?? [];
-    list.push(ev);
-    byId.set(key, list);
-  }
-
-  const rows: TestEventDigestRow[] = [];
-  for (const [testIdentifier, evs] of byId.entries()) {
-    // evs are newest-first; the latest non-hidden emission is the verdict view.
-    const latestVisible = evs.find((e) => !e.hidden) ?? null;
-    const latestStatus = (latestVisible?.status ?? null) as
-      | "pass"
-      | "fail"
-      | "error"
-      | null;
-    rows.push({
-      testIdentifier,
-      latestStatus,
-      latestRunAt: latestVisible?.createdAt ?? null,
-      lastCommit: latestVisible?.commitSha ?? evs[0]?.commitSha ?? null,
-      count: evs.length,
-      hidden: latestVisible === null,
-      pinning: latestStatus === "fail" || latestStatus === "error",
-    });
-  }
-  return rows.sort((a, b) => a.testIdentifier.localeCompare(b.testIdentifier));
+  return rows.map((r) => ({
+    testIdentifier: r.test_identifier,
+    latestStatus: r.latest_status,
+    latestRunAt:
+      r.latest_run_at == null
+        ? null
+        : r.latest_run_at instanceof Date
+          ? r.latest_run_at
+          : new Date(r.latest_run_at),
+    lastCommit: r.last_commit,
+    count: Number(r.count),
+    hidden: r.latest_status === null,
+    pinning: r.latest_status === "fail" || r.latest_status === "error",
+  }));
 }
 
 /**

--- a/packages/server/src/services/acs.ts
+++ b/packages/server/src/services/acs.ts
@@ -460,7 +460,31 @@ export async function listAcsForBriefWithVerification(
       runCount: testEventLatest.runCount,
     })
     .from(testEventLatest)
-    .where(inArray(testEventLatest.subjectRef, allRefs));
+    // spec-520 t-4 (ac-11): ONE bind parameter for the whole ref list.
+    //
+    // `IN (…)` binds one parameter PER REF, and each distinct COUNT is its own prepared
+    // statement, plan-cache entry and pg_stat_statements row. That fragmentation is what
+    // put 1,223 fingerprints — ~24.5% of the instance's 5,000 cap, which is 98.6% full and
+    // already evicting — behind one logical read (issue-10).
+    //
+    // `= ANY($1::text[])` is one parameter however many refs there are, so ONE fingerprint.
+    // Deliberately NOT rewritten to `memex_id = $1` alone like aggregateAcHealthForBriefs:
+    // that read already touched every row of the tenant, so scoping it tenant-wide cost
+    // nothing. This one serves a SINGLE Spec — tens of refs — and a tenant-wide read would
+    // fetch ~148k rows for the largest Memex to filter down to a handful.
+    //
+    // memex_id is added alongside so tenancy is an explicit predicate rather than an
+    // inference from ref-string uniqueness — the spec-396 posture, and what makes the
+    // (memex_id, subject_ref) index usable here.
+    .where(
+      and(
+        eq(testEventLatest.memexId, memexId),
+        // sql.param() is load-bearing: a bare `${allRefs}` makes drizzle interpolate the
+        // array as a LIST of parameters — the very fragmentation this is removing, and it
+        // fails outright against `= ANY(…)`. sql.param binds it as ONE array parameter.
+        sql`${testEventLatest.subjectRef} = ANY(${sql.param(allRefs)}::text[])`,
+      ),
+    );
 
   // Pull every parent link for our AC set in one query. The Decisions tab
   // uses these to find "the ACs hanging off this resolved decision" without
@@ -1071,11 +1095,38 @@ export async function aggregateAcHealthForBriefs(
   const allRefs = Array.from(refsByAcId.values());
   if (allRefs.length === 0) return result;
 
-  // Q2 — spec-162: the latest-per-pair summary for the AC universe, read
-  // directly from test_event_latest. Bounded by active AC×test pairs, not by
-  // history depth — this is the whole point of the change (ac-1). Hidden events
-  // were excluded at write time so there's no hidden filter here; '' is the
-  // stored key for null test_identifier (dec-2).
+  // Q2 — spec-162: the latest-per-pair summary for the AC universe, read directly from
+  // test_event_latest.
+  //
+  // spec-520 t-4 (dec-1, ac-7): ONE tenant parameter, not one per AC ref.
+  //
+  // This used to bind `subject_ref IN (…)` with every active ref — up to 3,745 values,
+  // 25KB of SQL. The cost that buys is not what the old comment ("bounded by active AC×test
+  // pairs, not by history depth") suggests:
+  //
+  //   • Each distinct bind-parameter COUNT is its own prepared statement, its own plan-cache
+  //     entry and its own pg_stat_statements row. Measured on prod: 1,098 fingerprints on
+  //     2026-08-18, 1,223 on 2026-08-28 — ~12/day, and ~24.5% of the instance's entire
+  //     5,000-entry cap, which is 98.6% full and already evicting (issue-10). One logical
+  //     read presenting as a thousand also makes that table illegible to anyone reading it
+  //     for top costs.
+  //   • Planning time 7.564 ms for the 1,800-literal form versus 0.037 ms for the simple
+  //     one — 200×, paid on every call before a row is touched.
+  //
+  // ⚠ DO NOT SIZE THIS AS A LATENCY FIX. s-4 §3 EXPLAINed both forms at ~48 ms with
+  // everything in shared_hit on a quiet connection, while pg_stat_statements puts the same
+  // read at a 642 ms mean in production. That 13× gap is contention and cache state, not
+  // plan shape, so a rewrite that only changes the plan will not deliver 642 → 48.
+  //
+  // ⚠ AND THE PLAN WILL PROBABLY STAY A SEQ SCAN for the tenant that matters, which is
+  // correct: one Memex holds 81.0% of this table (147,989 of 182,634 rows), so
+  // `memex_id = $1` selects four rows in five and an index scan would be slower. ac-8
+  // expects an index scan and is wrong for that tenant — see c-4.
+  //
+  // Over-fetching rows for ACs outside the requested Spec set is the accepted trade-off
+  // (dec-1): they are all read today anyway, since the seq scan touches every row. The
+  // bucketing below drops them, so the map stays bounded by the requested universe and
+  // parity is exact by construction rather than by argument.
   const summaryRows = await db
     .select({
       subjectRef: testEventLatest.subjectRef,
@@ -1085,13 +1136,18 @@ export async function aggregateAcHealthForBriefs(
       runCount: testEventLatest.runCount,
     })
     .from(testEventLatest)
-    .where(inArray(testEventLatest.subjectRef, allRefs));
+    .where(eq(testEventLatest.memexId, memexId));
 
   // Bucket the summary rows into per-AC snapshots in the same shape the AC tab
   // consumes, so deriveVerificationState gets identical input — card colour and
   // tab agree by construction (ac-2 parity). '' maps back to null.
   const snapshotsByRef = new Map<string, AcTestSnapshot[]>();
+  // spec-520 t-4: the read is now tenant-wide, so skip refs outside the requested universe.
+  // The tally below looks refs UP rather than iterating this map, so extra entries would be
+  // inert either way — this keeps the map bounded by the ACs actually asked about.
+  const wantedRefs = new Set(allRefs);
   for (const row of summaryRows) {
+    if (!wantedRefs.has(row.subjectRef)) continue;
     const list = snapshotsByRef.get(row.subjectRef) ?? [];
     list.push({
       testIdentifier: row.testIdentifier === "" ? null : row.testIdentifier,

--- a/packages/server/src/services/alignment-over-time-rollup.integration.test.ts
+++ b/packages/server/src/services/alignment-over-time-rollup.integration.test.ts
@@ -1,0 +1,316 @@
+// spec-520 t-11 (second half) — listAcAlignmentOverTime reads the per-day rollup.
+//
+// THE DEFECT. This query carried a correlated subquery per (day × AC):
+//
+//     SELECT te.status FROM test_events te
+//     WHERE te.subject_ref = a.subject_ref AND te.created_at < (s.day + INTERVAL '1 day')
+//     ORDER BY te.created_at DESC LIMIT 1
+//
+// against a table the retention trim caps at RETENTION_KEEP=10 rows per
+// (subject_ref, test_identifier). For a BUSY AC those ten rows are all from the last few
+// hours, so every older day finds nothing and reads as "never verified". The bias is the
+// same one that broke testRunVolume and it runs the same direction: the more an AC is
+// tested, the less of its history the chart can see. Measured on prod 2026-08-18 — 65,708
+// pairs sitting at exactly the cap of 10.
+//
+// THE PROOF SHAPE, as for ac-24's first half: seed the ROLLUP and leave the raw log EMPTY.
+// Under the old implementation that is indistinguishable from "nothing ever happened",
+// which is precisely the defect. Seeding raw events too would let a still-broken
+// implementation pass.
+//
+// AND A SEMANTIC UPGRADE t-11 ASKS FOR BY NAME: derive AC-green from ALL of an AC's tests
+// passing that day, not from whichever single event happened to be latest. The old read
+// took one row, so a passing test could mask a sibling that went red in the same minute.
+// The rollup keeps per-test counts, so the honest question is answerable for the first
+// time — and the third case below is red under any "latest single event" implementation.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  documents,
+  memexes,
+  namespaces,
+  testEventLatest,
+  testEvents,
+  testRunDaily,
+} from "../db/schema.js";
+import { createAc, listAcAlignmentOverTime } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+
+const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-24";
+// NOT ac-5. That criterion also claims "no behavioural change on the AC-health surfaces —
+// colours, counts and verification states identical before and after", which nothing here
+// exercises. Tagging it from the boundary clause alone would flip it green on a weaker
+// property than it states — the ac-22/ac-32 mistake. ac-40 is the boundary clause on its
+// own, and the sparkline half of it is proven in AcSparkline.boundary.test.tsx.
+const AC_BOUNDARY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-40";
+
+let memexId: string;
+let otherMemexId: string;
+/** Deliberately never given a rollup row — `otherMemexId` gets one by the tenancy case. */
+let emptyMemexId: string;
+/**
+ * The boundary cases need a Memex of their own. Coverage is min(day) across the WHOLE
+ * tenant, so a row seeded by any earlier case in this file would move the boundary under
+ * them — the cases would pass or fail on execution order rather than on the property.
+ */
+let boundaryMemexId: string;
+let boundarySlug: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedBrief(): Promise<{ id: string; handle: string }> {
+  const doc = await createDocDraft(memexId, "alignment rollup test", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  return { id: doc.id, handle: doc.handle! };
+}
+
+function refOf(briefHandle: string, seq: number): string {
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${briefHandle}/acs/ac-${seq}`;
+  createdRefs.push(ref);
+  return ref;
+}
+
+/**
+ * Write one rollup row. `dayOffset` counts BACK from the database's CURRENT_DATE — the
+ * query anchors its series on the server clock, so the fixture has to speak the same
+ * calendar rather than JS's.
+ */
+async function seedRollup(row: {
+  ref: string;
+  test: string;
+  dayOffset: number;
+  pass?: number;
+  fail?: number;
+  error?: number;
+  memex?: string;
+}): Promise<void> {
+  const pass = row.pass ?? 0;
+  const fail = row.fail ?? 0;
+  const error = row.error ?? 0;
+  await db.execute(sql`
+    INSERT INTO test_run_daily
+      (memex_id, subject_ref, test_identifier, day, run_count, pass_count, fail_count, error_count)
+    VALUES (
+      ${row.memex ?? memexId}::uuid, ${row.ref}, ${row.test},
+      CURRENT_DATE - ${row.dayOffset}::int,
+      ${pass + fail + error}, ${pass}, ${fail}, ${error}
+    )
+    ON CONFLICT (memex_id, subject_ref, test_identifier, day) DO UPDATE SET
+      run_count = EXCLUDED.run_count, pass_count = EXCLUDED.pass_count,
+      fail_count = EXCLUDED.fail_count, error_count = EXCLUDED.error_count
+  `);
+}
+
+/**
+ * Move an AC's createdAt back N days. The query gates `verified` on AC existence — an AC
+ * created today counts toward neither total nor verified on any earlier day — so a case
+ * asserting anything about the past has to put the AC in the past first.
+ */
+async function backdateAc(acId: string, days: number): Promise<void> {
+  await db.execute(sql`
+    UPDATE acs SET created_at = now() - (${days} || ' days')::interval WHERE id = ${acId}
+  `);
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t11b");
+  otherMemexId = await makeTestMemex("t11bx");
+  emptyMemexId = await makeTestMemex("t11be");
+  boundaryMemexId = await makeTestMemex("t11bb");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+  const [b] = await db
+    .select({ m: memexes.slug })
+    .from(memexes)
+    .where(eq(memexes.id, boundaryMemexId))
+    .limit(1);
+  boundarySlug = b!.m;
+});
+
+afterAll(async () => {
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, memexId)).catch(() => {});
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, otherMemexId)).catch(() => {});
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, emptyMemexId)).catch(() => {});
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, boundaryMemexId)).catch(() => {});
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-24: alignment history comes from the rollup, not the raw log", () => {
+  it("reports an AC as verified from rollup counts alone, with NO raw events", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "green from the rollup",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, pass: 3 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    const today = days.at(-1)!;
+    expect(today.total).toBe(1);
+    // The raw log is empty. Anything reading test_events sees zero here.
+    expect(today.verified).toBe(1);
+  });
+
+  it("carries a green forward on days the AC did not run", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "ran once, still green",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await backdateAc(ac.id, 5);
+    // Passed three days ago and has not run since. It is still green today — "latest
+    // known state", not "ran today".
+    await seedRollup({ ref, test: "a::t", dayOffset: 3, pass: 2 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.verified).toBe(1);
+    expect(days.at(-2)!.verified).toBe(1);
+    // …and not before it ran.
+    expect(days.at(-5)!.verified).toBe(0);
+  });
+
+  it("is NOT verified when one of its tests failed that day, even though another passed", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "two tests, one red",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    // THE SEMANTIC UPGRADE. Two tests carry this AC on the same day; one is green, one is
+    // red. "Latest single event" answers whichever wrote last — a coin toss that reads
+    // green half the time. An AC with a failing test is not verified.
+    // The green test also gets a REAL emission, so the raw log holds a passing row and
+    // nothing else. That is what makes this case discriminating rather than vacuous: a
+    // "latest single event" read finds that pass and calls the AC verified. Every other
+    // case here runs against an empty log, where any implementation answers zero.
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    await seedTestEvent({
+      subjectRef: ref, status: "pass", createdAt: yesterday, testIdentifier: "green::t",
+    });
+    await seedRollup({ ref, test: "red::t", dayOffset: 1, fail: 1 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.total).toBe(1);
+    expect(days.at(-1)!.verified).toBe(0);
+  });
+
+  it("goes green again on the day the red test starts passing", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "red then green",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await backdateAc(ac.id, 5);
+    await seedRollup({ ref, test: "a::t", dayOffset: 2, fail: 1 });
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, pass: 1 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    const byOffset = (n: number) => days.at(-1 - n)!;
+    expect(byOffset(2).verified).toBe(0); // still red
+    expect(byOffset(1).verified).toBe(1); // fixed
+    expect(byOffset(0).verified).toBe(1); // stays fixed
+  });
+
+  it("counts an errored run as not-green, the same as a failure", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "errored",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, error: 1 });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.verified).toBe(0);
+  });
+
+  it("ignores another tenant's rows carrying the very same subject_ref", async () => {
+    tagAc(AC_CHARTS);
+    const spec = await seedBrief();
+    const ac = await createAc({
+      memexId, briefId: spec.id, kind: "implementation", statement: "tenancy",
+    });
+    const ref = refOf(spec.handle, ac.seq);
+
+    // The old query filtered on subject_ref ALONE — no memex_id anywhere. Tenancy carried
+    // by a string is the spec-396 leak pattern this Spec closes elsewhere; a foreign row
+    // claiming this ref would have decided our chart.
+    await seedRollup({ ref, test: "a::t", dayOffset: 1, pass: 9, memex: otherMemexId });
+
+    const days = await listAcAlignmentOverTime(memexId, spec.id, 7);
+    expect(days.at(-1)!.verified).toBe(0);
+  });
+});
+
+describe("spec-520 ac-40: the chart declares where its history actually begins", () => {
+  it("marks days before the rollup's first row as unmeasured, and measured ones as measured", async () => {
+    tagAc(AC_BOUNDARY);
+    const doc = await createDocDraft(boundaryMemexId, "boundary", "purpose", "spec");
+    createdDocIds.push(doc.id);
+    const ac = await createAc({
+      memexId: boundaryMemexId, briefId: doc.id, kind: "implementation", statement: "boundary",
+    });
+    // The real canonical ref. `measured` is a TENANT-level property — it would read true
+    // off any row this Memex owns — so a made-up ref here would still pass, and would
+    // quietly tell the next reader that this row is what makes the boundary.
+    const ref = `${namespaceSlug}/${boundarySlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+
+    // The rollup ships mid-history. Every day before its first row is a day we CANNOT
+    // measure — the per-day past was deleted by retention and cannot be reconstructed.
+    // Rendering those as verified=0 without saying so lets a truncated past read as
+    // measured absence, which is exactly what ac-5 forbids.
+    await seedRollup({ ref, test: "a::t", dayOffset: 2, pass: 1, memex: boundaryMemexId });
+
+    const days = await listAcAlignmentOverTime(boundaryMemexId, doc.id, 7);
+    expect(days.at(-1)!.measured).toBe(true);
+    expect(days.at(-2)!.measured).toBe(true);
+    expect(days.at(-3)!.measured).toBe(true);
+    // One day earlier than anything the rollup holds.
+    expect(days.at(-4)!.measured).toBe(false);
+    expect(days[0]!.measured).toBe(false);
+  });
+
+  it("marks every day unmeasured when the rollup holds nothing for this tenant", async () => {
+    tagAc(AC_BOUNDARY);
+    // A Memex whose rollup is entirely empty — a brand-new tenant, or any tenant on the
+    // day the rollup ships. Its flat-zero line is not a measured absence of green; it is
+    // the absence of measurement. Claiming otherwise is the same lie in its strongest
+    // form, and this is the case a per-day flag derived from "is there a row" would get
+    // wrong by returning nothing to flag.
+    const doc = await createDocDraft(emptyMemexId, "empty rollup", "purpose", "spec");
+    createdDocIds.push(doc.id);
+    await createAc({
+      memexId: emptyMemexId, briefId: doc.id, kind: "implementation", statement: "no history",
+    });
+
+    const days = await listAcAlignmentOverTime(emptyMemexId, doc.id, 7);
+    expect(days.length).toBeGreaterThan(0);
+    expect(days.every((d) => d.measured === false)).toBe(true);
+  });
+});

--- a/packages/server/src/services/analytics.ts
+++ b/packages/server/src/services/analytics.ts
@@ -421,20 +421,35 @@ export interface TestRunVolumePoint {
  * verification badge. Gapless from the first emission to today.
  */
 export async function testRunVolume(memexId: string): Promise<TestRunVolumePoint[]> {
-  const [slugs] = (await db.execute(sql`
-    SELECT n.slug AS ns, m.slug AS mx
-    FROM memexes m JOIN namespaces n ON n.id = m.namespace_id
-    WHERE m.id = ${memexId}
-  `)) as unknown as Array<{ ns: string; mx: string }>;
-  if (!slugs) return [];
-  const prefix = `${slugs.ns}/${slugs.mx}/`;
-
+  // spec-520 t-11 (ac-24): reads the per-day ROLLUP, not the raw log.
+  //
+  // THE DEFECT THIS CLOSES. This counted rows in `test_events` — a table the retention
+  // trim caps at RETENTION_KEEP per (subject_ref, test_identifier). So it counted rows
+  // that had already been deleted, and the chart sloped upward as an artefact of deletion
+  // rather than because activity grew. Measured on prod 2026-08-18: the summary tier
+  // declared 23,718,476 runs while 1,072,186 raw rows survived — the chart was showing
+  // 4.5% of what happened. And the loss is NOT uniform: 65,708 pairs sat at exactly the
+  // cap of 10, so the busier an AC, the shorter its visible history. A volume chart that
+  // under-counts hardest where there is most activity inverts the story it exists to tell.
+  //
+  // ⚠ HISTORY STARTS AT THE ROLLUP'S SHIP DATE (2026-08-27). The per-day past was already
+  // deleted and cannot be reconstructed, so this chart is now CORRECT but SHORT. That is
+  // the fix landing, not a regression — but a chart spanning the boundary must say so on
+  // its face (ac-5, ac-6), or a truncated past reads as measured absence.
+  //
+  // Scoped by memex_id, which also retires the `subject_ref LIKE 'ns/mx/%'` predicate this
+  // used to carry — tenancy by string prefix, the spec-396 leak pattern (a real cross-org
+  // bleed of ~1.5M rows across 137 memexes) that this Spec closes elsewhere. The slug
+  // lookup it needed is gone with it.
   const rows = (await db.execute(sql`
     WITH per_day AS (
-      SELECT created_at::date AS day, status, count(*)::int AS n
-      FROM test_events
-      WHERE subject_ref LIKE ${prefix + "%"}
-      GROUP BY 1, 2
+      SELECT day,
+             sum(pass_count)::int  AS pass,
+             sum(fail_count)::int  AS fail,
+             sum(error_count)::int AS error
+      FROM test_run_daily
+      WHERE memex_id = ${memexId}
+      GROUP BY day
     ),
     days AS (
       SELECT generate_series(
@@ -445,12 +460,11 @@ export async function testRunVolume(memexId: string): Promise<TestRunVolumePoint
     )
     SELECT
       to_char(days.day, 'YYYY-MM-DD') AS day,
-      COALESCE(sum(per_day.n) FILTER (WHERE per_day.status = 'pass'), 0)::int AS pass,
-      COALESCE(sum(per_day.n) FILTER (WHERE per_day.status = 'fail'), 0)::int AS fail,
-      COALESCE(sum(per_day.n) FILTER (WHERE per_day.status = 'error'), 0)::int AS error
+      COALESCE(per_day.pass, 0)::int  AS pass,
+      COALESCE(per_day.fail, 0)::int  AS fail,
+      COALESCE(per_day.error, 0)::int AS error
     FROM days
     LEFT JOIN per_day ON per_day.day = days.day
-    GROUP BY days.day
     ORDER BY days.day
   `)) as unknown as TestRunVolumePoint[];
   return rows;

--- a/packages/server/src/services/analytics.ts
+++ b/packages/server/src/services/analytics.ts
@@ -355,14 +355,10 @@ export interface AcsOverTimePoint {
  * emissions for since-deleted ACs are a tolerable over-count noted here.
  */
 export async function acsOverTime(memexId: string): Promise<AcsOverTimePoint[]> {
-  const [slugs] = (await db.execute(sql`
-    SELECT n.slug AS ns, m.slug AS mx
-    FROM memexes m JOIN namespaces n ON n.id = m.namespace_id
-    WHERE m.id = ${memexId}
-  `)) as unknown as Array<{ ns: string; mx: string }>;
-  if (!slugs) return [];
-  const prefix = `${slugs.ns}/${slugs.mx}/`;
-
+  // spec-520 dec-7 option C: the slug lookup that used to run here is gone with the
+  // prefix it fed. Both CTEs now scope by memex_id, so this function no longer needs to
+  // know its own namespace/memex slugs — one fewer query per Insights page load, and one
+  // fewer place where tenancy is reconstructed from strings.
   const rows = (await db.execute(sql`
     WITH created_per_day AS (
       SELECT created_at::date AS day, count(*)::int AS n
@@ -375,9 +371,17 @@ export async function acsOverTime(memexId: string): Promise<AcsOverTimePoint[]> 
     -- deletes the oldest passing row, so the operational log can no longer answer
     -- "when did this AC first go green". One row per subject_ref already, so no min().
     first_pass AS (
+      -- spec-520 dec-7 option C: scoped by memex_id, not by a subject_ref STRING PREFIX.
+      -- The old LIKE 'ns/mx/%' predicate carried tenancy in a string — the spec-396 leak pattern
+      -- (a real cross-org bleed of ~1.5M rows across 137 memexes), whose whole fix was to
+      -- stop parsing tenancy out of refs at read time. This table never adopted it; 0136
+      -- gives it the column and this is the read catching up.
+      --
+      -- Rows the 0136 backfill could not resolve carry a NULL memex_id and so match no
+      -- tenant here. They are preserved, not deleted — see the migration.
       SELECT subject_ref, first_verified_at::date AS day
       FROM ac_first_verified
-      WHERE subject_ref LIKE ${prefix + "%"}
+      WHERE memex_id = ${memexId}
     ),
     verified_per_day AS (
       SELECT day, count(*)::int AS n FROM first_pass GROUP BY 1

--- a/packages/server/src/services/ci-emission-audit.spec-391.integration.test.ts
+++ b/packages/server/src/services/ci-emission-audit.spec-391.integration.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { eq, inArray, desc } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import { documents, acs, testEvents, testEventLatest, memexes, namespaces } from "../db/schema.js";
 import { createDocDraft } from "./documents.js";
@@ -71,19 +71,18 @@ async function passAc(
 ): Promise<void> {
   const ref = refOf(briefHandle, seq);
   createdAcUids.push(ref);
-  await seedTestEvent({ subjectRef: ref, status: "pass", createdAt: new Date(), testIdentifier: "t::ci" });
-  if (provenance) {
-    const [latest] = await db
-      .select({ id: testEvents.id })
-      .from(testEvents)
-      .where(eq(testEvents.subjectRef, ref))
-      .orderBy(desc(testEvents.createdAt))
-      .limit(1);
-    await db
-      .update(testEvents)
-      .set({ runId: provenance.runId ?? null, metadata: provenance.metadata ?? null })
-      .where(eq(testEvents.id, latest.id));
-  }
+  // spec-520 dec-8: provenance goes through the seeder, not patched onto the raw row
+  // afterwards. The route writes run_id / metadata to BOTH the log and the summary, and the
+  // audit now reads the summary — so patching only the log produced a shape production never
+  // writes, and this test failed the moment the audit moved. Sixth fixture of that class.
+  await seedTestEvent({
+    subjectRef: ref,
+    status: "pass",
+    createdAt: new Date(),
+    testIdentifier: "t::ci",
+    runId: provenance?.runId ?? null,
+    metadata: provenance?.metadata ?? null,
+  });
 }
 
 describe("emissionIsCiOriginated (spec-391 ac-10, pure)", () => {

--- a/packages/server/src/services/ci-provenance-from-summary.integration.test.ts
+++ b/packages/server/src/services/ci-provenance-from-summary.integration.test.ts
@@ -1,0 +1,167 @@
+// spec-520 dec-8 option A / ac-38 — the CI-origin audit reads provenance from the summary,
+// and knows the difference between "not CI" and "we don't know".
+//
+// WHAT THE AUDIT IS FOR. auditCiEmissionForBrief answers "which of your GREEN criteria were
+// last verified by something other than CI". Its output reaches phase-assessment's
+// localOnlyHandles and from there the assess_spec MCP tool, which every agent is instructed
+// to call before every forward phase move. It renders as: "'Verified' here rests on a
+// local-only run the deploy signal can't trust."
+//
+// TWO OPPOSITE WAYS TO GET THIS WRONG, and this file pins both:
+//
+//   FALSE NEGATIVE — reading the RAW log. The row is the latest emission of an ALREADY
+//   verified AC, so it can be arbitrarily old. Once t-12 shortens retention it ages out,
+//   `if (!latest) continue` fires, and the audit says "all clear" for an AC it can no longer
+//   see. Worse than no audit, at a phase decision.
+//
+//   FALSE POSITIVE — reading the summary naively. Rows predating migration 0137 have NULL
+//   provenance, and emissionIsCiOriginated({null, null}) returns FALSE, so every pre-existing
+//   AC would be reported as laptop-verified.
+//
+// The discriminator is that the writer stores `{}` and not null when an emission carries no
+// metadata. NULL therefore means only "predates 0137" → UNKNOWN → skip.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { acs, documents, memexes, namespaces, testEventLatest } from "../db/schema.js";
+import { auditCiEmissionForBrief } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { seedTestEvent } from "./test-helpers.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const AC_PROVENANCE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-38";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+/** A Spec with one active AC, verified by one passing emission. Returns its docId + ref. */
+async function specWithVerifiedAc(
+  label: string,
+  seq: number,
+): Promise<{ docId: string; ref: string }> {
+  return runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `dec8 ${label}`, "", "spec");
+    createdDocIds.push(doc.id);
+    await db.insert(acs).values({
+      memexId,
+      briefId: doc.id,
+      seq,
+      kind: "implementation",
+      statement: "the criterion under audit",
+      status: "active",
+    } as typeof acs.$inferInsert);
+    const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${seq}`;
+    createdRefs.push(ref);
+    return { docId: doc.id, ref };
+  });
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("d8");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-38: CI provenance comes from the summary", () => {
+  it("flags a verified AC whose latest emission carries NO CI marker", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("local", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // A laptop run: the writer stored `{}`, so provenance WAS observed and is genuinely
+    // absent — which is the one case that should be reported.
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).toContain("ac-1");
+  });
+
+  it("does NOT flag one whose latest emission carries a run id", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("ci", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    await db
+      .update(testEventLatest)
+      .set({ latestRunId: "31589392781" })
+      .where(eq(testEventLatest.subjectRef, ref));
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).not.toContain("ac-1");
+  });
+
+  it("does NOT flag one whose run id rides in metadata instead", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("ci-md", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // emissionIsCiOriginated accepts run_id OR run_url inside the bag — the shape a
+    // hand-rolled emitter produces. Re-deriving from the raw inputs is why dec-8 stored them
+    // rather than a computed boolean.
+    await db
+      .update(testEventLatest)
+      .set({ latestMetadata: { run_url: "https://ci.example/run/7" } })
+      .where(eq(testEventLatest.subjectRef, ref));
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).not.toContain("ac-1");
+  });
+
+  it("treats a row with NO RECORDED PROVENANCE as unknown and does NOT flag it", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("pre-0137", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // Reproduce a row written BEFORE 0137: provenance never recorded, both columns NULL.
+    // Judged naively this reads as "not CI" and the AC is reported laptop-verified — the
+    // false positive that mirrors the false negative the raw-log read produced.
+    await db
+      .update(testEventLatest)
+      .set({ latestRunId: null, latestMetadata: null })
+      .where(eq(testEventLatest.subjectRef, ref));
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).not.toContain("ac-1");
+  });
+
+  it("answers without the raw log — the row t-12's retention window will delete", async () => {
+    tagAc(AC_PROVENANCE);
+    const { docId, ref } = await specWithVerifiedAc("no-raw", 1);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
+
+    // THE point of dec-8. Delete every raw row and the audit must still answer, because it
+    // is reading the summary. Before this change it returned nothing here — silently.
+    await db.execute(sql`DELETE FROM test_events WHERE subject_ref = ${ref}`);
+
+    const flagged = await runWithMemexId(memexId, async () =>
+      auditCiEmissionForBrief(memexId, docId),
+    );
+    expect(flagged.map((r) => r.handle)).toContain("ac-1");
+  });
+});

--- a/packages/server/src/services/clause-coverage.ts
+++ b/packages/server/src/services/clause-coverage.ts
@@ -15,7 +15,7 @@
 // The denominator is TESTABLE OBLIGATIONS only (dec-5): non-obligations / untestable
 // clauses are shown but excluded from the coverage counts.
 
-import { and, asc, eq, inArray, ne } from "drizzle-orm";
+import { and, asc, eq, ne, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
   documents,
@@ -142,7 +142,22 @@ export async function listClausesForStandardWithVerification(
       runCount: testEventLatest.runCount,
     })
     .from(testEventLatest)
-    .where(inArray(testEventLatest.subjectRef, allRefs));
+    // spec-520 t-4 (ac-11): one bind parameter for the whole ref list, not one per ref.
+    // Each distinct IN-count is its own prepared statement and pg_stat_statements row —
+    // the fragmentation that put ~24.5% of the instance's fingerprint cap behind a single
+    // logical read (issue-10). Same shape as listAcsForBriefWithVerification, and NOT
+    // `memex_id = $1` alone: this serves one standard's clauses, so a tenant-wide read
+    // would fetch far more than it filters.
+    //
+    // sql.param() is load-bearing — a bare `${allRefs}` makes drizzle interpolate the array
+    // as a LIST of parameters, which is the fragmentation being removed and fails against
+    // `= ANY(…)` outright.
+    .where(
+      and(
+        eq(testEventLatest.memexId, memexId),
+        sql`${testEventLatest.subjectRef} = ANY(${sql.param(allRefs)}::text[])`,
+      ),
+    );
 
   const testsByRef = new Map<string, AcTestSnapshot[]>();
   for (const row of summaryRows) {

--- a/packages/server/src/services/emission-keys-last-used-throttle.integration.test.ts
+++ b/packages/server/src/services/emission-keys-last-used-throttle.integration.test.ts
@@ -1,0 +1,140 @@
+// spec-520 t-6 / ac-28 — the last_used_at bump updates ZERO rows when the stored
+// timestamp is already recent.
+//
+// THE COST BEING REMOVED. `bumpLastUsed` fires on every accepted emission with no
+// predicate, so `memex_emission_keys` — a table of roughly 1,100 rows — takes one UPDATE
+// per event. Measured on prod as a 600s delta 2026-08-28 (spec-520 c-9): **30.972
+// calls/s, 0.0426 ms each**, against an event rate of 30.973. Lifetime counters put it at
+// 23.6M updates and 613 autovacuums on those ~1,100 rows.
+//
+// Nothing consumes this timestamp at second-level freshness — it answers "is this key
+// live", shown in the settings UI. A five-minute window keeps that answer true and turns
+// almost every one of those UPDATEs into a no-op that writes nothing and creates no dead
+// tuple. The statement still runs; it just stops costing a row version.
+//
+// WHY THIS IS DB-BACKED AND POLLS. `bumpLastUsed` is deliberately fire-and-forget — it
+// returns void, wraps its mutate() in `void … .catch()`, and is `silent: true` so a missed
+// bump can never fail or delay an emission. There is nothing to await, so the test polls
+// for the write [per std-37] rather than assuming it has landed. Asserting against a mock
+// would prove only that we called a function.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexEmissionKeys } from "../db/schema.js";
+import { bumpLastUsed, mintEmissionKey } from "./emission-keys.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+
+const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-28";
+
+let memexId: string;
+let userId: string;
+const createdKeyIds: string[] = [];
+
+async function readLastUsed(keyId: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ lastUsedAt: memexEmissionKeys.lastUsedAt })
+    .from(memexEmissionKeys)
+    .where(eq(memexEmissionKeys.id, keyId))
+    .limit(1);
+  return row?.lastUsedAt ?? null;
+}
+
+/** Poll until `lastUsedAt` differs from `from`, or give up. Returns the observed value. */
+async function pollForBump(keyId: string, from: Date | null, tries = 40): Promise<Date | null> {
+  for (let i = 0; i < tries; i++) {
+    const now = await readLastUsed(keyId);
+    if (now?.getTime() !== from?.getTime()) return now;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return readLastUsed(keyId);
+}
+
+async function newKey(name: string): Promise<string> {
+  // mintEmissionKey returns { raw, row } — the id is on `row`, not the top level.
+  const minted = await mintEmissionKey(memexId, name, userId);
+  createdKeyIds.push(minted.row.id);
+  return minted.row.id;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t6k");
+  const user = await upsertUserByEmail(`spec520-t6-${process.pid}@example.com`);
+  userId = user.id;
+});
+
+afterAll(async () => {
+  if (createdKeyIds.length) {
+    await db
+      .delete(memexEmissionKeys)
+      .where(inArray(memexEmissionKeys.id, createdKeyIds))
+      .catch(() => {});
+  }
+});
+
+describe("spec-520 ac-28: last_used_at is bumped at most once per window", () => {
+  it("writes the timestamp on the first use, when it is still NULL", async () => {
+    tagAc(AC_THROTTLE);
+    const keyId = await newKey("first-use");
+    expect(await readLastUsed(keyId)).toBeNull();
+
+    bumpLastUsed(keyId);
+    const after = await pollForBump(keyId, null);
+    // The NULL arm of the predicate must fire, or a brand-new key would never record a
+    // first use at all — the throttle would have turned "cheap" into "broken".
+    expect(after).not.toBeNull();
+  });
+
+  it("updates ZERO rows on an immediate second use — the row version is not rewritten", async () => {
+    tagAc(AC_THROTTLE);
+    const keyId = await newKey("within-window");
+
+    bumpLastUsed(keyId);
+    const first = await pollForBump(keyId, null);
+    expect(first).not.toBeNull();
+
+    // The whole point: a key emitting continuously must stop rewriting its row. This is
+    // the ~31 updates/s case measured on prod.
+    bumpLastUsed(keyId);
+    await new Promise((r) => setTimeout(r, 250));
+    expect((await readLastUsed(keyId))?.getTime()).toBe(first!.getTime());
+  });
+
+  it("updates the row again once the window has elapsed", async () => {
+    tagAc(AC_THROTTLE);
+    const keyId = await newKey("past-window");
+
+    bumpLastUsed(keyId);
+    const first = await pollForBump(keyId, null);
+    expect(first).not.toBeNull();
+
+    // Backdate rather than sleep five minutes. The predicate compares against the
+    // DATABASE's now(), so the fixture moves the stored value, not the clock.
+    await db
+      .update(memexEmissionKeys)
+      .set({ lastUsedAt: sql`now() - interval '10 minutes'` })
+      .where(eq(memexEmissionKeys.id, keyId));
+    const backdated = await readLastUsed(keyId);
+
+    bumpLastUsed(keyId);
+    const bumped = await pollForBump(keyId, backdated);
+    expect(bumped!.getTime()).toBeGreaterThan(backdated!.getTime());
+  });
+
+  it("touches only the key it was given", async () => {
+    tagAc(AC_THROTTLE);
+    // The predicate is an AND on top of the id match. Getting the boolean structure wrong
+    // — an OR where an AND belongs — would update every stale key on the table at once,
+    // which is worse than the cost being removed and would not show up in a single-key
+    // assertion.
+    const target = await newKey("target");
+    const bystander = await newKey("bystander");
+
+    bumpLastUsed(target);
+    expect(await pollForBump(target, null)).not.toBeNull();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(await readLastUsed(bystander)).toBeNull();
+  });
+});

--- a/packages/server/src/services/emission-keys.ts
+++ b/packages/server/src/services/emission-keys.ts
@@ -1,5 +1,5 @@
 import { randomBytes, createHash } from "node:crypto";
-import { eq, and, isNull, or, gt, desc, sql } from "drizzle-orm";
+import { eq, and, isNull, or, gt, lt, desc, sql } from "drizzle-orm";
 import { db } from "../db/connection.js";
 import {
   memexEmissionKeys,
@@ -159,10 +159,36 @@ export function bumpLastUsed(keyId: string): void {
     {},
     { memexId: "", entity: "memex_emission_key", action: "updated" },
     async () => {
+      // spec-520 t-6 (ac-28): throttled to at most one write per key per window.
+      //
+      // Unpredicated, this fired one UPDATE per accepted emission against a table of
+      // roughly 1,100 rows. Measured on prod as a 600s delta 2026-08-28 (spec-520 c-9):
+      // 30.972 calls/s at 0.0426 ms — one per event, matching the event rate exactly —
+      // and 23.6M lifetime updates with 613 autovacuums chasing the dead tuples.
+      //
+      // The statement still runs on every emission; it just stops finding a row, so it
+      // writes no new row version and creates no dead tuple. That is the cheap half of
+      // this fix and it needs no call-site change: keeping the call unconditional means
+      // the throttle cannot be defeated by a caller that forgets it.
+      //
+      // Five minutes is chosen against the CONSUMER, not the cost: last_used_at answers
+      // "is this key live" in the settings UI. Nothing reads it at second-level
+      // freshness, so a value up to five minutes stale is still a true answer.
+      //
+      // The NULL arm is load-bearing — without it a brand-new key would never record a
+      // first use at all, and the throttle would have turned cheap into broken.
       await db
         .update(memexEmissionKeys)
         .set({ lastUsedAt: sql`now()` })
-        .where(eq(memexEmissionKeys.id, keyId));
+        .where(
+          and(
+            eq(memexEmissionKeys.id, keyId),
+            or(
+              isNull(memexEmissionKeys.lastUsedAt),
+              lt(memexEmissionKeys.lastUsedAt, sql`now() - interval '5 minutes'`),
+            ),
+          ),
+        );
     },
     { silent: true },
   ).catch((err) => {

--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -28,10 +28,16 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
 import { acFirstVerified } from "../db/schema.js";
 import { recordFirstVerified } from "./test-event-retention.js";
+import { makeTestMemex } from "./test-helpers.js";
 
 const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-34";
 
 const RUN = `spec520-d-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+// spec-520 dec-7 option C: ac_first_verified now carries memex_id, so the writer needs a
+// real tenant. Under the default OWNER connection RLS is bypassed (std-36: ENABLE, never
+// FORCE), so this file still exercises the throttle rather than the policy — the policy is
+// proven separately under the restricted role.
+let memexId: string;
 const refs: string[] = [];
 
 function refFor(name: string): string {
@@ -51,6 +57,7 @@ async function readRow(subjectRef: string): Promise<{ at: string; xmin: string }
 }
 
 beforeAll(async () => {
+  memexId = await makeTestMemex("d");
   await db.delete(acFirstVerified).where(inArray(acFirstVerified.subjectRef, refs)).catch(() => {});
 });
 
@@ -69,7 +76,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
     const ref = refFor("first");
     expect(await readRow(ref)).toBeNull();
 
-    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const row = await readRow(ref);
     expect(row).not.toBeNull();
     expect(new Date(row!.at).toISOString()).toBe("2026-08-20T10:00:00.000Z");
@@ -78,11 +85,11 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
   it("does NOT rewrite the row for a LATER pass — same value AND same row version", async () => {
     tagAc(AC_THROTTLE);
     const ref = refFor("later");
-    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
 
     // The ~31/s case: an AC that is already green keeps emitting.
-    await recordFirstVerified(db, ref, new Date("2026-08-21T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-21T10:00:00.000Z"), memexId);
     const after = await readRow(ref);
 
     expect(after!.at).toBe(before!.at);
@@ -95,10 +102,10 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
     tagAc(AC_THROTTLE);
     const ref = refFor("equal");
     const at = new Date("2026-08-20T10:00:00.000Z");
-    await recordFirstVerified(db, ref, at);
+    await recordFirstVerified(db, ref, at, memexId);
     const before = await readRow(ref);
 
-    await recordFirstVerified(db, ref, at);
+    await recordFirstVerified(db, ref, at, memexId);
     const after = await readRow(ref);
     expect(after!.xmin).toBe(before!.xmin);
   });
@@ -106,12 +113,12 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
   it("STILL writes for a genuinely EARLIER pass — LEAST-wins survives the throttle", async () => {
     tagAc(AC_THROTTLE);
     const ref = refFor("earlier");
-    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
 
     // Out-of-order arrival: a replay or backfill carrying an earlier first pass. This is
     // the arm a careless predicate breaks, turning "earliest" into "first seen".
-    await recordFirstVerified(db, ref, new Date("2026-08-01T09:00:00.000Z"));
+    await recordFirstVerified(db, ref, new Date("2026-08-01T09:00:00.000Z"), memexId);
     const after = await readRow(ref);
 
     expect(new Date(after!.at).toISOString()).toBe("2026-08-01T09:00:00.000Z");
@@ -122,10 +129,10 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
     tagAc(AC_THROTTLE);
     const target = refFor("target");
     const bystander = refFor("bystander");
-    await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"));
+    await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const bystanderBefore = await readRow(bystander);
 
-    await recordFirstVerified(db, target, new Date("2026-08-22T10:00:00.000Z"));
+    await recordFirstVerified(db, target, new Date("2026-08-22T10:00:00.000Z"), memexId);
 
     // A predicate written without the id/ref conjunct in the right place could suppress or
     // rewrite unrelated rows; a single-ref assertion would never see it.

--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -32,6 +32,14 @@ import { makeTestMemex } from "./test-helpers.js";
 
 const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-34";
 
+// spec-520 ac-23 is the COMPOSITE statement of what dec-7 actually delivered, so it is
+// tagged from BOTH halves — the tenancy work here and the throttle in
+// first-verified-throttle.integration.test.ts. Tagging it from either alone would flip it
+// green on half its claim, which is exactly the mistake ac-24/ac-25 made earlier in this
+// Spec and why ac-35/ac-36 had to be split out of them.
+const AC_DEC7 = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-23";
+
+
 const RUN = `spec520-d-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
 // spec-520 dec-7 option C: ac_first_verified now carries memex_id, so the writer needs a
 // real tenant. Under the default OWNER connection RLS is bypassed (std-36: ENABLE, never
@@ -73,6 +81,7 @@ afterAll(async () => {
 describe("spec-520 ac-34: first-verified is written once, not on every passing event", () => {
   it("writes on the first pass", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("first");
     expect(await readRow(ref)).toBeNull();
 
@@ -84,6 +93,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("does NOT rewrite the row for a LATER pass — same value AND same row version", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("later");
     await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
@@ -100,6 +110,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("does NOT rewrite the row for an IDENTICAL timestamp either", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("equal");
     const at = new Date("2026-08-20T10:00:00.000Z");
     await recordFirstVerified(db, ref, at, memexId);
@@ -112,6 +123,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("STILL writes for a genuinely EARLIER pass — LEAST-wins survives the throttle", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const ref = refFor("earlier");
     await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"), memexId);
     const before = await readRow(ref);
@@ -127,6 +139,7 @@ describe("spec-520 ac-34: first-verified is written once, not on every passing e
 
   it("touches only the ref it was given", async () => {
     tagAc(AC_THROTTLE);
+    tagAc(AC_DEC7);
     const target = refFor("target");
     const bystander = refFor("bystander");
     await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"), memexId);

--- a/packages/server/src/services/first-verified-throttle.integration.test.ts
+++ b/packages/server/src/services/first-verified-throttle.integration.test.ts
@@ -1,0 +1,136 @@
+// spec-520 dec-7 option D / ac-34 — the first-verified upsert stops rewriting a row it is
+// not changing.
+//
+// THE WASTE. `recordFirstVerified` runs on every non-hidden PASSING emission and does
+// `ON CONFLICT DO UPDATE SET first_verified_at = LEAST(existing, EXCLUDED)`. After the
+// first pass LEAST always returns the value ALREADY STORED — so every subsequent write
+// stores an identical value and still creates a new row version. Measured on prod
+// 2026-08-28 as a 600s delta: 30.972 calls/s at 0.0496 ms, one per event, ~21.3M lifetime
+// updates that changed nothing.
+//
+// ⚠ THE TEST-DESIGN TRAP, and it is the whole reason this file reads the way it does.
+// Asserting the stored VALUE is unchanged proves NOTHING here: LEAST already returns the
+// same value with or without the fix. A value assertion passes identically against the
+// wasteful implementation and the fixed one. What has to be observed is whether the ROW
+// WAS REWRITTEN — so these tests read `xmin`, the system column holding the transaction
+// that last wrote the row. Same value + same xmin = the statement found no row. Same value
+// + new xmin = the waste is still there.
+//
+// The second arm matters as much as the first: LEAST-wins exists for OUT-OF-ORDER arrival
+// (replays, backfills). A predicate that suppresses ALL conflicts rather than only the
+// ones where the stored value is already at or before the incoming one would silently turn
+// "earliest pass" into "first pass SEEN" — and no test asserting only the no-op case would
+// catch it.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { acFirstVerified } from "../db/schema.js";
+import { recordFirstVerified } from "./test-event-retention.js";
+
+const AC_THROTTLE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-34";
+
+const RUN = `spec520-d-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+const refs: string[] = [];
+
+function refFor(name: string): string {
+  const r = `mindset-prod/fixture/specs/spec-1/acs/${RUN}-${name}`;
+  refs.push(r);
+  return r;
+}
+
+/** The stored date AND the row version that produced it. */
+async function readRow(subjectRef: string): Promise<{ at: string; xmin: string } | null> {
+  const rows = await db.execute(sql`
+    SELECT first_verified_at::text AS at, xmin::text AS xmin
+      FROM ac_first_verified WHERE subject_ref = ${subjectRef}
+  `);
+  const r = (rows as unknown as { at: string; xmin: string }[])[0];
+  return r ?? null;
+}
+
+beforeAll(async () => {
+  await db.delete(acFirstVerified).where(inArray(acFirstVerified.subjectRef, refs)).catch(() => {});
+});
+
+afterAll(async () => {
+  if (refs.length) {
+    await db
+      .delete(acFirstVerified)
+      .where(inArray(acFirstVerified.subjectRef, refs))
+      .catch(() => {});
+  }
+});
+
+describe("spec-520 ac-34: first-verified is written once, not on every passing event", () => {
+  it("writes on the first pass", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("first");
+    expect(await readRow(ref)).toBeNull();
+
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    const row = await readRow(ref);
+    expect(row).not.toBeNull();
+    expect(new Date(row!.at).toISOString()).toBe("2026-08-20T10:00:00.000Z");
+  });
+
+  it("does NOT rewrite the row for a LATER pass — same value AND same row version", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("later");
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    const before = await readRow(ref);
+
+    // The ~31/s case: an AC that is already green keeps emitting.
+    await recordFirstVerified(db, ref, new Date("2026-08-21T10:00:00.000Z"));
+    const after = await readRow(ref);
+
+    expect(after!.at).toBe(before!.at);
+    // THE assertion. Without the predicate the value is identical and xmin MOVES, because
+    // LEAST wrote the same date into a brand-new row version.
+    expect(after!.xmin).toBe(before!.xmin);
+  });
+
+  it("does NOT rewrite the row for an IDENTICAL timestamp either", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("equal");
+    const at = new Date("2026-08-20T10:00:00.000Z");
+    await recordFirstVerified(db, ref, at);
+    const before = await readRow(ref);
+
+    await recordFirstVerified(db, ref, at);
+    const after = await readRow(ref);
+    expect(after!.xmin).toBe(before!.xmin);
+  });
+
+  it("STILL writes for a genuinely EARLIER pass — LEAST-wins survives the throttle", async () => {
+    tagAc(AC_THROTTLE);
+    const ref = refFor("earlier");
+    await recordFirstVerified(db, ref, new Date("2026-08-20T10:00:00.000Z"));
+    const before = await readRow(ref);
+
+    // Out-of-order arrival: a replay or backfill carrying an earlier first pass. This is
+    // the arm a careless predicate breaks, turning "earliest" into "first seen".
+    await recordFirstVerified(db, ref, new Date("2026-08-01T09:00:00.000Z"));
+    const after = await readRow(ref);
+
+    expect(new Date(after!.at).toISOString()).toBe("2026-08-01T09:00:00.000Z");
+    expect(after!.xmin).not.toBe(before!.xmin);
+  });
+
+  it("touches only the ref it was given", async () => {
+    tagAc(AC_THROTTLE);
+    const target = refFor("target");
+    const bystander = refFor("bystander");
+    await recordFirstVerified(db, bystander, new Date("2026-08-20T10:00:00.000Z"));
+    const bystanderBefore = await readRow(bystander);
+
+    await recordFirstVerified(db, target, new Date("2026-08-22T10:00:00.000Z"));
+
+    // A predicate written without the id/ref conjunct in the right place could suppress or
+    // rewrite unrelated rows; a single-ref assertion would never see it.
+    const bystanderAfter = await readRow(bystander);
+    expect(bystanderAfter!.xmin).toBe(bystanderBefore!.xmin);
+    expect(bystanderAfter!.at).toBe(bystanderBefore!.at);
+  });
+});

--- a/packages/server/src/services/issues-auto-resolve-query-count.integration.test.ts
+++ b/packages/server/src/services/issues-auto-resolve-query-count.integration.test.ts
@@ -1,0 +1,179 @@
+// spec-520 t-15 / ac-33 — the ingest path's auto-resolve reverse lookup costs ONE query,
+// not three.
+//
+// WHY THIS IS DB-BACKED AND COUNTS AGAINST A REAL `db`. Two ways to write this test are
+// available and both are wrong, and t-15 exists partly because the second one hid the cost
+// for months:
+//
+//   1. Against the route's mocked `db.select`: the bare stub makes `.from()` throw, the
+//      handler's deliberate best-effort catch swallows it, and the spy records exactly ONE
+//      call however many the real path makes. A count assertion there reports 1 forever —
+//      it would have passed against the three-query implementation and against a one-query
+//      one, identically.
+//   2. Without tenant context: pre-t-7, `documents` RLS filtered the first lookup to zero
+//      rows, so the chain returned at statement 1. A test in that state also sees one
+//      query, also passes, and also measures nothing. That is precisely the reading that
+//      made s-4 §4 conclude the cost was 0.44% of DB time and t-15's premise dead.
+//
+// So the count is taken against a real database, with a resolvable document, inside
+// `runWithMemexId`. (Under the default owner connection RLS is bypassed anyway — std-36:
+// ENABLE, never FORCE — so the wrapper is not what makes this work here. It is kept
+// because the property under test is "the chain runs to completion", and the wrapper is
+// how the production path guarantees that.)
+//
+// THE COST BEING REMOVED, measured on prod as a 600s delta 2026-08-28 (c-9):
+//   documents ⋈ memexes ⋈ namespaces   30.970 calls/s   0.0770 ms
+//   task_satisfies_ac                  30.972 calls/s   0.0314 ms
+//   (event rate                        30.973 calls/s)
+// The chain runs on essentially every event and costs ≈18% of the emission path. A third
+// statement — the `acs` lookup — is in the chain but was outside that query filter, so
+// 0.1084 ms/event is a lower bound.
+
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import { acs, documents, memexes, namespaces, taskSatisfiesAc, tasks } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { maybeAutoResolveIssuesForAcUid } from "./issues.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const AC_ONE_QUERY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-33";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+
+/** Seed a Spec + one AC, and return the ref the ingest path would receive. */
+async function seedAcRef(seq: number, withSatisfyingTask: boolean): Promise<string> {
+  return runWithMemexId(memexId, async () => {
+    const doc = await createDocDraft(memexId, `t15 target ${seq}`, "", "spec");
+    createdDocIds.push(doc.id);
+
+    const [ac] = await db
+      .insert(acs)
+      .values({
+        memexId,
+        briefId: doc.id,
+        seq,
+        kind: "implementation",
+        statement: "the criterion under reverse lookup",
+        status: "active",
+      } as typeof acs.$inferInsert)
+      .returning();
+
+    if (withSatisfyingTask) {
+      const [task] = await db
+        .insert(tasks)
+        .values({
+          memexId,
+          docId: doc.id,
+          seq: 1,
+          title: "the satisfying task",
+          description: "",
+          status: "complete",
+        } as typeof tasks.$inferInsert)
+        .returning();
+      await db
+        .insert(taskSatisfiesAc)
+        .values({ taskId: task!.id, acId: ac!.id } as typeof taskSatisfiesAc.$inferInsert);
+    }
+
+    return `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${seq}`;
+  });
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t15");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-33: the auto-resolve reverse lookup issues ONE query", () => {
+  it("costs exactly one query on the common path — an AC with no satisfying task", async () => {
+    tagAc(AC_ONE_QUERY);
+
+    // THE dominant case, and the one the prod delta measures: the overwhelming majority of
+    // passing events are for ACs that no converted Issue is waiting on. Before this change
+    // such an event still paid all three statements to discover there was nothing to do —
+    // `documents ⋈ memexes ⋈ namespaces`, then `acs`, then `task_satisfies_ac` — because
+    // every early return in the chain is a NOT-FOUND return, never a cheap-path return.
+    const acRef = await seedAcRef(1, false);
+
+    const spy = vi.spyOn(db, "select");
+    try {
+      const resolved = await runWithMemexId(memexId, async () =>
+        maybeAutoResolveIssuesForAcUid(acRef),
+      );
+      expect(resolved).toEqual([]);
+      // Was 3. Counting db.select isolates the reverse lookup: everything downstream
+      // (maybeAutoResolveIssuesForTask, verifyingAcIsGreen) goes through db.query.*, and on
+      // this path the satisfying set is empty so none of it runs at all.
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      // std-37 cl-5: restore what the test replaced, or the next file inherits the spy.
+      spy.mockRestore();
+    }
+  });
+
+  it("still finds the satisfying task through that single query", async () => {
+    tagAc(AC_ONE_QUERY);
+
+    // The collapse must not lose the join's RESULT. This asserts the lookup still reaches
+    // the satisfying task — the row the old third statement existed to fetch — rather than
+    // only asserting that fewer queries ran, which a broken implementation returning []
+    // would also satisfy.
+    const acRef = await seedAcRef(2, true);
+
+    const spy = vi.spyOn(db, "select");
+    try {
+      await runWithMemexId(memexId, async () => maybeAutoResolveIssuesForAcUid(acRef));
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("keeps the tenant scoping — a ref naming another namespace resolves to nothing [per std-7]", async () => {
+    tagAc(AC_ONE_QUERY);
+
+    // `documents.handle` is per-memex, NOT globally unique. Collapsing three statements
+    // into one join is exactly where a scoping conjunct is easiest to drop, and dropping it
+    // turns a bare handle match into a cross-tenant resolution. The one-query form must
+    // still require namespace AND memex to match.
+    const acRef = await seedAcRef(3, true);
+    const foreign = acRef.replace(`${namespaceSlug}/${memexSlug}/`, `${namespaceSlug}/not-this-memex/`);
+    expect(foreign).not.toBe(acRef);
+
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForAcUid(foreign),
+    );
+    expect(resolved).toEqual([]);
+  });
+
+  it("returns nothing for a ref that is not an AC ref at all", async () => {
+    tagAc(AC_ONE_QUERY);
+    // The grammar guard runs before any query. Kept so the collapse cannot accidentally
+    // move parsing after the database round trip.
+    const spy = vi.spyOn(db, "select");
+    try {
+      expect(await maybeAutoResolveIssuesForAcUid("not/a/valid/ref")).toEqual([]);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/services/issues-conversions.integration.test.ts
+++ b/packages/server/src/services/issues-conversions.integration.test.ts
@@ -33,7 +33,7 @@ import {
 } from "./issues.js";
 import { buildAcRef } from "./acs.js";
 import { searchMemex } from "./memex-search.js";
-import { makeTestMemex } from "./test-helpers.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const AC = (n: number) =>
@@ -97,8 +97,13 @@ async function emitEvent(
   at: Date = new Date(),
 ): Promise<void> {
   createdAcUids.push(subjectRef);
-  await db.insert(testEvents).values({
-    memexId,
+  // spec-520 t-11: seed through the helper, not a bare insert. The emission route
+  // maintains test_events, test_event_latest AND the per-day rollup in one
+  // transaction, so a raw-only row is a shape production never writes. This fixture
+  // used to insert raw only and passed purely because verifyingAcIsGreen scanned the
+  // raw log; the moment that gate moved to the summary (ac-25) it went red — the
+  // fixture had been unrepresentative all along.
+  await seedTestEvent({
     subjectRef,
     status,
     testIdentifier: "tests/example.test.ts::it",

--- a/packages/server/src/services/issues.ts
+++ b/packages/server/src/services/issues.ts
@@ -551,36 +551,49 @@ export async function maybeAutoResolveIssuesForAcUid(subjectRef: string): Promis
   const specHandle = m[3];
   const acSeq = Number(m[4]);
 
-  const [doc] = await db
-    .select({ id: documents.id, memexId: documents.memexId })
+  // spec-520 t-15 (ac-33): ONE query, not three. This used to walk the reverse lookup in
+  // three awaited round trips — documents ⋈ memexes ⋈ namespaces, then `acs`, then
+  // `task_satisfies_ac` — and every one of its early returns was a NOT-FOUND return, never
+  // a cheap-path return. So an event whose AC has no converted Issue still paid all three
+  // to discover there was nothing to do, and that is the overwhelming majority of events.
+  //
+  // Measured on prod as a 600s delta 2026-08-28 (spec-520 c-9), AFTER t-7 made the chain
+  // actually run: the documents join ran at 30.970 calls/s against an event rate of 30.973
+  // — on essentially every event — and the two measurable statements cost 0.1084 ms/event,
+  // about 18% of the whole emission path, with this join the third most expensive statement
+  // per call on it.
+  //
+  // ⚠ THE PRE-t-7 COUNTERS SAY THE OPPOSITE, and they are not evidence. Lifetime
+  // pg_stat_statements showed 221 calls against 21.2M — but only because `documents` RLS
+  // filtered this first statement to zero rows while the ingest path had no tenant context,
+  // so the chain returned at statement 1 every time. That is a measurement of the chain not
+  // RUNNING, not of it being cheap. Do not re-derive this cost from cumulative counters;
+  // take a delta.
+  //
+  // The scoping conjuncts are the part to guard when touching this. `documents.handle`
+  // (e.g. `spec-1`) is per-memex, NOT globally unique, so namespace AND memex must both
+  // match or a bare handle resolves across tenants [per std-7].
+  const satisfying = await db
+    .select({ taskId: taskSatisfiesAc.taskId, memexId: documents.memexId })
     .from(documents)
     .innerJoin(memexes, eq(documents.memexId, memexes.id))
     .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .innerJoin(acs, and(eq(acs.briefId, documents.id), eq(acs.seq, acSeq)))
+    .innerJoin(taskSatisfiesAc, eq(taskSatisfiesAc.acId, acs.id))
     .where(
       and(
         eq(documents.handle, specHandle),
         eq(memexes.slug, memexSlug),
         eq(namespaces.slug, namespaceSlug),
       ),
-    )
-    .limit(1);
-  if (!doc) return [];
+    );
 
-  const [ac] = await db
-    .select({ id: acs.id })
-    .from(acs)
-    .where(and(eq(acs.briefId, doc.id), eq(acs.seq, acSeq)))
-    .limit(1);
-  if (!ac) return [];
-
-  const satisfying = await db
-    .select({ taskId: taskSatisfiesAc.taskId })
-    .from(taskSatisfiesAc)
-    .where(eq(taskSatisfiesAc.acId, ac.id));
-
+  // Every not-found case the three statements returned early on now simply yields no rows:
+  // no such doc, no such AC, or no task satisfying it. All three meant `[]` before and mean
+  // `[]` now, so the behaviour is unchanged — only the round trips are gone.
   const resolved: string[] = [];
   for (const s of satisfying) {
-    const ids = await maybeAutoResolveIssuesForTask(doc.memexId, s.taskId);
+    const ids = await maybeAutoResolveIssuesForTask(s.memexId, s.taskId);
     resolved.push(...ids);
   }
   return resolved;

--- a/packages/server/src/services/issues.ts
+++ b/packages/server/src/services/issues.ts
@@ -34,7 +34,7 @@ import {
   acs,
   acParentLinks,
   taskSatisfiesAc,
-  testEvents,
+  testEventLatest,
   memexes,
   namespaces,
 } from "../db/schema.js";
@@ -471,11 +471,24 @@ async function verifyingAcIsGreen(satisfyingTaskId: string, docId: string): Prom
   // the general case so multi-AC tasks don't resolve prematurely.
   for (const link of links) {
     const subjectRef = buildAcRef(slugs, link.seq);
+    // spec-520 t-11 (ac-25): read the verdict from the SUMMARY, not by scanning the raw
+    // log. test_event_latest already holds the newest emission per (subject_ref,
+    // test_identifier), so the newest overall is the row with the greatest latest_run_at —
+    // the same answer, without depending on a row the raw log may no longer have.
+    //
+    // That dependency is why this had to move: t-12 replaces count-based retention with a
+    // short TIME window, at which point the newest emission for a long-since-verified AC
+    // ages out and this gate would start answering "not green" for ACs that are.
+    //
+    // One deliberate semantic gain: the summary EXCLUDES hidden emissions (spec-115), which
+    // this raw scan did not. Hidden means "excluded from verification signals", so reading
+    // the summary is the more correct behaviour, not merely the cheaper one. Only historical
+    // rows can be hidden — spec-358 froze the column at false.
     const [latest] = await db
-      .select({ status: testEvents.status })
-      .from(testEvents)
-      .where(eq(testEvents.subjectRef, subjectRef))
-      .orderBy(desc(testEvents.createdAt))
+      .select({ status: testEventLatest.latestStatus })
+      .from(testEventLatest)
+      .where(eq(testEventLatest.subjectRef, subjectRef))
+      .orderBy(desc(testEventLatest.latestRunAt))
       .limit(1);
     if (!latest || latest.status !== "pass") return false;
   }

--- a/packages/server/src/services/partition-drop.rls-restricted.test.ts
+++ b/packages/server/src/services/partition-drop.rls-restricted.test.ts
@@ -1,0 +1,107 @@
+// spec-520 t-12 (ac-13) — the request path's role cannot drop a partition.
+//
+// ac-13 requires partition maintenance to run "as the owning role from deploy or cron,
+// never from the request path, whose non-owner runtime role cannot drop a partition". This
+// file is the second half of that: it runs under the restricted `memex_app` role (only
+// vitest.rls.config.ts includes *.rls-restricted.test.ts) and asserts the refusal.
+//
+// ⚠ WHAT THIS PROVES, AND WHAT IT DOES NOT. It proves the MECHANISM: a non-owner is refused
+// by Postgres, so a maintenance path that accidentally ran in-process would fail loudly
+// rather than quietly delete a day of emissions.
+//
+// It does NOT prove production is wired that way today, and this file cannot. deploy.sh
+// reads:
+//
+//     RUNTIME_DB_USER="${RUNTIME_DB_USER:-$DB_USER}"   # deploy.sh:282
+//
+// — the runtime role FALLS BACK TO THE OWNER when the deploy-env secret sets no
+// RUNTIME_DB_USER. Whether it does is an environment fact this repo cannot see.
+//
+// ⚠ AND THE RECORD IS AMBIGUOUS ON THAT POINT. deploy.sh attributes the rollout to
+// spec-199 t-14, which is marked COMPLETE on a Spec that is `done`, with acceptance
+// criteria asserting Cloud Run INT *and* PROD use memex_app credentials. Either the secret
+// sets RUNTIME_DB_USER and the fallback never fires — in which case this comment in
+// deploy.sh is simply stale — or the cutover did not happen and a closed Spec is claiming
+// something untrue of production. Those are very different situations and only reading the
+// deployed service settles it. Raised on spec-520 t-12 rather than assumed either way.
+//
+// (An earlier version of this comment attributed the rollout to spec-520's own t-14. That
+// was wrong: spec-520 t-14 is the release-gating task — e2e, smoke, post-deploy emission
+// verification. The runtime-role cutover is spec-199's.)
+
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+
+const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+
+/**
+ * Run a statement and return the POSTGRES error code.
+ *
+ * ⚠ NOT the message. Drizzle wraps driver errors, so `.message` is "Failed query: …" and a
+ * regex on it matches nothing useful — a `/must be owner/` assertion fails even when the
+ * refusal happened exactly as intended. The real error hangs off `.cause`, and `42501`
+ * (insufficient_privilege) is the code that says "this role is not the owner". Asserting
+ * the code also means the test cannot pass because a statement was malformed.
+ */
+async function errorCodeOf(statement: string): Promise<string | undefined> {
+  try {
+    await db.execute(sql.raw(statement));
+    return undefined;
+  } catch (err) {
+    const cause = (err as { cause?: { code?: string } }).cause;
+    return cause?.code;
+  }
+}
+
+async function anyPartitionName(): Promise<string> {
+  const rows = (await db.execute(sql`
+    SELECT c.relname::text AS name
+    FROM pg_class c
+    JOIN pg_inherits i ON i.inhrelid = c.oid
+    WHERE i.inhparent = 'test_events'::regclass
+    ORDER BY c.relname
+    LIMIT 1
+  `)) as unknown as Array<{ name: string }>;
+  return rows[0]!.name;
+}
+
+describe("spec-520 ac-13 — partition maintenance is refused to the restricted role", () => {
+  it("confirms this suite really is connected as the non-owner role", async () => {
+    tagAc(AC_PARTITIONED);
+    const [row] = (await db.execute(sql`SELECT current_user::text AS who`)) as unknown as Array<{ who: string }>;
+    // Without this the refusals below could pass because the statements were malformed
+    // rather than because the role lacked the right — the two are indistinguishable from a
+    // thrown error alone.
+    expect(row.who).toBe("memex_app");
+  });
+
+  it("refuses DROP TABLE on a partition", async () => {
+    tagAc(AC_PARTITIONED);
+    const name = await anyPartitionName();
+    expect(await errorCodeOf(`DROP TABLE ${name}`)).toBe("42501");
+  });
+
+  it("refuses DETACH PARTITION on the parent", async () => {
+    tagAc(AC_PARTITIONED);
+    const name = await anyPartitionName();
+    // The maintenance script detaches before dropping, so both verbs have to be refused —
+    // a role that could detach could strand a partition outside the parent, which reads as
+    // silent data loss to every consumer.
+    expect(await errorCodeOf(`ALTER TABLE test_events DETACH PARTITION ${name}`)).toBe("42501");
+  });
+
+  it("still lets the restricted role do what the emission path needs", async () => {
+    tagAc(AC_PARTITIONED);
+    // The refusals above would be trivially satisfiable by a role with no rights at all.
+    // This is the other side: the same role must still be able to write emissions, or the
+    // "restrict it" answer would have broken the product to secure it.
+    const [row] = (await db.execute(sql`
+      SELECT has_table_privilege('test_events', 'INSERT') AS ins,
+             has_table_privilege('test_events', 'SELECT') AS sel
+    `)) as unknown as Array<{ ins: boolean; sel: boolean }>;
+    expect(row.ins).toBe(true);
+    expect(row.sel).toBe(true);
+  });
+});

--- a/packages/server/src/services/rollup-tenant-deletion.integration.test.ts
+++ b/packages/server/src/services/rollup-tenant-deletion.integration.test.ts
@@ -1,0 +1,106 @@
+// spec-520 t-13 (ac-30) — deleting a workspace must reach the per-day rollup.
+//
+// WHY THIS TABLE AND NOT THE OTHERS. Every table on the emission path has so far been
+// forgiven by retention: the trim capped test_events, so a deleted tenant's rows aged out
+// on their own. Retention was the de facto eraser. `test_run_daily` is PERMANENT by
+// design — it exists precisely so history survives retention — and it grows per tenant,
+// per subject, per test, per day, forever. Nothing will ever remove it on its own.
+//
+// WHAT THE INVESTIGATION FOUND (recorded on t-13):
+//
+//   1. There is NO production tenant-deletion path. The only DELETE against `memexes`,
+//      `orgs` or `namespaces` in the whole server is the env-gated test surface. No route
+//      on memexes.ts/orgs.ts deletes, and there is no soft-delete column.
+//   2. Coverage for every other tenant table IS by construction — 16 tables carry an
+//      ON DELETE CASCADE foreign key to `memexes`, and `acs`/`issues` inherit it
+//      transitively through `documents`.
+//   3. The emission family — test_events, test_event_latest, ac_first_verified and (as
+//      shipped) test_run_daily — carries NO foreign key at all, direct or transitive. It
+//      sits entirely outside the cascade graph.
+//
+// So the leak is latent rather than live: nothing deletes a tenant today, so nothing is
+// orphaned yet. But when that path is built it will silently miss these four tables, and
+// t-13 is explicit that coverage must be by construction rather than by someone
+// remembering to add a line to an enumeration.
+//
+// THIS TEST DELETES THE ROW DIRECTLY, not through any service. That is deliberate: the
+// guarantee has to hold for whatever code eventually issues the delete, including code
+// that has never heard of this table. Going through a helper would prove only that the
+// helper remembered.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { memexes, testRunDaily } from "../db/schema.js";
+import { makeTestMemex } from "./test-helpers.js";
+
+const AC_DELETION = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-30";
+
+let doomedMemexId: string;
+let survivorMemexId: string;
+
+async function seedRollup(memexId: string, subjectRef: string): Promise<void> {
+  await db.insert(testRunDaily).values({
+    memexId,
+    subjectRef,
+    testIdentifier: "a::t",
+    day: "2026-08-30",
+    runCount: 3,
+    passCount: 3,
+    failCount: 0,
+    errorCount: 0,
+  } as typeof testRunDaily.$inferInsert);
+}
+
+async function rollupRowsFor(memexId: string): Promise<number> {
+  const rows = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(testRunDaily)
+    .where(eq(testRunDaily.memexId, memexId));
+  return Number(rows[0]?.n ?? 0);
+}
+
+beforeAll(async () => {
+  doomedMemexId = await makeTestMemex("t13d");
+  survivorMemexId = await makeTestMemex("t13s");
+});
+
+afterAll(async () => {
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, survivorMemexId)).catch(() => {});
+  await db.delete(memexes).where(eq(memexes.id, survivorMemexId)).catch(() => {});
+});
+
+describe("spec-520 ac-30: workspace deletion reaches the rollup", () => {
+  it("removes the rollup rows when the memex row is deleted, with no application code involved", async () => {
+    tagAc(AC_DELETION);
+    await seedRollup(doomedMemexId, "ns/mx/specs/spec-1/acs/ac-1");
+    await seedRollup(doomedMemexId, "ns/mx/specs/spec-1/acs/ac-2");
+    await seedRollup(survivorMemexId, "ns/other/specs/spec-1/acs/ac-1");
+    expect(await rollupRowsFor(doomedMemexId)).toBe(2);
+
+    // The raw row delete — the thing every future deletion path will ultimately do.
+    await db.delete(memexes).where(eq(memexes.id, doomedMemexId));
+
+    expect(await rollupRowsFor(doomedMemexId)).toBe(0);
+    // A cascade that took the neighbours with it would be a far worse bug than the one
+    // being fixed, and it would look like success from the doomed tenant's side.
+    expect(await rollupRowsFor(survivorMemexId)).toBe(1);
+  });
+
+  it("holds the guarantee structurally — the constraint exists and cascades", async () => {
+    tagAc(AC_DELETION);
+    // The behavioural case above would keep passing if someone replaced the cascade with
+    // an application-level cleanup. This asserts the guarantee is where t-13 requires it:
+    // in the schema, reached automatically, not in a list somebody maintains.
+    const rows = (await db.execute(sql`
+      SELECT c.confdeltype::text AS on_delete
+      FROM pg_constraint c
+      WHERE c.contype = 'f'
+        AND c.conrelid = 'test_run_daily'::regclass
+        AND c.confrelid = 'memexes'::regclass
+    `)) as unknown as Array<{ on_delete: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].on_delete).toBe("c"); // 'c' = ON DELETE CASCADE
+  });
+});

--- a/packages/server/src/services/spec-398-retention.integration.test.ts
+++ b/packages/server/src/services/spec-398-retention.integration.test.ts
@@ -193,11 +193,15 @@ describe("spec-398 retention + tenancy", () => {
       .limit(1);
     expect(tel.memexId).toBe(memexId);
     // first-verified snapshot recorded too.
-    await recordFirstVerified(db, subjectRef, new Date(Date.UTC(2026, 0, 1)));
+    // spec-520 dec-7 option C: the snapshot now carries the tenant too, so the writer takes
+    // the memexId. The assertion below gains a tenancy check for the same reason the row
+    // gained the column — this table used to be scoped purely by ref string.
+    await recordFirstVerified(db, subjectRef, new Date(Date.UTC(2026, 0, 1)), memexId);
     const [fv] = await db
-      .select({ at: acFirstVerified.firstVerifiedAt })
+      .select({ at: acFirstVerified.firstVerifiedAt, memexId: acFirstVerified.memexId })
       .from(acFirstVerified)
       .where(eq(acFirstVerified.subjectRef, subjectRef));
+    expect(fv!.memexId).toBe(memexId);
     expect(fv).toBeDefined();
   });
 

--- a/packages/server/src/services/spec-398-retention.integration.test.ts
+++ b/packages/server/src/services/spec-398-retention.integration.test.ts
@@ -29,9 +29,7 @@ import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
 import { createDocDraft } from "./documents.js";
 import { listActivityView } from "./activity-view.js";
 import {
-  trimTestEventsForPair,
   recordFirstVerified,
-  RETENTION_KEEP,
 } from "./test-event-retention.js";
 import { deriveVerificationState } from "./acs.js";
 
@@ -92,54 +90,59 @@ beforeAll(async () => {
 });
 
 describe("spec-398 retention + tenancy", () => {
-  it("ac-5: trim-on-write caps a pair at the latest 10; the 11th drops the oldest", async () => {
+  // ⚠ REWRITTEN FOR spec-520 t-12, AND GATED ON AN AMENDMENT THAT IS NOT YET MADE.
+  //
+  // spec-398 ac-5 still reads "trim-on-write caps a pair at the latest 10; the 11th drops
+  // the oldest", and ac-6 reads "Retention is by COUNT not age". t-12 deletes the trim and
+  // replaces it with a time window, so both statements become false about the code.
+  //
+  // t-8 is explicit that the amendment lands BEFORE OR WITH the code change, so no spec-398
+  // criterion is ever left failing — and that no assertion is loosened or deleted without
+  // its criterion being amended first. The new text is drafted and waiting for the Spec's
+  // owner (spec-520 c-14); rewriting an acceptance criterion changes the definition of
+  // finished and is not an agent's call.
+  //
+  // So these assertions describe the NEW behaviour and the change they belong to MUST NOT
+  // MERGE until ac-5 and ac-6 carry their new text. Between those two events the criteria
+  // would read green off tests proving the opposite of what they say, which is precisely
+  // the drift this system exists to prevent.
+  //
+  // ac-4 keeps its tag and needs no new text: it describes the ONE-TIME rewrite-and-swap of
+  // migration 0111, which happened and stays historically true. Its old test asserted the
+  // steady-state trim instead — a tagging defect, also flagged in c-14.
+
+  it("ac-5: an emission issues no DELETE — the 11th run does not evict the oldest", async () => {
     tagAc(`${AC}/ac-5`);
     const subjectRef = ref(1);
     const tid = "tests/a.test.ts::it";
-    // Simulate the route's insert-then-trim, 11 times, ascending timestamps.
     const oldest = new Date("2026-01-01T00:00:00Z");
-    for (let i = 0; i < 11; i++) {
-      const createdAt = new Date(oldest.getTime() + i * 60_000);
-      await insertRaw(subjectRef, tid, [createdAt]);
-      await trimTestEventsForPair(db, subjectRef, tid);
-    }
-    expect(await countFor(subjectRef, tid)).toBe(RETENTION_KEEP);
-    // The oldest (i=0) must be gone; the newest survives.
+    const stamps = Array.from({ length: 11 }, (_, i) => new Date(oldest.getTime() + i * 60_000));
+    await insertRaw(subjectRef, tid, stamps);
+
+    // Under the trim this was exactly 10, forever, however many ran. The write path now
+    // deletes nothing; rows leave only when an aged-out partition is dropped.
+    expect(await countFor(subjectRef, tid)).toBe(11);
     const survivors = await db
       .select({ createdAt: testEvents.createdAt })
       .from(testEvents)
       .where(eq(testEvents.subjectRef, subjectRef));
-    const times = survivors.map((s) => s.createdAt.getTime()).sort((a, b) => a - b);
-    expect(times[0]).toBe(oldest.getTime() + 1 * 60_000); // i=1 is now the oldest kept
-    expect(times).not.toContain(oldest.getTime());
+    const times = survivors.map((sv) => sv.createdAt.getTime()).sort((a, b) => a - b);
+    // The oldest row is the one the trim used to take first. It survives.
+    expect(times[0]).toBe(oldest.getTime());
   });
 
-  it("ac-4 / ac-6: keep the latest 10 by COUNT regardless of age (the rewrite-and-swap invariant)", async () => {
-    tagAc(`${AC}/ac-4`);
+  it("ac-6: retention is by AGE not count — a busy pair keeps everything inside the window", async () => {
     tagAc(`${AC}/ac-6`);
     const subjectRef = ref(2);
     const tid = "tests/b.test.ts::it";
-    // 15 rows: 5 spread across months (old by calendar), 10 packed into one minute
-    // (recent). Keep-last-10 must keep the 10 RECENT ones and drop the 5 old ones,
-    // proving COUNT (not age) is the axis.
-    const old5 = [0, 1, 2, 3, 4].map(
-      (m) => new Date(Date.UTC(2025, m, 1, 0, 0, 0)),
-    );
-    const recent10 = Array.from(
-      { length: 10 },
-      (_, i) => new Date(Date.UTC(2026, 5, 24, 12, 0, i)),
-    );
-    await insertRaw(subjectRef, tid, [...old5, ...recent10]);
-    await trimTestEventsForPair(db, subjectRef, tid);
-    expect(await countFor(subjectRef, tid)).toBe(10);
-    const survivors = await db
-      .select({ createdAt: testEvents.createdAt })
-      .from(testEvents)
-      .where(eq(testEvents.subjectRef, subjectRef));
-    // None of the 5 calendar-old rows survive; all survivors are the recent batch.
-    for (const s of survivors) {
-      expect(s.createdAt.getUTCFullYear()).toBe(2026);
-    }
+    // The old criterion's own example, inverted: "a pair with 50 runs inside one day keeps
+    // exactly its latest 10" becomes "keeps all 50". Fifty runs packed into one minute is
+    // the shape a busy AC actually has, and it is the shape the count cap punished hardest
+    // — which is why the history charts saw 4.5% of what happened.
+    const burst = Array.from({ length: 50 }, (_, i) => new Date(Date.UTC(2026, 5, 24, 12, 0, i)));
+    await insertRaw(subjectRef, tid, burst);
+
+    expect(await countFor(subjectRef, tid)).toBe(50);
   });
 
   it("ac-7: pruning test_events never reduces test_event_latest.run_count", async () => {
@@ -162,9 +165,15 @@ describe("spec-398 retention + tenancy", () => {
         and(eq(testEventLatest.subjectRef, subjectRef), eq(testEventLatest.testIdentifier, tid)),
       );
     expect(before.runCount).toBe(12);
-    // Now prune the log to 10.
-    await trimTestEventsForPair(db, subjectRef, tid);
-    expect(await countFor(subjectRef, tid)).toBe(10);
+    // Now lose the raw rows. Under spec-520 t-12 this happens when an aged-out partition
+    // is DROPPED, not by a per-pair trim — but the claim ac-7 makes is about the
+    // CONSEQUENCE, not the mechanism: run_count is the incremental all-time counter and
+    // losing log rows must never reduce it. A direct delete reproduces exactly the state a
+    // partition drop leaves behind, without needing the test to own a partition.
+    await db
+      .delete(testEvents)
+      .where(and(eq(testEvents.subjectRef, subjectRef), eq(testEvents.testIdentifier, tid)));
+    expect(await countFor(subjectRef, tid)).toBe(0);
     const [after] = await db
       .select({ runCount: testEventLatest.runCount })
       .from(testEventLatest)
@@ -230,7 +239,14 @@ describe("spec-398 retention + tenancy", () => {
         createdAt: new Date(Date.UTC(2026, 5, 24, 12, 0, i)),
       });
     }
-    await trimTestEventsForPair(db, subjectRef, tid); // prune log to 10
+    // Same substitution as in ac-7: the raw rows go, standing in for a dropped partition.
+    // ac-8's claim — verification reads test_event_latest, so a dormant test still surfaces
+    // its last known status rather than a false "untested" — is about surviving the LOSS,
+    // whatever removed the rows. Under a time window this case stops being hypothetical:
+    // measured on prod 2026-08-30, 81% of pairs hold no row inside three days.
+    await db
+      .delete(testEvents)
+      .where(and(eq(testEvents.subjectRef, subjectRef), eq(testEvents.testIdentifier, tid)));
     const [tel] = await db
       .select({
         testIdentifier: testEventLatest.testIdentifier,
@@ -282,7 +298,24 @@ describe("spec-398 retention + tenancy", () => {
       `)) as unknown as Array<Record<string, string>>;
       return plan.map((r) => Object.values(r)[0]).join("\n");
     });
-    expect(planText).toContain("test_events_memex_id_created_at_idx");
+    // ⚠ ASSERTS THE PROPERTY, NOT AN INDEX NAME. ac-11 says the plan "shows an index-driven
+    // access path with no full sequential scan of test_events" — it names no index. The
+    // original assertion matched on `test_events_memex_id_created_at_idx` literally, which
+    // broke the moment spec-520 t-12 partitioned the table: the plan now reaches each
+    // PARTITION through that partition's own copy of the index
+    // (test_events_20260831_memex_id_created_at_idx, and the legacy one under its renamed
+    // name). Nothing regressed; the assertion was over-specified.
+    const testEventScans = planText
+      .split("\n")
+      .filter((line) => /test_events/.test(line));
+    expect(testEventScans.length).toBeGreaterThan(0);
+    // Every access to test_events (parent or any partition) is an index scan.
+    for (const line of testEventScans) {
+      expect(line, `sequential scan of test_events in the plan:\n${planText}`).not.toMatch(
+        /Seq Scan on test_events/,
+      );
+    }
+    expect(planText).toMatch(/Index (Only )?Scan using test_events\w*_memex/);
   });
 
   it("ac-12 / ac-3: activity_view returns the same test_event entries, tenant-scoped to its memex", async () => {

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -1,0 +1,220 @@
+// spec-520 t-11 — the two consumers that could be re-based cleanly.
+//
+// ac-24 (testRunVolume) and ac-25 (verifyingAcIsGreen). The other two named by t-11 are
+// NOT here and not attempted:
+//   • auditCiEmissionForBrief needs run_id + metadata, which test_event_latest does not
+//     carry — dec-8.
+//   • listAcAlignmentOverTime's first-verified half reads ac_first_verified, which dec-7
+//     deliberately left in place.
+//
+// THE PROOF SHAPE ac-24 ASKS FOR is "results no longer change when raw events age out".
+// So these tests seed the DERIVED tier and leave the raw log EMPTY. Under the old
+// implementation that is indistinguishable from "nothing ever happened" — which is exactly
+// the defect: the charts read a log that retention had already emptied. Seeding the raw log
+// too would let a still-broken implementation pass.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db, runWithMemexId } from "../db/connection.js";
+import {
+  acs,
+  documents,
+  issues,
+  memexes,
+  namespaces,
+  taskSatisfiesAc,
+  tasks,
+  testEventLatest,
+  testEvents,
+  testRunDaily,
+} from "../db/schema.js";
+import { testRunVolume } from "./analytics.js";
+import { createDocDraft } from "./documents.js";
+import { maybeAutoResolveIssuesForTask } from "./issues.js";
+import { makeTestMemex } from "./test-helpers.js";
+import { upsertUserByEmail } from "./users.js";
+
+// NARROWED to ac-35 / ac-36 rather than ac-24 / ac-25 (2026-08-28). Each of those states
+// TWO consumers and only one of each pair could be moved — listAcAlignmentOverTime is
+// blocked on dec-7, auditCiEmissionForBrief on dec-8. Tagging the two-consumer criteria
+// from half the work would flip them green on a weaker property than they state, which is
+// exactly why ac-22 and ac-32 were split. It briefly happened here before these existed;
+// the stale emissions on ac-24/ac-25 were retired with discontinue_test_events.
+const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-35";
+const AC_LATEST = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-36";
+
+let memexId: string;
+let userId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t11");
+  const user = await upsertUserByEmail(`spec520-t11-${process.pid}@example.com`);
+  userId = user.id;
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  await db.delete(testRunDaily).where(eq(testRunDaily.memexId, memexId)).catch(() => {});
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () => {
+  it("reports the counts the rollup holds even with NO raw events at all", async () => {
+    tagAc(AC_CHARTS);
+
+    const ref = `${namespaceSlug}/${memexSlug}/specs/spec-1/acs/ac-1`;
+    createdRefs.push(ref);
+
+    // The rollup is the durable tier. The raw log is left EMPTY on purpose — that is the
+    // aged-out state the charts have been misreading as "no activity".
+    await db.insert(testRunDaily).values([
+      { memexId, subjectRef: ref, testIdentifier: "a::t", day: "2026-08-20", runCount: 5, passCount: 4, failCount: 1, errorCount: 0 },
+      { memexId, subjectRef: ref, testIdentifier: "b::t", day: "2026-08-20", runCount: 3, passCount: 3, failCount: 0, errorCount: 0 },
+      { memexId, subjectRef: ref, testIdentifier: "a::t", day: "2026-08-21", runCount: 2, passCount: 1, failCount: 0, errorCount: 1 },
+    ] as (typeof testRunDaily.$inferInsert)[]);
+
+    const points = await testRunVolume(memexId);
+    const byDay = new Map(points.map((p) => [p.day, p]));
+
+    // Summed ACROSS test_identifiers, which is what a per-day volume chart means.
+    expect(byDay.get("2026-08-20")).toMatchObject({ pass: 7, fail: 1, error: 0 });
+    expect(byDay.get("2026-08-21")).toMatchObject({ pass: 1, fail: 0, error: 1 });
+  });
+
+  it("is scoped by memex_id, not by a subject_ref string prefix", async () => {
+    tagAc(AC_CHARTS);
+
+    // The old read matched `subject_ref LIKE 'ns/mx/%'` — tenancy carried by a string,
+    // which is the spec-396 leak pattern this Spec closes elsewhere. A row belonging to
+    // another tenant must not appear however its ref happens to read.
+    const otherMemexId = await makeTestMemex("t11b");
+    const foreignRef = `${namespaceSlug}/${memexSlug}/specs/spec-9/acs/ac-9`;
+    createdRefs.push(foreignRef);
+    await db.insert(testRunDaily).values({
+      memexId: otherMemexId,
+      subjectRef: foreignRef,
+      testIdentifier: "x::t",
+      day: "2026-08-20",
+      runCount: 99,
+      passCount: 99,
+      failCount: 0,
+      errorCount: 0,
+    } as typeof testRunDaily.$inferInsert);
+
+    const points = await testRunVolume(memexId);
+    const day = points.find((p) => p.day === "2026-08-20");
+    // 7, not 106 — the foreign row carries this memex's ref prefix but another memex_id.
+    expect(day?.pass).toBe(7);
+
+    await db.delete(testRunDaily).where(eq(testRunDaily.memexId, otherMemexId)).catch(() => {});
+  });
+});
+
+describe("spec-520 ac-25: the auto-resolve gate reads test_event_latest, not the raw log", () => {
+  it("resolves a converted Issue from the SUMMARY alone, with the raw log empty", async () => {
+    tagAc(AC_LATEST);
+
+    const built = await runWithMemexId(memexId, async () => {
+      const doc = await createDocDraft(memexId, `t11 gate ${process.pid}`, "", "spec");
+      createdDocIds.push(doc.id);
+
+      const [ac] = await db
+        .insert(acs)
+        .values({ memexId, briefId: doc.id, seq: 1, kind: "implementation", statement: "verifies", status: "active" } as typeof acs.$inferInsert)
+        .returning();
+      const [task] = await db
+        .insert(tasks)
+        .values({ memexId, docId: doc.id, seq: 1, title: "satisfying", description: "", status: "complete" } as typeof tasks.$inferInsert)
+        .returning();
+      await db.insert(taskSatisfiesAc).values({ taskId: task!.id, acId: ac!.id } as typeof taskSatisfiesAc.$inferInsert);
+      const [issue] = await db
+        .insert(issues)
+        .values({ memexId, docId: doc.id, seq: 1, title: "awaiting green", body: "", type: "bug", severity: "high", status: "converted", source: "agent", satisfyingTaskId: task!.id, createdByUserId: userId } as typeof issues.$inferInsert)
+        .returning();
+      return { handle: doc.handle, taskId: task!.id, issueId: issue!.id };
+    });
+
+    const ref = `${namespaceSlug}/${memexSlug}/specs/${built.handle}/acs/ac-1`;
+    createdRefs.push(ref);
+
+    // ONLY the summary. No raw test_events row exists — the state after retention has aged
+    // the passing event out. The old implementation scans test_events, finds nothing, and
+    // refuses to resolve; that is the red.
+    await runWithMemexId(memexId, async () => {
+      await db.insert(testEventLatest).values({
+        subjectRef: ref,
+        memexId,
+        testIdentifier: "suite::verifies",
+        latestStatus: "pass",
+        latestRunAt: new Date("2026-08-20T10:00:00.000Z"),
+        runCount: 1,
+      } as typeof testEventLatest.$inferInsert);
+    });
+
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForTask(memexId, built.taskId),
+    );
+    expect(resolved).toContain(built.issueId);
+  });
+
+  it("still refuses when the summary's latest is a FAIL", async () => {
+    tagAc(AC_LATEST);
+
+    const built = await runWithMemexId(memexId, async () => {
+      const doc = await createDocDraft(memexId, `t11 gate red ${process.pid}`, "", "spec");
+      createdDocIds.push(doc.id);
+      const [ac] = await db
+        .insert(acs)
+        .values({ memexId, briefId: doc.id, seq: 1, kind: "implementation", statement: "verifies", status: "active" } as typeof acs.$inferInsert)
+        .returning();
+      const [task] = await db
+        .insert(tasks)
+        .values({ memexId, docId: doc.id, seq: 1, title: "satisfying", description: "", status: "complete" } as typeof tasks.$inferInsert)
+        .returning();
+      await db.insert(taskSatisfiesAc).values({ taskId: task!.id, acId: ac!.id } as typeof taskSatisfiesAc.$inferInsert);
+      const [issue] = await db
+        .insert(issues)
+        .values({ memexId, docId: doc.id, seq: 1, title: "awaiting green", body: "", type: "bug", severity: "high", status: "converted", source: "agent", satisfyingTaskId: task!.id, createdByUserId: userId } as typeof issues.$inferInsert)
+        .returning();
+      return { handle: doc.handle, taskId: task!.id, issueId: issue!.id };
+    });
+
+    const ref = `${namespaceSlug}/${memexSlug}/specs/${built.handle}/acs/ac-1`;
+    createdRefs.push(ref);
+
+    await runWithMemexId(memexId, async () => {
+      await db.insert(testEventLatest).values({
+        subjectRef: ref,
+        memexId,
+        testIdentifier: "suite::verifies",
+        latestStatus: "fail",
+        latestRunAt: new Date("2026-08-20T10:00:00.000Z"),
+        runCount: 1,
+      } as typeof testEventLatest.$inferInsert);
+    });
+
+    // Re-basing must not weaken the gate into "a row exists" — the STATUS still decides.
+    const resolved = await runWithMemexId(memexId, async () =>
+      maybeAutoResolveIssuesForTask(memexId, built.taskId),
+    );
+    expect(resolved).toEqual([]);
+  });
+});

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -1,11 +1,17 @@
 // spec-520 t-11 — the two consumers that could be re-based cleanly.
 //
-// ac-24 (testRunVolume) and ac-25 (verifyingAcIsGreen). The other two named by t-11 are
-// NOT here and not attempted:
+// ac-24 (testRunVolume) and ac-25 (verifyingAcIsGreen). Of the other two named by t-11:
 //   • auditCiEmissionForBrief needs run_id + metadata, which test_event_latest does not
 //     carry — dec-8.
-//   • listAcAlignmentOverTime's first-verified half reads ac_first_verified, which dec-7
-//     deliberately left in place.
+//   • listAcAlignmentOverTime moved in a follow-up, and now lives in
+//     alignment-over-time-rollup.integration.test.ts.
+//
+// ⚠ AN EARLIER VERSION OF THIS NOTE WAS WRONG and is corrected here rather than deleted,
+// because it is the kind of error that costs the next reader a wasted afternoon. It said
+// listAcAlignmentOverTime "reads ac_first_verified, which dec-7 deliberately left in
+// place". It never did: its accepted_at comes from the `acs` table via the inlined
+// ac_set VALUES list. The only reader of ac_first_verified is analytics.acsOverTime
+// (analytics.ts:383) — a THIRD chart, and the one dec-7's note is actually about.
 //
 // THE PROOF SHAPE ac-24 ASKS FOR is "results no longer change when raw events age out".
 // So these tests seed the DERIVED tier and leave the raw log EMPTY. Under the old
@@ -42,6 +48,12 @@ import { upsertUserByEmail } from "./users.js";
 // exactly why ac-22 and ac-32 were split. It briefly happened here before these existed;
 // the stale emissions on ac-24/ac-25 were retired with discontinue_test_events.
 const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-35";
+// ac-24 names BOTH history consumers. Its second half — listAcAlignmentOverTime — landed
+// in alignment-over-time-rollup.integration.test.ts once dec-7 unblocked it, so the
+// criterion is now true as written and is tagged from both halves rather than either one
+// alone. That is the whole reason ac-35 exists: it held the half that could ship while the
+// other was blocked, and it stays as the narrower statement.
+const AC_BOTH_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-24";
 const AC_LATEST = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-36";
 
 let memexId: string;
@@ -79,6 +91,7 @@ afterAll(async () => {
 describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () => {
   it("reports the counts the rollup holds even with NO raw events at all", async () => {
     tagAc(AC_CHARTS);
+    tagAc(AC_BOTH_CHARTS);
 
     const ref = `${namespaceSlug}/${memexSlug}/specs/spec-1/acs/ac-1`;
     createdRefs.push(ref);
@@ -101,6 +114,7 @@ describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () =
 
   it("is scoped by memex_id, not by a subject_ref string prefix", async () => {
     tagAc(AC_CHARTS);
+    tagAc(AC_BOTH_CHARTS);
 
     // The old read matched `subject_ref LIKE 'ns/mx/%'` — tenancy carried by a string,
     // which is the spec-396 leak pattern this Spec closes elsewhere. A row belonging to

--- a/packages/server/src/services/test-event-latest.ts
+++ b/packages/server/src/services/test-event-latest.ts
@@ -11,7 +11,7 @@
 
 import { and, eq, sql } from "drizzle-orm";
 import { type Db } from "../db/connection.js";
-import { testEvents, testEventLatest } from "../db/schema.js";
+import { testEventLatest } from "../db/schema.js";
 
 export interface EmissionForSummary {
   subjectRef: string;
@@ -24,6 +24,14 @@ export interface EmissionForSummary {
   latestRunAt: Date;
   /** spec-115: hidden emissions are stored in the log but excluded from badges. */
   hidden: boolean;
+  /** spec-520 dec-8: the emission's CI run id, if it carried one. */
+  runId?: string | null;
+  /**
+   * spec-520 dec-8: the emission's metadata bag. Written as `{}` when absent, NEVER left
+   * null — a NULL on this column means "this row predates provenance being recorded", and
+   * the CI-origin audit relies on that being unambiguous.
+   */
+  metadata?: Record<string, string> | null;
 }
 
 /**
@@ -55,6 +63,10 @@ export async function applyEmissionToSummary(
       latestStatus: emission.status,
       latestRunAt: emission.latestRunAt,
       runCount: 1,
+      latestRunId: emission.runId ?? null,
+      // `{}` and not null when the emission carries none — see the interface note. NULL is
+      // reserved to mean "this row predates 0137".
+      latestMetadata: emission.metadata ?? {},
     })
     .onConflictDoUpdate({
       target: [testEventLatest.subjectRef, testEventLatest.testIdentifier],
@@ -65,6 +77,11 @@ export async function applyEmissionToSummary(
         latestRunAt: sql`GREATEST(excluded.latest_run_at, ${testEventLatest.latestRunAt})`,
         // Every non-hidden emission counts, regardless of arrival order.
         runCount: sql`${testEventLatest.runCount} + 1`,
+        // spec-520 dec-8: provenance follows the STATUS, not the clock — it must describe
+        // the same emission the badge is showing, or the audit would report the origin of
+        // one run against the verdict of another. Same newest-wins guard as latestStatus.
+        latestRunId: sql`CASE WHEN excluded.latest_run_at >= ${testEventLatest.latestRunAt} THEN excluded.latest_run_id ELSE ${testEventLatest.latestRunId} END`,
+        latestMetadata: sql`CASE WHEN excluded.latest_run_at >= ${testEventLatest.latestRunAt} THEN excluded.latest_metadata ELSE ${testEventLatest.latestMetadata} END`,
       },
     });
 }

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -1,47 +1,106 @@
-// spec-398 — bounded retention for test_events + the durable first-verified snapshot.
+// spec-520 t-12 — retention for test_events is AGE, enforced by partition drop.
 //
-// test_events is the OPERATIONAL tier: keep only the latest N runs per
-// (subject_ref, test_identifier) (dec-1/dec-2). The one-time shrink is the rewrite-and-swap
-// in migration 0111; THIS module is the steady-state trim-on-write, called inside the
-// emission transaction so the log never grows unbounded between deploys.
+// WHAT USED TO BE HERE. `trimTestEventsForPair` ran inside every emission transaction and
+// deleted the pair's oldest rows past RETENTION_KEEP=10. It cost 13.4% of all database
+// time and produced 11.24M deletes against 11.87M inserts — autovacuum ran near-
+// continuously chasing the dead tuples it created. Retention is now a property of WHICH
+// PARTITION a row lands in: rows leave only when an aged-out partition is dropped, which
+// is a catalogue operation. No row deletion, no dead tuples, nothing for autovacuum to
+// chase. The 13.4% does not shrink — it goes to zero.
 //
-// recordFirstVerified maintains ac_first_verified — the analytical tier that survives
-// retention (spec-125), so analytics.acsOverTime keeps a true "first went green" date
-// even after the oldest passing row is trimmed away.
+// The window is CONFIGURATION, not a compiled-in constant, following spec-60 dec-6's
+// precedent for activity_log (`PULSE_RETENTION_DAYS`). spec-62's W4 retention workstream
+// has not pinned a schedule for this table — the ISO 27001 audit trail rides
+// `change_events`, not `test_events` — so no floor is fixed today, but one may be later,
+// and it must be a config change rather than a re-partitioning.
+//
+// ⚠ THE WINDOW IS NOT A DISPLAY BOUND. Measured on prod 2026-08-30, 196,978 of 243,339
+// pairs had not run in three days: 81% of pairs hold NO row inside a 3-day window. The AC
+// tab handles that through dec-9's carry-forward, reading the durable summary. Shortening
+// this window makes more pairs carry-forward; it does not make them invisible.
+//
+// recordFirstVerified stays: ac_first_verified is the analytical tier that survives
+// retention (spec-125), and dec-7 deliberately declined to retire it.
 
 import { sql } from "drizzle-orm";
 import { type Db } from "../db/connection.js";
 
-// dec-2 (ac-2): retention is by COUNT, not age. N=10 fixed.
-export const RETENTION_KEEP = 10;
+const DEFAULT_RETENTION_DAYS = 3;
 
 /**
- * Trim a single (subject_ref, test_identifier) group to its latest RETENTION_KEEP rows
- * by created_at DESC (id DESC as a deterministic tiebreak) — the steady-state
- * trim-on-write (ac-1). Scoped to the one pair: a narrow delete riding
- * test_events_retention_idx, no table lock, no cross-pair contention. A null
- * test_identifier collapses to '' to match the migration's partitioning and the
- * test_event_latest key.
+ * How many days of raw emissions are retained, from TEST_EVENTS_RETENTION_DAYS.
+ *
+ * Read once at module load and clamped, mirroring `PULSE_RETENTION_DAYS`. A missing,
+ * non-numeric or non-positive value falls back to the default: a zero or negative window
+ * would mean "drop every partition", so a typo must never be able to express it.
+ *
+ * The upper clamp is not tidiness. At ~2.68M emissions/day (spec-520 c-12) each retained
+ * day is roughly 2.7M rows; 3 days is ~8M and 30 days is ~80M. An accidental extra zero in
+ * an env var would silently commit the database to an order of magnitude more storage and
+ * scan cost, and nothing downstream would complain until it hurt.
  */
-export async function trimTestEventsForPair(
-  conn: Db,
-  subjectRef: string,
-  testIdentifier: string | null,
-): Promise<void> {
-  const key = testIdentifier ?? "";
-  await conn.execute(sql`
-    DELETE FROM test_events
-    WHERE id IN (
-      SELECT id FROM test_events
-      WHERE subject_ref = ${subjectRef} AND COALESCE(test_identifier, '') = ${key}
-      ORDER BY created_at DESC, id DESC
-      OFFSET ${RETENTION_KEEP}
-    )
-  `);
+const MAX_RETENTION_DAYS = 90;
+
+function resolveRetentionDays(): number {
+  const raw = process.env.TEST_EVENTS_RETENTION_DAYS;
+  if (raw === undefined || raw === "") return DEFAULT_RETENTION_DAYS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RETENTION_DAYS;
+  return Math.min(parsed, MAX_RETENTION_DAYS);
+}
+
+export const TEST_EVENTS_RETENTION_DAYS = resolveRetentionDays();
+
+/**
+ * How many days of partitions are created AHEAD of today.
+ *
+ * A partitioned table with no partition for an incoming row rejects the INSERT outright
+ * ("no partition of relation found for row") — proven on pg16 2026-08-30. That is a loud,
+ * immediate failure rather than a silent one, which is the right direction, but it must
+ * never be reachable: maintenance runs at DEPLOY time, so the horizon has to outlast any
+ * realistic gap between deploys.
+ *
+ * ⚠ A DEFAULT PARTITION IS NOT THE ANSWER, and this was measured rather than assumed.
+ * Once rows for a given day land in a DEFAULT partition, creating that day's real
+ * partition FAILS outright:
+ *
+ *     ERROR: updated partition constraint for default partition would be violated by
+ *            some row
+ *
+ * So a default would convert a quiet no-deploy gap into a migration that cannot apply
+ * until someone drains it by hand — a worse failure than the one it was meant to prevent.
+ *
+ * Sixty days costs nothing to CREATE: 61 daily partitions measured 122 ms, and the
+ * idempotent re-run 2 ms (local pg16, 2026-08-30).
+ *
+ * ⚠ BUT THE HORIZON IS NOT FREE TO READ AGAINST, and this is the number to revisit first
+ * if the feed ever feels slow. A query with no `created_at` predicate cannot be pruned, so
+ * the planner walks EVERY partition — the activity feed's plan was observed touching all
+ * 61, of which 60 were empty future days. Each is a cheap index scan and the MergeAppend
+ * over them is correct, but it is 61 plan nodes to answer a LIMIT 8.
+ *
+ * Once retention settles (the legacy partition drops three days after the migration) the
+ * POPULATED set is `TEST_EVENTS_RETENTION_DAYS + 1` — about four. The rest of the fan-out
+ * is horizon. Shortening the horizon reduces it proportionally; the floor is "longer than
+ * any realistic gap between deploys", because running out is a hard insert failure rather
+ * than a slow query. Sixty is deliberately generous on that side of the trade.
+ */
+export const PARTITION_HORIZON_DAYS = 60;
+
+/**
+ * The partition name for a UTC day — `test_events_YYYYMMDD`. One function, used by both
+ * the maintenance script and the tests, so a naming drift cannot make maintenance silently
+ * create duplicates alongside the ones it should have found.
+ */
+export function partitionNameFor(day: Date): string {
+  const y = day.getUTCFullYear();
+  const m = String(day.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(day.getUTCDate()).padStart(2, "0");
+  return `test_events_${y}${m}${d}`;
 }
 
 /**
- * Record the earliest passing emission for an subject_ref into the durable
+ * Record the earliest passing emission for a subject_ref into the durable
  * ac_first_verified snapshot (spec-398 t-6). LEAST-wins so the earliest survives
  * regardless of arrival order (out-of-order backfills, replays). Call only for
  * non-hidden passes — hidden emissions are excluded from verification signals.
@@ -54,38 +113,22 @@ export async function recordFirstVerified(
 ): Promise<void> {
   // Pass the timestamp as an ISO string + explicit cast: a raw drizzle `sql`
   // template has no column-type context, so postgres.js can't bind a bare Date.
-  // spec-520 dec-7 option D (ac-34): the DO UPDATE is now predicated, so it stops
+  // spec-520 dec-7 option D (ac-34): the DO UPDATE is predicated, so it stops
   // rewriting a row it is not changing.
-  //
-  // Without the WHERE, LEAST returns the value ALREADY STORED on every pass after the
-  // first — so the statement wrote an identical date into a brand-new row version, every
-  // time. Measured on prod 2026-08-28 as a 600s delta: 30.972 calls/s at 0.0496 ms, one
-  // per passing event, ~21.3M lifetime updates that changed nothing. The statement still
-  // runs; it now finds no row, so there is no new row version and no dead tuple.
   //
   // ⚠ THE WHERE MUST COMPARE, NOT JUST SUPPRESS. LEAST-wins exists for OUT-OF-ORDER
   // arrival — a replay or backfill carrying an EARLIER first pass must still win, or
   // "earliest pass" quietly becomes "first pass SEEN". `stored > EXCLUDED` fires exactly
   // when LEAST would actually change the value and never otherwise. A blanket
   // `DO NOTHING` would have been cheaper to write and would have broken that silently.
-  //
-  // LEAST is kept in the SET even though the WHERE already implies it: it states the
-  // intent at the point of the write, and it keeps the statement correct if the predicate
-  // is ever loosened.
-  //
-  // Note this is the COST half only. `ac_first_verified` still exists, is still read, and
-  // still has no memex_id — see dec-7 for why the retirement (ac-23) was separated from
-  // this and deliberately left open.
   await conn.execute(sql`
     INSERT INTO ac_first_verified (subject_ref, first_verified_at, memex_id)
     VALUES (${subjectRef}, ${at.toISOString()}::timestamptz, ${memexId}::uuid)
     ON CONFLICT (subject_ref) DO UPDATE
       SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at),
-          -- spec-520 dec-7 option C: heal a NULL left by the 0136 backfill. A row whose ref
-          -- had no surviving test_event_latest match could not be resolved at migration time;
-          -- the next emission for it knows the memex and fills it in. Never OVERWRITES a
-          -- resolved value — a ref cannot change tenant, so a differing value would be a bug
-          -- worth keeping visible rather than silently reconciling.
+          -- spec-520 dec-7 option C: heal a NULL left by the 0136 backfill. Never
+          -- OVERWRITES a resolved value — a ref cannot change tenant, so a differing value
+          -- would be a bug worth keeping visible rather than silently reconciling.
           memex_id = COALESCE(ac_first_verified.memex_id, EXCLUDED.memex_id)
       WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at
          OR ac_first_verified.memex_id IS NULL

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -53,10 +53,33 @@ export async function recordFirstVerified(
 ): Promise<void> {
   // Pass the timestamp as an ISO string + explicit cast: a raw drizzle `sql`
   // template has no column-type context, so postgres.js can't bind a bare Date.
+  // spec-520 dec-7 option D (ac-34): the DO UPDATE is now predicated, so it stops
+  // rewriting a row it is not changing.
+  //
+  // Without the WHERE, LEAST returns the value ALREADY STORED on every pass after the
+  // first — so the statement wrote an identical date into a brand-new row version, every
+  // time. Measured on prod 2026-08-28 as a 600s delta: 30.972 calls/s at 0.0496 ms, one
+  // per passing event, ~21.3M lifetime updates that changed nothing. The statement still
+  // runs; it now finds no row, so there is no new row version and no dead tuple.
+  //
+  // ⚠ THE WHERE MUST COMPARE, NOT JUST SUPPRESS. LEAST-wins exists for OUT-OF-ORDER
+  // arrival — a replay or backfill carrying an EARLIER first pass must still win, or
+  // "earliest pass" quietly becomes "first pass SEEN". `stored > EXCLUDED` fires exactly
+  // when LEAST would actually change the value and never otherwise. A blanket
+  // `DO NOTHING` would have been cheaper to write and would have broken that silently.
+  //
+  // LEAST is kept in the SET even though the WHERE already implies it: it states the
+  // intent at the point of the write, and it keeps the statement correct if the predicate
+  // is ever loosened.
+  //
+  // Note this is the COST half only. `ac_first_verified` still exists, is still read, and
+  // still has no memex_id — see dec-7 for why the retirement (ac-23) was separated from
+  // this and deliberately left open.
   await conn.execute(sql`
     INSERT INTO ac_first_verified (subject_ref, first_verified_at)
     VALUES (${subjectRef}, ${at.toISOString()}::timestamptz)
     ON CONFLICT (subject_ref) DO UPDATE
       SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at)
+      WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at
   `);
 }

--- a/packages/server/src/services/test-event-retention.ts
+++ b/packages/server/src/services/test-event-retention.ts
@@ -50,6 +50,7 @@ export async function recordFirstVerified(
   conn: Db,
   subjectRef: string,
   at: Date,
+  memexId: string,
 ): Promise<void> {
   // Pass the timestamp as an ISO string + explicit cast: a raw drizzle `sql`
   // template has no column-type context, so postgres.js can't bind a bare Date.
@@ -76,10 +77,17 @@ export async function recordFirstVerified(
   // still has no memex_id — see dec-7 for why the retirement (ac-23) was separated from
   // this and deliberately left open.
   await conn.execute(sql`
-    INSERT INTO ac_first_verified (subject_ref, first_verified_at)
-    VALUES (${subjectRef}, ${at.toISOString()}::timestamptz)
+    INSERT INTO ac_first_verified (subject_ref, first_verified_at, memex_id)
+    VALUES (${subjectRef}, ${at.toISOString()}::timestamptz, ${memexId}::uuid)
     ON CONFLICT (subject_ref) DO UPDATE
-      SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at)
+      SET first_verified_at = LEAST(ac_first_verified.first_verified_at, EXCLUDED.first_verified_at),
+          -- spec-520 dec-7 option C: heal a NULL left by the 0136 backfill. A row whose ref
+          -- had no surviving test_event_latest match could not be resolved at migration time;
+          -- the next emission for it knows the memex and fills it in. Never OVERWRITES a
+          -- resolved value — a ref cannot change tenant, so a differing value would be a bug
+          -- worth keeping visible rather than silently reconciling.
+          memex_id = COALESCE(ac_first_verified.memex_id, EXCLUDED.memex_id)
       WHERE ac_first_verified.first_verified_at > EXCLUDED.first_verified_at
+         OR ac_first_verified.memex_id IS NULL
   `);
 }

--- a/packages/server/src/services/test-events-partitioned.integration.test.ts
+++ b/packages/server/src/services/test-events-partitioned.integration.test.ts
@@ -1,0 +1,184 @@
+// spec-520 t-12 (ac-13) — test_events is time-partitioned, and an emission deletes nothing.
+//
+// WHAT THIS REPLACES. `trimTestEventsForPair` ran inside every emission transaction and
+// deleted the pair's oldest rows past a count of 10. It was 13.4% of all database time and
+// produced 11.24M deletes against 11.87M inserts, with autovacuum running near-continuously
+// behind it. Retention is now which PARTITION a row landed in; rows leave only when an
+// aged-out partition is dropped, which is a catalogue operation.
+//
+// ⚠ THE COUNT-BASED ASSERTIONS THAT USED TO LIVE IN spec-398-retention.integration.test.ts
+// ARE NOT MOVED HERE. spec-398 ac-5 and ac-6 still SAY "latest 10 by count", and rewriting
+// their tests to assert the opposite before those criteria are amended would flip them
+// green on a property they do not state. The amendments are drafted (spec-520 c-14) and
+// belong to the Spec's owner. This file asserts the NEW behaviour under spec-520's own
+// criteria; that file is left alone until the amendment lands.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import { documents, memexes, namespaces, testEventLatest, testEvents } from "../db/schema.js";
+import { createAc } from "./acs.js";
+import { createDocDraft } from "./documents.js";
+import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
+import { PARTITION_HORIZON_DAYS, TEST_EVENTS_RETENTION_DAYS, partitionNameFor } from "./test-event-retention.js";
+
+const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+
+let memexId: string;
+let namespaceSlug: string;
+let memexSlug: string;
+const createdDocIds: string[] = [];
+const createdRefs: string[] = [];
+
+async function seedAc(statement: string): Promise<string> {
+  const doc = await createDocDraft(memexId, "partitioned", "purpose", "spec");
+  createdDocIds.push(doc.id);
+  const ac = await createAc({ memexId, briefId: doc.id, kind: "implementation", statement });
+  const ref = `${namespaceSlug}/${memexSlug}/specs/${doc.handle}/acs/ac-${ac.seq}`;
+  createdRefs.push(ref);
+  return ref;
+}
+
+beforeAll(async () => {
+  memexId = await makeTestMemex("t12p");
+  const [row] = await db
+    .select({ m: memexes.slug, n: namespaces.slug })
+    .from(memexes)
+    .innerJoin(namespaces, eq(namespaces.id, memexes.namespaceId))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  memexSlug = row!.m;
+  namespaceSlug = row!.n;
+});
+
+afterAll(async () => {
+  if (createdRefs.length) {
+    await db.delete(testEventLatest).where(inArray(testEventLatest.subjectRef, createdRefs)).catch(() => {});
+    await db.delete(testEvents).where(inArray(testEvents.subjectRef, createdRefs)).catch(() => {});
+  }
+  if (createdDocIds.length) {
+    await db.delete(documents).where(inArray(documents.id, createdDocIds)).catch(() => {});
+  }
+});
+
+describe("spec-520 ac-13: the table is partitioned by time", () => {
+  it("is a partitioned relation keyed on created_at, with the PK the partition key requires", async () => {
+    tagAc(AC_PARTITIONED);
+    const [rel] = (await db.execute(sql`
+      SELECT c.relkind::text AS relkind,
+             pg_get_partkeydef(c.oid) AS partkey,
+             (SELECT pg_get_constraintdef(k.oid) FROM pg_constraint k
+               WHERE k.conrelid = c.oid AND k.contype = 'p') AS pk
+      FROM pg_class c WHERE c.relname = 'test_events'
+    `)) as unknown as Array<{ relkind: string; partkey: string; pk: string }>;
+
+    expect(rel.relkind).toBe("p");
+    expect(rel.partkey).toBe("RANGE (created_at)");
+    // A partitioned parent cannot have a PK that excludes the partition key, so this is
+    // also what forced (id, created_at) — the old PK was (id) alone.
+    expect(rel.pk).toBe("PRIMARY KEY (id, created_at)");
+  });
+
+  it("carries a horizon of future partitions, so an insert can never find no home", async () => {
+    tagAc(AC_PARTITIONED);
+    const [{ n }] = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM pg_inherits WHERE inhparent = 'test_events'::regclass
+    `)) as unknown as Array<{ n: number }>;
+    // A partitioned table with no partition for an incoming row REJECTS the insert
+    // outright. The horizon is what keeps that unreachable between deploys, and a DEFAULT
+    // partition is not an option: once rows land in one, that day's real partition can
+    // never be created (measured — "would be violated by some row").
+    expect(n).toBeGreaterThan(PARTITION_HORIZON_DAYS);
+  });
+
+  it("gives every FORWARD partition the parent's indexes, not just a primary key", async () => {
+    tagAc(AC_PARTITIONED);
+    // THE DEFECT THIS EXISTS FOR. The first version of 0142 created the parent indexes with
+    // CREATE INDEX **IF NOT EXISTS** using the same names the legacy partition still held
+    // after the rename. Every statement found its name taken and silently did nothing, so
+    // the parent ended up with only its primary key — and so did every partition created
+    // afterwards. Nothing failed. A NOTICE scrolled past in the migration output.
+    //
+    // In production that surfaces the day the first daily partition starts taking rows:
+    // the AC matrix, both digest CTEs, the Pulse and the activity feed all sequential-scan
+    // ~2.7M rows a day. The rehearsal under load caught it; this keeps it caught.
+    const parentIdx = (await db.execute(sql`
+      SELECT c.relname::text AS name
+      FROM pg_class c
+      WHERE c.oid IN (SELECT indexrelid FROM pg_index WHERE indrelid = 'test_events'::regclass)
+    `)) as unknown as Array<{ name: string }>;
+    const names = parentIdx.map((r) => r.name).sort();
+    expect(names).toContain("test_events_retention_idx");
+    expect(names).toContain("test_events_memex_id_created_at_idx");
+    expect(names).toContain("test_events_created_at_idx");
+    expect(names.length).toBeGreaterThanOrEqual(6); // 5 + the PK
+
+    // And they must have REACHED a partition — a parent index that failed to propagate
+    // looks identical from the parent's catalogue alone.
+    const [{ n }] = (await db.execute(sql`
+      SELECT count(*)::int AS n
+      FROM pg_indexes
+      WHERE tablename = (
+        SELECT c.relname FROM pg_class c
+        JOIN pg_inherits i ON i.inhrelid = c.oid
+        WHERE i.inhparent = 'test_events'::regclass AND c.relname <> 'test_events_legacy'
+        ORDER BY c.relname LIMIT 1
+      )
+    `)) as unknown as Array<{ n: number }>;
+    expect(n).toBeGreaterThanOrEqual(6);
+  });
+
+  it("routes a row to the partition its created_at names", async () => {
+    tagAc(AC_PARTITIONED);
+    const ref = await seedAc("routing");
+    const future = new Date(Date.now() + 10 * 86_400_000);
+    await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "a::t", createdAt: future });
+
+    const [row] = (await db.execute(sql`
+      SELECT tableoid::regclass::text AS part FROM test_events WHERE subject_ref = ${ref} LIMIT 1
+    `)) as unknown as Array<{ part: string }>;
+    expect(row.part).toBe(partitionNameFor(future));
+  });
+});
+
+describe("spec-520 ac-13: an emission deletes nothing", () => {
+  it("keeps every emission for a pair — the 11th no longer evicts the oldest", async () => {
+    tagAc(AC_PARTITIONED);
+    const ref = await seedAc("no trim");
+    const base = Date.now() - 20 * 60_000;
+    for (let i = 0; i < 15; i++) {
+      await seedTestEvent({
+        subjectRef: ref, status: "pass", testIdentifier: "a::t",
+        createdAt: new Date(base + i * 60_000),
+      });
+    }
+
+    const [{ n }] = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM test_events
+      WHERE subject_ref = ${ref} AND test_identifier = 'a::t'
+    `)) as unknown as Array<{ n: number }>;
+    // Under the old trim this was exactly 10, forever, no matter how many ran. That cap is
+    // the reason the history charts were reading 4.5% of what happened.
+    expect(n).toBe(15);
+  });
+
+  it("exports no per-pair trim to call any more", async () => {
+    tagAc(AC_PARTITIONED);
+    const mod = await import("./test-event-retention.js");
+    // A leftover export is an invitation to reintroduce the 13.4%: the emission path used
+    // to call it, and a future edit restoring that call would be a one-line regression with
+    // no test to catch it if the function still existed.
+    expect(Object.keys(mod)).not.toContain("trimTestEventsForPair");
+    expect(Object.keys(mod)).not.toContain("RETENTION_KEEP");
+  });
+
+  it("exposes the retention window as configuration, not a constant", async () => {
+    tagAc(AC_PARTITIONED);
+    // spec-60 dec-6's precedent (PULSE_RETENTION_DAYS). spec-62's W4 retention workstream
+    // has pinned no schedule for this table, so no floor is fixed today — but one may be,
+    // and it must be a config change rather than a re-partitioning.
+    expect(TEST_EVENTS_RETENTION_DAYS).toBeGreaterThan(0);
+    expect(TEST_EVENTS_RETENTION_DAYS).toBeLessThanOrEqual(90);
+  });
+});

--- a/packages/server/src/services/test-helpers.ts
+++ b/packages/server/src/services/test-helpers.ts
@@ -8,6 +8,7 @@ import { namespaces, orgs, memexes, orgMemberships, testEvents, users } from "..
 import { upsertUserByEmail } from "./users.js";
 import { ensureUserNamespace } from "./user-namespaces.js";
 import { applyEmissionToSummary } from "./test-event-latest.js";
+import { applyEmissionToRollup } from "./test-run-daily.js";
 import { resolveMemexId } from "./emission-keys.js";
 
 function uniqueSlug(prefix: string): string {
@@ -27,12 +28,17 @@ export interface SeedTestEventInput {
 }
 
 /**
- * Seed a test_events row the way the real emission route does (spec-162):
- * insert the log row AND maintain the test_event_latest summary in ONE
- * transaction. Integration tests that assert on the badge read paths
- * (aggregateAcHealthForBriefs / listAcsForBriefWithVerification) must seed via
- * this helper — a bare db.insert(testEvents) leaves the summary the reads
- * consume empty, so the AC would read as untested.
+ * Seed a test_events row the way the real emission route does: insert the log row
+ * AND maintain every derived tier, in ONE transaction — test_event_latest
+ * (spec-162) and, since spec-520 t-9, the per-day test_run_daily rollup.
+ *
+ * ALWAYS seed through this helper. A bare `db.insert(testEvents)` writes a shape
+ * PRODUCTION NEVER PRODUCES: the emission route maintains all three tiers
+ * together, so a raw-only row is not a smaller version of a real emission, it is
+ * an impossible one. Fixtures that did it worked only for as long as the consumer
+ * under test happened to read the raw log — spec-520 t-11 moved two consumers to
+ * the derived tiers and two such fixtures failed immediately, which is the test
+ * suite noticing a defect in itself rather than a regression in the code.
  */
 export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
   const hidden = input.hidden ?? false;
@@ -66,6 +72,18 @@ export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
       testIdentifier,
       status: input.status,
       latestRunAt: row.createdAt,
+      hidden,
+    });
+    // spec-520 t-9: the third tier. Keep this in step with routes/test-events.ts —
+    // a fixture that maintains only some of the tiers is the shape production
+    // never writes, and it silently invalidates any test whose consumer reads the
+    // tier the fixture skipped.
+    await applyEmissionToRollup(tx, {
+      subjectRef: input.subjectRef,
+      memexId,
+      testIdentifier,
+      status: input.status,
+      runAt: row.createdAt,
       hidden,
     });
   });

--- a/packages/server/src/services/test-helpers.ts
+++ b/packages/server/src/services/test-helpers.ts
@@ -25,6 +25,14 @@ export interface SeedTestEventInput {
   /** Defaults to server now(). Pass a past date to exercise stale / out-of-order paths. */
   createdAt?: Date;
   hidden?: boolean;
+  /**
+   * spec-520 dec-8: the emission's CI provenance. The route writes these to BOTH the log row
+   * and the summary, so a fixture that patches them onto the raw row afterwards produces a
+   * shape production never writes — and any consumer reading the summary then sees a
+   * local-only run where a CI one happened.
+   */
+  runId?: string | null;
+  metadata?: Record<string, string> | null;
 }
 
 /**
@@ -63,6 +71,8 @@ export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
         status: input.status,
         testIdentifier,
         hidden,
+        runId: input.runId ?? null,
+        metadata: input.metadata ?? null,
         ...(input.createdAt ? { createdAt: input.createdAt } : {}),
       })
       .returning({ createdAt: testEvents.createdAt });
@@ -73,6 +83,8 @@ export async function seedTestEvent(input: SeedTestEventInput): Promise<void> {
       status: input.status,
       latestRunAt: row.createdAt,
       hidden,
+      runId: input.runId ?? null,
+      metadata: input.metadata ?? null,
     });
     // spec-520 t-9: the third tier. Keep this in step with routes/test-events.ts —
     // a fixture that maintains only some of the tiers is the shape production

--- a/packages/ui/src/api/acs.ts
+++ b/packages/ui/src/api/acs.ts
@@ -134,9 +134,20 @@ export interface AcTestMatrixRow {
   /** test_identifier as emitted by the helper; empty string when the
    *  source row had a NULL test_identifier (legacy / hand-rolled emit). */
   testIdentifier: string;
-  /** Every emission ever recorded for this (acUid, testIdentifier),
-   *  newest-first. Per b-96 dec-11: one entry per emission, no run-batching. */
+  /** Every RETAINED emission for this (acUid, testIdentifier), newest-first.
+   *  Per b-96 dec-11: one entry per emission, no run-batching. */
   emissions: TestMatrixEmission[];
+  /**
+   * spec-520 dec-9 (ac-42): the pair's last known state, carried forward from the
+   * durable summary when no emission for it survives retention. Null whenever
+   * `emissions` is non-empty.
+   *
+   * Not an emission, and deliberately not in the list above: it is older than the
+   * matrix's axis window, so it must be rendered as text rather than positioned as a
+   * square claiming a run inside that window. Optional so a response from a server
+   * predating the field still renders.
+   */
+  carriedForward?: { status: TestEventStatus; emittedAt: string } | null;
 }
 
 export async function fetchAcTestMatrix(

--- a/packages/ui/src/api/acs.ts
+++ b/packages/ui/src/api/acs.ts
@@ -60,6 +60,16 @@ export interface AcAlignmentDay {
   kind: AcKind;
   verified: number;
   total: number;
+  /**
+   * spec-520 ac-5. False for days that predate the per-day rollup's first row for this
+   * Memex — days the server CANNOT measure, because the per-day past was destroyed by
+   * retention and cannot be reconstructed. Their `verified: 0` is an absence of
+   * measurement, not a measured absence, and must never be drawn as a flat zero line.
+   *
+   * Optional so a response from a server predating the flag still renders: absent is
+   * treated as measured, which is exactly the pre-flag behaviour.
+   */
+  measured?: boolean;
 }
 
 export async function fetchAcsForBrief(

--- a/packages/ui/src/components/AcPanel.tsx
+++ b/packages/ui/src/components/AcPanel.tsx
@@ -132,24 +132,41 @@ function relativeTime(d: Date | null): string {
 // The alignment-history endpoint returns one row per (date, kind). The
 // unified header sums verified + total across kinds so the sparkline reflects
 // one health curve, not two stacked ones.
-function mergeAlignmentHistory(history: AcAlignmentDay[]): AcAlignmentDay[] {
-  const byDate = new Map<string, { verified: number; total: number }>();
+//
+// Exported for test only: it is the single path feeding the sparkline, so a regression
+// here is invisible in every chart-level assertion.
+export function mergeAlignmentHistory(history: AcAlignmentDay[]): AcAlignmentDay[] {
+  const byDate = new Map<
+    string,
+    { verified: number; total: number; measured: boolean }
+  >();
   for (const h of history) {
-    const entry = byDate.get(h.date) ?? { verified: 0, total: 0 };
+    const entry = byDate.get(h.date) ?? {
+      verified: 0,
+      total: 0,
+      measured: true,
+    };
     entry.verified += h.verified;
     entry.total += h.total;
+    // spec-520 ac-5: `measured` is a property of the DAY, so both kinds carry the same
+    // value and AND-ing is a no-op today. It is written as an AND rather than an
+    // overwrite so that if the two ever disagree the chart under-claims — the safe
+    // direction. Dropping the flag here would leave the sparkline's whole boundary
+    // treatment as dead code, since this is the only path that feeds it.
+    entry.measured = entry.measured && h.measured !== false;
     byDate.set(h.date, entry);
   }
   return Array.from(byDate.entries())
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, { verified, total }]) => ({
-      // `kind` is unused by the sparkline (it only reads date/verified/total)
+    .map(([date, { verified, total, measured }]) => ({
+      // `kind` is unused by the sparkline (it only reads date/verified/total/measured)
       // but the type requires the field, so we tag the merged rows as 'scope'
       // arbitrarily. Don't read this value downstream.
       date,
       kind: 'scope' as const,
       verified,
       total,
+      measured,
     }));
 }
 

--- a/packages/ui/src/components/AcSparkline.boundary.test.tsx
+++ b/packages/ui/src/components/AcSparkline.boundary.test.tsx
@@ -1,0 +1,170 @@
+// spec-520 ac-40 — the alignment sparkline declares where its history actually begins.
+//
+// The per-day rollup ships mid-history. Every day before its first row is a day we CANNOT
+// measure: the per-day past was destroyed by retention and cannot be reconstructed. The
+// server marks those days `measured: false`.
+//
+// Drawing them as a flat 0% line would be the exact misreading ac-5 forbids — a deleted
+// past rendering as a measured absence of green, which reads as "this Spec was red for a
+// month" when the truth is "we were not counting yet". So: no line over unmeasured days,
+// a visibly distinct band, and a note that names the first day we can actually vouch for.
+//
+// The span shrinks on its own as history accumulates and eventually disappears, so this is
+// a treatment that retires itself rather than a permanent caveat.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AcSparkline } from './AcSparkline';
+import type { AcAlignmentDay } from '../api/client';
+
+const AC_BOUNDARY =
+  'mindset-prod/memex-building-itself/specs/spec-520/acs/ac-40';
+
+function day(
+  date: string,
+  verified: number,
+  total: number,
+  measured: boolean,
+): AcAlignmentDay {
+  return { date, kind: 'scope', verified, total, measured };
+}
+
+/** Count the drawn vertices — `M` plus one per `L`. */
+function vertexCount(container: HTMLElement): number {
+  const d = container.querySelector('path')?.getAttribute('d') ?? '';
+  if (!d) return 0;
+  return (d.match(/[ML]/g) ?? []).length;
+}
+
+describe('AcSparkline · unmeasured history', () => {
+  it('draws no line across days the rollup cannot vouch for', () => {
+    tagAc(AC_BOUNDARY);
+    const { container } = render(
+      <AcSparkline
+        data={[
+          day('2026-08-24', 0, 2, false),
+          day('2026-08-25', 0, 2, false),
+          day('2026-08-26', 1, 2, true),
+          day('2026-08-27', 2, 2, true),
+          day('2026-08-28', 2, 2, true),
+        ]}
+      />,
+    );
+    // Three measured days → three vertices. A line drawn over all five would put the
+    // curve at 0% for two days nobody measured.
+    expect(vertexCount(container)).toBe(3);
+  });
+
+  it('names the first day it can vouch for', () => {
+    tagAc(AC_BOUNDARY);
+    render(
+      <AcSparkline
+        data={[
+          day('2026-08-24', 0, 2, false),
+          day('2026-08-27', 2, 2, true),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/no history before 2026-08-27/i)).toBeInTheDocument();
+  });
+
+  it('says nothing when every day is measured', () => {
+    tagAc(AC_BOUNDARY);
+    render(
+      <AcSparkline
+        data={[
+          day('2026-08-27', 1, 2, true),
+          day('2026-08-28', 2, 2, true),
+        ]}
+      />,
+    );
+    // The note must retire itself once history covers the window, or it becomes furniture
+    // that everyone learns to ignore.
+    expect(screen.queryByText(/no history before/i)).not.toBeInTheDocument();
+  });
+
+  it('explains the boundary on hover instead of reporting a measured zero', () => {
+    tagAc(AC_BOUNDARY);
+    // The interaction a reader trusts most. Excluding unmeasured days from the LINE while
+    // the tooltip still says "0/2 verified · 0%" over them puts the forbidden statement
+    // back on screen in the one place someone went looking for detail. Hover is where the
+    // boundary should get explained, not where it leaks.
+    const { container } = render(
+      <AcSparkline
+        data={[
+          day('2026-08-24', 0, 2, false),
+          day('2026-08-27', 2, 2, true),
+          day('2026-08-28', 2, 2, true),
+        ]}
+      />,
+    );
+    const svg = container.querySelector('svg')!;
+    svg.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 320, height: 48 }) as DOMRect;
+
+    fireEvent.mouseMove(svg, { clientX: 0 });
+    expect(screen.queryByText(/0%/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/verified/)).not.toBeInTheDocument();
+    expect(screen.getByText(/not measured/i)).toBeInTheDocument();
+
+    // …and a measured day still reports its numbers.
+    fireEvent.mouseMove(svg, { clientX: 320 });
+    expect(screen.getByText(/2\/2 verified/)).toBeInTheDocument();
+  });
+
+  it('treats a response with no `measured` field as measured', () => {
+    tagAc(AC_BOUNDARY);
+    // Backward compatibility with a server that predates the flag: the absence of the
+    // field must not paint the whole chart as unmeasured.
+    const legacy = [
+      { date: '2026-08-27', kind: 'scope', verified: 1, total: 2 },
+      { date: '2026-08-28', kind: 'scope', verified: 2, total: 2 },
+    ] as unknown as AcAlignmentDay[];
+    const { container } = render(<AcSparkline data={legacy} />);
+    expect(vertexCount(container)).toBe(2);
+    expect(screen.queryByText(/no history before/i)).not.toBeInTheDocument();
+  });
+
+  it('reports the whole window as unmeasured rather than as a flat zero', () => {
+    tagAc(AC_BOUNDARY);
+    const { container } = render(
+      <AcSparkline
+        data={[
+          day('2026-08-27', 0, 2, false),
+          day('2026-08-28', 0, 2, false),
+        ]}
+      />,
+    );
+    // A brand-new Memex, or any tenant on the day the rollup ships. A flat 0% line here
+    // would be the strongest form of the same lie.
+    expect(vertexCount(container)).toBe(0);
+    expect(screen.getByText(/no alignment history yet/i)).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// The wiring that decides whether any of the above reaches a user.
+// ─────────────────────────────────────────────────────────────────────────
+//
+// The panel merges the server's per-(date, kind) rows into one curve before handing them
+// to the sparkline. That merge is the ONLY path into the chart, so a merge that drops
+// `measured` leaves every assertion above passing while the real screen still draws a flat
+// zero line across a month nobody measured.
+
+describe('AcPanel · the kind-merge preserves the boundary flag', () => {
+  it('keeps a day unmeasured through the merge of both kinds', async () => {
+    tagAc(AC_BOUNDARY);
+    const { mergeAlignmentHistory } = await import('./AcPanel');
+    const merged = mergeAlignmentHistory([
+      { date: '2026-08-24', kind: 'scope', verified: 0, total: 1, measured: false },
+      { date: '2026-08-24', kind: 'implementation', verified: 0, total: 2, measured: false },
+      { date: '2026-08-25', kind: 'scope', verified: 1, total: 1, measured: true },
+      { date: '2026-08-25', kind: 'implementation', verified: 2, total: 2, measured: true },
+    ]);
+    expect(merged.map((d) => [d.date, d.total, d.measured])).toEqual([
+      ['2026-08-24', 3, false],
+      ['2026-08-25', 3, true],
+    ]);
+  });
+});

--- a/packages/ui/src/components/AcSparkline.tsx
+++ b/packages/ui/src/components/AcSparkline.tsx
@@ -11,12 +11,24 @@
 //
 // Behaviour:
 //   - Empty data        → renders the baseline + a "no history yet" hint.
+//   - Unmeasured days   → NOT drawn (spec-520 ac-5). Days before the per-day rollup's
+//                         first row cannot be measured — the past was deleted by
+//                         retention — so a flat 0% line there would read as "this Spec
+//                         was red for a month" when the truth is "we were not counting
+//                         yet". The span is shaded, excluded from the path, and named
+//                         below the chart. It shrinks on its own and eventually goes
+//                         away, so it is a treatment that retires itself.
 //   - One data point    → renders as a tiny dot, no path.
 //   - All-100% data     → flat green line at the top. Looks like a flat
 //                         green line, which is exactly the message.
 //   - Hover             → vertical guide line + a small tooltip showing
 //                         date + verified/total + percentage for the point
-//                         under the cursor. Snaps to the nearest x.
+//                         under the cursor. Snaps to the nearest x. Over an
+//                         UNMEASURED day it says so instead of reporting a
+//                         percentage: the guide still tracks (so the shaded
+//                         span is explorable rather than dead) but there is no
+//                         dot on the baseline and no "0%" — that number would
+//                         be the exact claim the shading exists to deny.
 //
 // Y-axis is fixed 0..100 (absolute %, not stretched to data range).
 // X-axis is index-based (day count). Coordinates: SVG y grows downward, so
@@ -39,6 +51,11 @@ export interface AcSparklineProps {
 function percent(d: AcAlignmentDay): number {
   if (d.total === 0) return 0;
   return (d.verified / d.total) * 100;
+}
+
+// Absent means "server predates the flag" — treat as measured so nothing regresses.
+function isMeasured(d: AcAlignmentDay): boolean {
+  return d.measured !== false;
 }
 
 export function AcSparkline({
@@ -81,16 +98,32 @@ export function AcSparkline({
         : padX + (i / (data.length - 1)) * usableW;
     const pct = percent(d);
     const y = padY + (1 - pct / 100) * usableH;
-    return { x, y, pct, date: d.date, verified: d.verified, total: d.total };
+    return {
+      x, y, pct,
+      date: d.date,
+      verified: d.verified,
+      total: d.total,
+      measured: isMeasured(d),
+    };
   });
 
-  const path =
-    points.length >= 2
-      ? `M ${points[0].x} ${points[0].y} ` +
-        points.slice(1).map((p) => `L ${p.x} ${p.y}`).join(' ')
-      : '';
+  // The unmeasured span is always a PREFIX — coverage is "every day at or after the
+  // rollup's first row", so it cannot have holes. Taking the first measured index rather
+  // than filtering keeps that assumption visible: if the server ever sends a gap, the
+  // chart draws through it instead of silently stitching two eras into one line.
+  const firstMeasured = points.findIndex((p) => p.measured);
+  const drawn = firstMeasured === -1 ? [] : points.slice(firstMeasured);
+  const unmeasuredCount = firstMeasured === -1 ? points.length : firstMeasured;
 
-  const lastPoint = points[points.length - 1];
+  const path =
+    drawn.length >= 2
+      ? `M ${drawn[0].x} ${drawn[0].y} ` +
+        drawn.slice(1).map((p) => `L ${p.x} ${p.y}`).join(' ')
+      : drawn.length === 1
+        ? `M ${drawn[0].x} ${drawn[0].y}`
+        : '';
+
+  const lastPoint = drawn[drawn.length - 1];
   const hovered = hoverIndex !== null ? points[hoverIndex] : null;
 
   function handleMove(e: React.MouseEvent<SVGSVGElement>) {
@@ -112,7 +145,7 @@ export function AcSparkline({
 
   return (
     <div ref={containerRef} className={`relative ${className ?? ''}`}>
-      {data.length === 0 ? (
+      {drawn.length === 0 ? (
         <div className="text-xs text-muted italic py-2">
           No alignment history yet.
         </div>
@@ -123,13 +156,24 @@ export function AcSparkline({
             height={height}
             viewBox={`0 0 ${width} ${height}`}
             role="img"
-            aria-label={`Alignment over ${data.length} days, currently ${
+            aria-label={`Alignment over ${drawn.length} measured days, currently ${
               lastPoint ? Math.round(lastPoint.pct) : 0
             }% verified`}
             onMouseMove={handleMove}
             onMouseLeave={() => setHoverIndex(null)}
             style={{ display: 'block' }}
           >
+            {/* The span we cannot vouch for — drawn FIRST so the chart sits on top. */}
+            {unmeasuredCount > 0 && drawn.length > 0 && (
+              <rect
+                x={padX}
+                y={padY}
+                width={Math.max(0, drawn[0].x - padX)}
+                height={usableH}
+                fill="currentColor"
+                fillOpacity={0.05}
+              />
+            )}
             {/* Baseline + top dashed line so the band reads as a chart. */}
             <line
               x1={padX}
@@ -160,7 +204,8 @@ export function AcSparkline({
                 strokeLinecap="round"
               />
             )}
-            {/* Hover guide line + dot. */}
+            {/* Hover guide line + dot. No dot on an unmeasured day: it would sit on
+                the 0% baseline and read as a measured zero. */}
             {hovered && (
               <>
                 <line
@@ -172,7 +217,9 @@ export function AcSparkline({
                   strokeOpacity={0.3}
                   strokeWidth={1}
                 />
-                <circle cx={hovered.x} cy={hovered.y} r={4} fill={stroke} />
+                {hovered.measured && (
+                  <circle cx={hovered.x} cy={hovered.y} r={4} fill={stroke} />
+                )}
               </>
             )}
             {/* The persistent "where are we now" dot at the last point. */}
@@ -180,6 +227,12 @@ export function AcSparkline({
               <circle cx={lastPoint.x} cy={lastPoint.y} r={3} fill={stroke} />
             )}
           </svg>
+          {/* Says on the chart's face where its history begins (spec-520 ac-5). */}
+          {unmeasuredCount > 0 && drawn.length > 0 && (
+            <div className="text-[11px] text-muted italic mt-1">
+              No history before {drawn[0].date} — per-day counts start there.
+            </div>
+          )}
           {/* Tooltip — positioned in CSS so it can extend outside the SVG. */}
           {hovered && (
             <div
@@ -190,10 +243,16 @@ export function AcSparkline({
               }}
             >
               <div className="font-medium">{hovered.date}</div>
-              <div>
-                {hovered.verified}/{hovered.total} verified ·{' '}
-                {hovered.total === 0 ? '—' : `${Math.round(hovered.pct)}%`}
-              </div>
+              {hovered.measured ? (
+                <div>
+                  {hovered.verified}/{hovered.total} verified ·{' '}
+                  {hovered.total === 0 ? '—' : `${Math.round(hovered.pct)}%`}
+                </div>
+              ) : (
+                <div>
+                  Not measured — counts start {drawn[0]?.date ?? 'later'}
+                </div>
+              )}
             </div>
           )}
         </>

--- a/packages/ui/src/components/TestMatrix.carryForward.test.tsx
+++ b/packages/ui/src/components/TestMatrix.carryForward.test.tsx
@@ -1,0 +1,78 @@
+// spec-520 dec-9 (ac-42) — a row whose emissions have all left the retention window shows
+// its last known state instead of a blank strip.
+//
+// Measured on prod 2026-08-30, before any swap: 196,978 of 243,339 pairs had not run in
+// three days. Under the time window t-12 introduces, four out of five rows would render an
+// empty strip beneath a "Verified" badge — the badge reads test_event_latest, which
+// retention never touches, and the strip reads the log. A blank strip asserts "no evidence";
+// the truth is "the evidence aged out, and here is what it said".
+//
+// The carried-forward state is NOT an emission and must never reach the strip's time axis:
+// it is months older than the window, so positioning it as a square would put it off the
+// axis and claim a run that the log no longer holds.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { TestMatrix } from './TestMatrix';
+import type { AcTestMatrixRow } from '../api/client';
+
+const AC_CARRY = 'mindset-prod/memex-building-itself/specs/spec-520/acs/ac-42';
+
+const NOW = new Date('2026-08-30T12:00:00Z').getTime();
+
+function darkRow(id: string, status: 'pass' | 'fail'): AcTestMatrixRow {
+  return {
+    testIdentifier: id,
+    emissions: [],
+    carriedForward: { status, emittedAt: '2026-06-12T09:00:00.000Z' },
+  };
+}
+
+function liveRow(id: string): AcTestMatrixRow {
+  return {
+    testIdentifier: id,
+    emissions: [{ status: 'pass', emittedAt: '2026-08-30T11:00:00.000Z' }],
+    carriedForward: null,
+  };
+}
+
+describe('TestMatrix · carried-forward rows', () => {
+  it('shows the last known state where the strip would otherwise be blank', () => {
+    tagAc(AC_CARRY);
+    render(<TestMatrix rows={[darkRow('a::t', 'pass')]} now={NOW} />);
+    const strip = screen.getByTestId('test-matrix-strip');
+    expect(strip.textContent).toMatch(/last known/i);
+    // The date matters: "last known: passed" with no WHEN is nearly as misleading as a
+    // blank strip. Computed here rather than hardcoded, so the assertion does not depend
+    // on the runner's locale.
+    const shown = new Date('2026-06-12T09:00:00.000Z').toLocaleDateString();
+    expect(strip.textContent).toContain(shown);
+    // …and hovering explains why the strip is empty, not just what it last said.
+    expect(within(strip).getByTitle(/no retained emissions/i)).toBeInTheDocument();
+  });
+
+  it('does not place the carried-forward state on the time axis', () => {
+    tagAc(AC_CARRY);
+    const { container } = render(<TestMatrix rows={[darkRow('a::t', 'pass')]} now={NOW} />);
+    // No emission square: a June point on an axis whose left edge is 30 days back would be
+    // positioned off the strip, and it would assert a run inside the window.
+    expect(container.querySelectorAll('[data-testid="emission-square"]')).toHaveLength(0);
+  });
+
+  it('carries a RED state forward as red', () => {
+    tagAc(AC_CARRY);
+    render(<TestMatrix rows={[darkRow('a::t', 'fail')]} now={NOW} />);
+    const strip = screen.getByTestId('test-matrix-strip');
+    // Carrying only greens forward would make the fallback a way of hiding failures.
+    expect(strip.textContent).toMatch(/fail/i);
+  });
+
+  it('leaves a row that still has emissions completely alone', () => {
+    tagAc(AC_CARRY);
+    render(<TestMatrix rows={[liveRow('a::t')]} now={NOW} />);
+    const strip = screen.getByTestId('test-matrix-strip');
+    expect(strip.textContent).not.toMatch(/last known/i);
+    expect(strip.querySelectorAll('[data-testid="emission-square"]').length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/components/TestMatrix.tsx
+++ b/packages/ui/src/components/TestMatrix.tsx
@@ -262,6 +262,7 @@ function EmissionSquare({
 
   return (
     <span
+      data-testid="emission-square"
       className="group/sq absolute inline-block"
       style={{ left: leftPx, top: 0 }}
     >
@@ -392,6 +393,23 @@ export function TestMatrix({
                     leftPx={em.leftPx}
                   />
                 ))}
+                {/* spec-520 dec-9 (ac-42): every emission for this pair has left the
+                    retention window. A blank strip asserts "no evidence"; the truth is
+                    "the evidence aged out, and this is what it last said". Rendered as
+                    TEXT, never as a square — the state is months older than the axis
+                    window, so positioning it would put it off the strip and claim a run
+                    inside a window it is not in. */}
+                {positioned.length === 0 && row.carriedForward && (
+                  <span
+                    className="absolute inset-y-0 left-0 flex items-center whitespace-nowrap text-[11px] italic text-zinc-500 dark:text-zinc-400"
+                    title={`No retained emissions — last known state, recorded ${new Date(
+                      row.carriedForward.emittedAt,
+                    ).toLocaleString()}`}
+                  >
+                    last known: {STATUS_LABEL[row.carriedForward.status]} ·{' '}
+                    {formatAxisDate(new Date(row.carriedForward.emittedAt).getTime())}
+                  </span>
+                )}
               </div>
               <span className="shrink-0">
                 {renderRowAction ? renderRowAction(row) : null}

--- a/packages/ui/src/pages/Pulse.test.tsx
+++ b/packages/ui/src/pages/Pulse.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -467,3 +467,111 @@ describe('Pulse page', () => {
 
 // Placate the unused-import linter if `within` ends up unused in some refactors.
 void within;
+
+// ── spec-520 t-6 (ac-16 / ac-17 / ac-18): the poll pauses while the tab is hidden ──
+//
+// Pulse polls fetchDocs('spec', { include: ['acHealth'] }) every 15s. Leaving the route
+// already stopped it; being merely HIDDEN did not — a Pulse tab on a second monitor kept
+// firing for nobody, and each tick is the AC-health aggregate, 640–790 ms server-side on
+// prod. AcPanel, DecisionPanel and HomeValue all already gate on document.visibilityState;
+// this pins Pulse to the same behaviour.
+//
+// ⚠ FAKE TIMERS MUST BE INSTALLED BEFORE render(). Installing them afterwards does not
+// adopt the interval the mount already scheduled on the real clock, so advancing fake time
+// does nothing and the assertion reads as "the poll never fired" — which is exactly what a
+// correctly-paused poll looks like. Two of these three tests passed for that wrong reason
+// on the first draft.
+//
+// jsdom's document.visibilityState is a readonly getter, so it is redefined per test and
+// deleted after [per std-37 cl-5] — leaving it patched would silently change every later
+// test in this file.
+describe('Pulse — the AC-health poll pauses while the tab is hidden (spec-520 t-6)', () => {
+  const AC520 = (n: number) =>
+    `mindset-prod/memex-building-itself/specs/spec-520/acs/ac-${n}`;
+
+  function setVisibility(state: 'visible' | 'hidden') {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  afterEach(() => {
+    // Restore jsdom's own getter rather than pinning 'visible' — a pinned value is
+    // indistinguishable from the real one until something depends on it changing.
+    delete (document as unknown as Record<string, unknown>).visibilityState;
+    vi.useRealTimers();
+  });
+
+  /** Mount with fake timers already running, and flush the mount's own fetch. */
+  async function mountWithFakeTimers() {
+    vi.useFakeTimers();
+    const view = renderPulse();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchDocsMock).toHaveBeenCalled();
+    fetchDocsMock.mockClear();
+    return view;
+  }
+
+  it('polls on a 15s interval while visible, and issues nothing while hidden [ac-16][ac-18]', async () => {
+    tagAc(AC520(16));
+    tagAc(AC520(18));
+
+    await mountWithFakeTimers();
+
+    // Visible: the interval is unchanged at 15s (ac-18). Asserted BEFORE hiding, so a
+    // paused-from-the-start poll cannot pass this test by never firing at all.
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    fetchDocsMock.mockClear();
+
+    // Three full intervals with the tab hidden must produce nothing (ac-16).
+    await vi.advanceTimersByTimeAsync(45_000);
+    expect(fetchDocsMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes once immediately on becoming visible rather than waiting out the interval [ac-17]', async () => {
+    tagAc(AC520(17));
+
+    await mountWithFakeTimers();
+
+    setVisibility('hidden');
+    await vi.advanceTimersByTimeAsync(30_000);
+    fetchDocsMock.mockClear();
+
+    // The point of ac-17: a returning user must not read AC health that is up to 15s
+    // stale while the resumed interval counts down. The refresh is immediate — asserted
+    // with the clock advanced by ZERO.
+    setVisibility('visible');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    // …and the interval genuinely resumed, rather than the tab-show refresh being the
+    // only thing left alive.
+    fetchDocsMock.mockClear();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still stops on unmount, so leaving the route ends the poll [ac-18]', async () => {
+    tagAc(AC520(18));
+
+    const view = await mountWithFakeTimers();
+
+    // Prove the poll was actually running first — otherwise the assertion below is
+    // vacuous and would hold against a component that never polled.
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchDocsMock).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    fetchDocsMock.mockClear();
+
+    // The pre-existing guarantee. The visibility gate adds a second stop condition; it
+    // must not have replaced this one.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchDocsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/Pulse.tsx
+++ b/packages/ui/src/pages/Pulse.tsx
@@ -126,10 +126,51 @@ export function Pulse() {
       .catch(() => {})
       .finally(() => setSpecsLoading(false));
   }, []);
+  // Initial fetch + polling, paused while the tab is hidden (spec-520 t-6,
+  // ac-16/17/18).
+  //
+  // Leaving the route already stopped this — the interval clears on unmount and
+  // refreshSpecs is a stable useCallback([]). What it did NOT do is stop when the tab is
+  // merely hidden, so a Pulse tab on a second monitor or behind another window kept
+  // firing every 15 seconds for nobody. Each tick is the AC-health aggregate, measured at
+  // 640–790 ms server-side on prod, so an idle backgrounded tab was not free.
+  //
+  // This is the established local pattern, not a new one: AcPanel, DecisionPanel and
+  // HomeValue all start/stop on document.visibilityState. Pulse was the outlier — copied
+  // from AcPanel deliberately so the four read the same.
+  //
+  // The interval stays 15s. Whether Pulse should poll AT ALL is spec-408 dec-4's
+  // question (the same one for the presence band on this page) and is not settled here;
+  // the bus does not currently carry AC-health changes, which SpecList.tsx documents.
   useEffect(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
     refreshSpecs();
-    const id = setInterval(refreshSpecs, 15_000);
-    return () => clearInterval(id);
+    const start = () => {
+      if (timer !== null) return;
+      timer = setInterval(refreshSpecs, 15_000);
+    };
+    const stop = () => {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+    const onVisChange = () => {
+      if (document.visibilityState === 'visible') {
+        // Refresh once on tab-show rather than waiting out the remainder of the
+        // interval, so a returning user never reads stale AC health (ac-17).
+        refreshSpecs();
+        start();
+      } else {
+        stop();
+      }
+    };
+    if (document.visibilityState === 'visible') start();
+    document.addEventListener('visibilitychange', onVisChange);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisChange);
+    };
   }, [refreshSpecs]);
 
   const pickerSpecs: SpecPickerSpec[] = useMemo(


### PR DESCRIPTION
16 commits, **5 in-band migrations**, all live and green on int.

> Per std-21 this PR **is** the decision to ship: merging deploys prod.

## What ships

**`test_events` becomes time-partitioned and the per-pair retention trim is deleted.** The trim ran inside every emission transaction — the largest single statement in the path. Rows now leave only when an aged-out partition is dropped, which is a catalogue operation: no deletes, no dead tuples, nothing for autovacuum to chase.

**Both history charts stop reading a table retention had already emptied.** Prod declared 23.7M runs while 1.07M rows survived — the charts were seeing 4.5%, and worst where activity was highest.

**The AC tab stops contradicting itself.** 81% of pairs hold no row inside a 3-day window; they now report *"last known: passed · 12/06"* instead of an empty grid under a green badge. And the alignment sparkline marks the days it cannot measure rather than drawing them as a flat zero.

Plus: the rollup gains its cascading tenant FK, `ac_first_verified` gains the tenancy column it never had, and four per-event costs are removed or throttled.

## Pre-deploy checks — all done

| | |
|---|---|
| int deploy for this SHA | ✅ green (the prod gate's own precondition) |
| e2e journeys | ✅ 157/157, cold DB, partitioned schema, clean worktree |
| out-of-band `0141` applied to prod | ✅ index built `CONCURRENTLY` in 2.07s, `indisvalid = t`, 55 MB |
| backups | ✅ 6 consecutive SUCCESSFUL, latest <24h; **PITR on, 7 days** of transaction logs |
| migration rehearsed under load | ✅ 1.5M rows, 8 concurrent writers, **1.006s** exclusive window, zero writer errors, no `40P01`/`55P03` |
| pre-deploy measurement captured | ✅ emission path at **32.518%** of DB time (delta, c-20) |
| rollback path | ✅ written **and executed** against a probe DB (`drizzle/reverts/0142_*.revert.sql`) |

## After the merge

1. **Verify emission positively** — `scratchpad/verify-emission-after-deploy.sh prod`. This Spec modifies the machinery that reports whether ACs pass; break it and the failure hides itself, because the emitter swallows its own errors by design. Emit a known event, confirm it lands in **all three tiers**.
2. **`n_tup_del` on `test_events` must stop advancing** — that is ac-13, and it is binary. Read it twice a few minutes apart.
3. **The after-measurement** takes several windows, not one: two pre-deploy windows ten minutes apart disagreed by 2x, so a single comparison could land either way (c-20).

## If it goes wrong

**Redeploy the previous revision — do not revert the schema.** The old code runs unchanged against the partitioned table; verified. The trim simply starts deleting again: wasteful, not wrong.

The migration itself destroys nothing. Data starts disappearing at the first partition DROP — roughly four days out, and only on a deploy. PITR covers 7 days, so the true recovery window outlasts it.