### PR TITLE
chore(spec-520): move the post-deploy ops scripts into the repo (t-14)

### DIFF
--- a/packages/server/scripts/ops/day-after-check.sh
+++ b/packages/server/scripts/ops/day-after-check.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# spec-520 — the day-after check. Things that could not be observed on deploy day.
+#
+# Read-only. Answers four questions the first 24 hours make answerable:
+#   1. Are rows routing to a DAILY partition now? (yesterday everything went to legacy)
+#   2. Is n_tup_del still frozen across a full day of traffic? (ac-13, now unarguable)
+#   3. Is the table growing at the predicted rate? (dec-9 was corrected to ~5M/day, c-21)
+#   4. Is there traffic RIGHT NOW, i.e. can the ac-4 after-measurement be taken?
+set -uo pipefail
+cd "$(dirname "$0")/../../../.."
+export ENV=prod DEPLOY_CONFIG_PROJECT=memex-ai-prod
+source scripts/deploy-config.sh || exit 1
+PORT=15459
+cloud-sql-proxy "$CLOUD_SQL_INSTANCE_CONN" --port "$PORT" >/dev/null 2>&1 &
+P=$!; trap 'kill $P 2>/dev/null || true' EXIT
+for i in $(seq 1 30); do
+  PGPASSWORD="$DB_PASS" psql -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -c 'SELECT 1' >/dev/null 2>&1 && break
+  sleep 1
+done
+Q() { PGPASSWORD="$DB_PASS" psql -q -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -c "SET default_transaction_read_only=on; $1"; }
+
+echo "══ 1. WHERE ARE ROWS LANDING NOW? (yesterday: all in test_events_legacy) ══"
+Q "SELECT tableoid::regclass::text AS partition, count(*),
+          min(created_at)::timestamp(0) AS oldest, max(created_at)::timestamp(0) AS newest
+   FROM test_events GROUP BY 1 ORDER BY 3 DESC NULLS LAST LIMIT 6;"
+echo "   A daily partition (test_events_YYYYMMDD) holding recent rows = routing works past the boundary."
+
+echo ""
+echo "══ 2. ac-13 — n_tup_del across a full day of traffic ══"
+Q "SELECT sum(n_tup_ins) AS ins, sum(n_tup_del) AS del, sum(n_live_tup) AS live, count(*) AS relations
+   FROM pg_stat_user_tables WHERE relname='test_events' OR relname LIKE 'test\_events\_%';"
+echo "   del was 38,723,340 on 2026-08-31 (c-22/c-23). Unchanged after a day of traffic"
+echo "   is the strongest form this evidence can take."
+
+echo ""
+echo "══ 3. growth rate — dec-9 was corrected to ~5M rows/day (c-21) ══"
+Q "SELECT date_trunc('day', created_at)::date AS day, count(*),
+          pg_size_pretty(sum(pg_column_size(t.*))) AS approx_bytes
+   FROM test_events t GROUP BY 1 ORDER BY 1 DESC LIMIT 5;"
+
+echo ""
+echo "══ 4. is there traffic RIGHT NOW? (ac-4's after-measurement needs an active window) ══"
+Q "SELECT count(*) FILTER (WHERE created_at > now() - interval '5 minutes')  AS last_5min,
+          count(*) FILTER (WHERE created_at > now() - interval '60 minutes') AS last_hour
+   FROM test_events;"
+echo "   last_5min in the hundreds → run prod-emission-delta.sh 300 now."
+echo "   near zero → still idle; the after-measurement would read ~0% and mean nothing (c-23)."

--- a/packages/server/scripts/ops/emission-cost-delta.sh
+++ b/packages/server/scripts/ops/emission-cost-delta.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# spec-520 t-14 / ac-4 — the emission path's share of database time, as a DELTA.
+#
+#   ./emission-cost-delta.sh [WINDOW_SECONDS] [int|prod]     (default: 300 prod)
+#
+# ⚠ LIVES IN THE REPO ON PURPOSE. This was a scratchpad script for one session and was
+# wiped overnight — while t-14's post-deploy procedure still referenced it by name. A
+# procedure that does not survive a night is not a procedure.
+#
+# WHY A DELTA AND NOT A CUMULATIVE SHARE. pg_stat_statements counters run since
+# stats_reset (2026-06-25 for prod). They hold months of pre-change traffic, so after a
+# change they barely move: a statement going from 12.6% to ZERO still reads ~12%
+# cumulatively because its 21M historical calls do not disappear. Reading that as "the fix
+# did nothing" is a measurement artifact, and it has already bitten this Spec once.
+#
+# ⚠ FOUR WAYS THIS MEASUREMENT LIED BEFORE, all now guarded, all of which failed TOWARDS
+# the flattering answer:
+#   1. CREATE TEMP TABLE for the snapshot — refused under default_transaction_read_only.
+#      Both readings now go to local CSV and are differenced here; prod stays read-only.
+#   2. A dropped connection left an empty snapshot; nothing differenced against something
+#      reported "0.000%" — a triumph, on the exact criterion being measured. A short
+#      snapshot now ABORTS instead of reporting zeros.
+#   3. Patterns matched unquoted SQL only. Drizzle quotes identifiers, so the INSERT was
+#      silently dropped from the total. Matching is quote-insensitive, and any BUSY
+#      statement no pattern classified is printed.
+#   4. A window taken while traffic was idle read ~0% and meant nothing. Check there is
+#      traffic first (scripts/ops/day-after-check.sh answers this).
+#
+# And one that is not the script's fault but bites the reader: a single window is not a
+# comparator. Two windows ten minutes apart disagreed by 2x on an unchanged system. Take
+# several on each side and compare ranges.
+set -uo pipefail
+WINDOW="${1:-300}"
+ENVNAME="${2:-prod}"
+cd "$(dirname "$0")/../../../.."
+
+export ENV="$ENVNAME" DEPLOY_CONFIG_PROJECT="memex-ai-${ENVNAME}"
+source scripts/deploy-config.sh || { echo "deploy-config failed"; exit 1; }
+
+PORT=15452
+cloud-sql-proxy "$CLOUD_SQL_INSTANCE_CONN" --port "$PORT" >/dev/null 2>&1 &
+PROXY=$!
+TMP=$(mktemp -d)
+trap 'kill $PROXY 2>/dev/null || true; rm -rf "$TMP"' EXIT
+for i in $(seq 1 30); do
+  PGPASSWORD="$DB_PASS" psql -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -c 'SELECT 1' >/dev/null 2>&1 && break
+  sleep 1
+done
+Q() { PGPASSWORD="$DB_PASS" psql -q -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -At -F'|' \
+        -c "SET default_transaction_read_only = on; $1"; }
+
+echo "══ gate: has pg_stat_statements been reset since the t-1 baseline? ══"
+Q "SELECT stats_reset, stats_reset = '2026-06-25 10:04:23.277059+00'::timestamptz FROM pg_stat_statements_info;" \
+  | awk -F'|' '{printf "  stats_reset=%s   same_window_as_t1=%s\n", $1, $2}'
+
+SNAP="SELECT queryid, calls, total_exec_time, replace(left(regexp_replace(query, '\s+', ' ', 'g'), 90), '|', ' ') FROM pg_stat_statements WHERE queryid IS NOT NULL;"
+snap() {
+  for attempt in 1 2 3; do
+    if Q "$SNAP" > "$1" 2>"$TMP/err" && [ "$(wc -l < "$1")" -gt 100 ]; then return 0; fi
+    echo "  snapshot attempt $attempt failed ($(wc -l < "$1") rows) — retrying" >&2
+    sed 's/^/    /' "$TMP/err" >&2
+    sleep 3
+  done
+  echo "  ✗ ABORTING: no complete snapshot after 3 attempts. Zeros here would look like a result." >&2
+  exit 1
+}
+echo ""
+echo "══ reading 1 … waiting ${WINDOW}s … reading 2 ══"
+snap "$TMP/a" ; sleep "$WINDOW" ; snap "$TMP/b"
+echo "  (${WINDOW}s elapsed; $(wc -l < "$TMP/a") and $(wc -l < "$TMP/b") statements captured)"
+
+python3 - "$TMP/a" "$TMP/b" "$WINDOW" <<'PY'
+import sys
+a_path, b_path, window = sys.argv[1], sys.argv[2], float(sys.argv[3])
+def norm(q): return q.lower().replace('"', "")
+def load(p):
+    out = {}
+    for line in open(p):
+        parts = line.rstrip("\n").split("|")
+        if len(parts) < 4 or not parts[0].lstrip("-").isdigit(): continue
+        out[parts[0]] = (int(parts[1]), float(parts[2]), parts[3])
+    return out
+a, b = load(a_path), load(b_path)
+rows = []
+for qid, (c2, t2, q) in b.items():
+    c1, t1, _ = a.get(qid, (0, 0.0, q))
+    dc, dt = c2 - c1, t2 - t1
+    if dc > 0 and dt > 0: rows.append((dt, dc, q, norm(q)))
+total = sum(r[0] for r in rows) or 1.0
+PATTERNS = [
+    ("retention DELETE   (t-1: 12.606%)", "delete from test_events"),
+    ("test_events insert (t-1:  4.967%)", "insert into test_events"),
+    ("test_event_latest  (t-1:  2.017%)", "test_event_latest"),
+    ("ac_first_verified  (t-1:  6.073%)", "ac_first_verified"),
+    ("emission key bump  (t-1:  3.618%)", "memex_emission_keys"),
+    ("test_run_daily     (new tier)    ", "test_run_daily"),
+]
+print(f"\n══ THE EMISSION PATH over the last {int(window)}s ══")
+print(f"{'statement':36} {'%db':>7} {'calls/s':>9} {'mean ms':>9}")
+claimed, path_ms = set(), 0.0
+for label, pat in PATTERNS:
+    hit = [r for r in rows if pat in r[3]]
+    for r in hit: claimed.add(id(r))
+    if not hit:
+        print(f"{label:36} {'—':>7} {'0':>9} {'—':>9}   (no calls in window)"); continue
+    dt = sum(r[0] for r in hit); dc = sum(r[1] for r in hit)
+    path_ms += dt
+    print(f"{label:36} {100*dt/total:7.3f} {dc/window:9.3f} {dt/dc:9.4f}")
+print(f"\n  emission path total: {100*path_ms/total:.3f}%")
+print(f"  pre-deploy delta baseline (2026-08-31, c-20): 32.518%")
+missed = [r for r in rows if id(r) not in claimed
+          and any(t in r[3] for t in ("test_event","ac_first_verified","memex_emission_keys","test_run_daily"))
+          and r[1]/window >= 0.5]
+if missed:
+    print("\n  ⚠ UNCLASSIFIED but busy — touch the emission tables, matched no pattern:")
+    for dt, dc, q, _ in sorted(missed, reverse=True)[:8]:
+        print(f"     {100*dt/total:6.3f}%  {dc/window:8.2f}/s  {q[:88]}")
+else:
+    print("\n  ✓ nothing busy on these tables went unclassified.")
+PY
+
+echo ""
+echo "══ ac-13 — deletes across the WHOLE partition family, never the parent alone ══"
+Q "SELECT sum(n_tup_ins), sum(n_tup_del), sum(n_live_tup), count(*)
+     FROM pg_stat_user_tables
+    WHERE relname = 'test_events' OR relname LIKE 'test\_events\_%';" \
+  | awk -F'|' '{printf "  ins=%s  del=%s  live=%s  across %s relations\n",$1,$2,$3,$4}'
+echo "  del read 38,723,340 on 2026-08-31 and 38,723,352 a day later — +12, all from"
+echo "  explicit retirement (discontinue_test_events), not the trim. It was ~54,000/90s before."

--- a/packages/server/scripts/ops/verify-emission-landed.sh
+++ b/packages/server/scripts/ops/verify-emission-landed.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# spec-520 t-14 — POSITIVELY verify AC emission after a deploy. int first, then prod.
+#
+#   MEMEX_EMIT_KEY=mxk_... ./verify-emission-landed.sh int|prod
+#
+# ⚠ WHY "NO ALARM FIRED" IS NOT EVIDENCE. spec-520 modifies the machinery by which every
+# AC on every Spec reports whether it passes. Break it and the failure HIDES ITSELF:
+# emissions stop landing, the board keeps showing the last known state, and "no ACs went
+# red" reads as "nothing broke". The emitter swallows its own errors by design (std-48 —
+# telemetry must never fail CI), so the client cannot tell you either. The only honest
+# check is to emit a known event and confirm it arrived, in all three tiers.
+#
+# It also covers the failure mode partitioning introduced: a row whose created_at finds no
+# partition is REJECTED. That shows up as a non-201 on the POST — loud, but only if
+# somebody looks.
+set -uo pipefail
+ENVNAME="${1:-}"
+case "$ENVNAME" in
+  int)  BASE="https://int.memex.ai";  NS="mindset-int" ;;
+  prod) BASE="https://memex.ai";      NS="mindset-prod" ;;
+  *) echo "usage: MEMEX_EMIT_KEY=... $0 int|prod"; exit 2 ;;
+esac
+[ -n "${MEMEX_EMIT_KEY:-}" ] || { echo "MEMEX_EMIT_KEY is required (provision_ac_emission)"; exit 2; }
+cd "$(dirname "$0")/../../../.."
+
+AC="${AC_REF:-${NS}/memex-building-itself/specs/spec-520/acs/ac-14}"
+MARK="post-deploy-verify::$(date -u +%Y%m%dT%H%M%SZ)"
+
+echo "══ 1. emit a known event through the REAL ingest path ══"
+echo "   ac  = $AC"
+echo "   tid = $MARK"
+BODY=$(mktemp)
+CODE=$(curl -s -o "$BODY" -w '%{http_code}' -X POST "$BASE/api/test-events" \
+  -H "Authorization: Bearer $MEMEX_EMIT_KEY" -H 'Content-Type: application/json' \
+  -d "{\"ac_uid\":\"$AC\",\"status\":\"pass\",\"test_identifier\":\"$MARK\",\"duration_ms\":1}")
+echo "   HTTP $CODE"
+if [ "$CODE" != "201" ]; then
+  echo "   ✗ THE INGEST PATH IS BROKEN. Body:"; sed 's/^/     /' "$BODY"; rm -f "$BODY"
+  echo "   After a partitioning deploy, suspect first: 'no partition of relation found for"
+  echo "   row' — the forward horizon ran out and maintenance has not run."
+  exit 1
+fi
+rm -f "$BODY"; echo "   ✓ accepted"
+
+echo ""
+echo "══ 2. confirm it LANDED in all three tiers (201 only proves the route accepted it) ══"
+export ENV="$ENVNAME" DEPLOY_CONFIG_PROJECT="memex-ai-${ENVNAME}"
+source scripts/deploy-config.sh || { echo "   deploy-config failed"; exit 1; }
+PORT=15453
+cloud-sql-proxy "$CLOUD_SQL_INSTANCE_CONN" --port "$PORT" >/dev/null 2>&1 &
+PROXY=$!; trap 'kill $PROXY 2>/dev/null || true' EXIT
+for i in $(seq 1 30); do
+  PGPASSWORD="$DB_PASS" psql -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -c 'SELECT 1' >/dev/null 2>&1 && break
+  sleep 1
+done
+PGPASSWORD="$DB_PASS" psql -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d "$DB_NAME" <<SQL
+SET default_transaction_read_only = on;
+\echo '  -- tier 1: the raw log, and WHICH PARTITION it routed to --'
+SELECT tableoid::regclass::text AS partition, status, created_at FROM test_events WHERE test_identifier = '${MARK}';
+\echo '  -- tier 2: the summary the badge reads --'
+SELECT latest_status, latest_run_at, run_count FROM test_event_latest WHERE test_identifier = '${MARK}';
+\echo '  -- tier 3: the per-day rollup the charts read --'
+SELECT day, run_count, pass_count FROM test_run_daily WHERE test_identifier = '${MARK}';
+SQL
+
+echo ""
+echo "  A MISSING tier is the interesting failure:"
+echo "    no tier 1 → the insert was rejected (partition? RLS?)"
+echo "    no tier 2 → applyEmissionToSummary failed; the badge goes stale silently"
+echo "    no tier 3 → the rollup upsert failed; both history charts flatten with no error"
+echo ""
+echo "  ⚠ THEN RETIRE THE PROBE, or it lingers as a fake test on the AC (std-48):"
+echo "    discontinue_test_events(ref: '$AC', test_identifier: '$MARK')"
+echo "    (each retirement is a real row delete — it is why n_tup_del ticks up by a few a day)"


### PR DESCRIPTION
t-14's post-deploy procedure referenced three scripts **by name**. All three lived in a session scratchpad under `/tmp`, and **the scratchpad was wiped overnight** — while the procedure still pointed at them.

A procedure that does not survive a night is not a procedure. They now live in `packages/server/scripts/ops/`.

| script | what it answers |
|---|---|
| `emission-cost-delta.sh` | ac-4's before/after measurement, as a delta |
| `verify-emission-landed.sh` | the positive post-deploy emission check — all three tiers |
| `day-after-check.sh` | partition routing, `n_tup_del`, growth rate, and whether there is traffic to measure |

## They carry what went wrong, not just what to run

Four ways this measurement lied during the deploy — each now guarded, and **each failed towards the flattering answer**:

1. **`CREATE TEMP TABLE` for the snapshot** — refused under `default_transaction_read_only`. Both readings now go to local CSV; prod stays strictly read-only.
2. **A dropped connection left an empty snapshot.** Nothing differenced against something reported **`0.000%`** — a triumph, on the exact criterion being measured. A short snapshot now **aborts** rather than reporting zeros.
3. **Patterns matched unquoted SQL only.** Drizzle quotes identifiers, so the INSERT was silently dropped from the total and the path read 40.5% instead of 32.5%. Matching is quote-insensitive, and any *busy* statement no pattern classified is now printed.
4. **A window taken while traffic was idle** read ~0% and meant nothing. `day-after-check.sh` answers "is there traffic" before you spend 300 seconds.

Plus the one that is not the script's fault but bites the reader: **a single window is not a comparator.** Two windows ten minutes apart disagreed by 2x on an unchanged system.

Read-only except where stated. No production behaviour changes.