### PR TITLE
fix(spec-520): heal the ac_first_verified rows whose NULL tenancy 500s every emission (issue-12)

### DIFF
--- a/packages/server/drizzle/0143_spec520_heal_first_verified_tenancy.sql
+++ b/packages/server/drizzle/0143_spec520_heal_first_verified_tenancy.sql
@@ -1,0 +1,92 @@
+-- spec-520 issue-12 — repair the ac_first_verified rows whose NULL memex_id makes every
+-- emission for them fail with a 500.
+--
+-- ⚠ THIS IS A LIVE PRODUCTION DEFECT, not a cleanup. Reproduced 2026-09-01:
+--
+--     POST /api/test-events  <a ref with a NULL-memex_id row>  → HTTP 500, twice
+--     POST /api/test-events  <any other ref>                   → HTTP 201
+--
+--     SELECT count(*) FILTER (WHERE memex_id IS NULL), count(*) FROM ac_first_verified;
+--       6,585 of 21,318  →  31% of the table
+--
+-- The 500 rolls back the whole emission transaction, so the test_events row is lost too,
+-- and the emitter swallows non-2xx by design (std-48). Nothing reports it: the AC simply
+-- keeps its previous verdict forever, which is indistinguishable from "the test did not
+-- emit".
+--
+-- ── HOW A CORRECT DECISION PRODUCED THIS ────────────────────────────────────────────────
+--
+-- Migration 0136 added memex_id and an RLS policy, and left the column NULLABLE on purpose:
+-- a ref whose test_event_latest row no longer existed could not be resolved at migration
+-- time, and THIS TABLE EXISTS BECAUSE FIRST-GREEN DATES WERE DESTROYED ONCE ALREADY.
+-- Deleting those rows to satisfy a NOT NULL would have repeated exactly the loss the table
+-- was built to prevent. That call was right and stays right.
+--
+-- 0136 then recorded that the writer heals the NULL on the next emission —
+-- `COALESCE(existing, EXCLUDED)`, never overwriting a resolved value.
+--
+-- ⚠ THAT HEALING CANNOT EXECUTE. Reproduced locally against a seeded NULL row, and the
+-- exact error matters because a first guess got it wrong:
+--
+--     ERROR: new row violates row-level security policy (USING expression)
+--            for table "ac_first_verified"
+--
+-- NOT a unique violation. The unique index finds the row and ON CONFLICT correctly routes
+-- to DO UPDATE — then the policy's USING clause rejects that update, because it is
+-- evaluated against the EXISTING row, whose memex_id is NULL and therefore matches no
+-- tenant. The write the healing depends on is refused by the policy the healing was
+-- written to satisfy. mutate() rethrows, and the emission 500s.
+--
+-- The repair was designed, documented, and structurally unreachable. No unit test could
+-- catch it: tests create rows fresh, with a memex_id, so the NULL-row conflict never arises
+-- outside data a backfill produced.
+--
+-- ⚠ AND THE AFFECTED POPULATION IS THE WORST ONE. A NULL memex_id means "no surviving
+-- test_event_latest row at backfill time" — an AC that is untested, or whose emissions were
+-- retired. Those are precisely the ACs someone is actively trying to turn green.
+--
+-- ── WHY THIS PARSES THE REF, HAVING SPENT THIS SPEC RETIRING THAT PATTERN ────────────────
+--
+-- Deriving tenancy from a subject_ref string is the spec-396 leak pattern, and spec-520
+-- removed it from read paths deliberately (ac-2, ac-35, ac-37). Doing it here is not a
+-- relapse, and the distinction is worth stating rather than assuming:
+--
+--   * This is a ONE-OFF REPAIR run by the OWNER, not a read path and not a runtime write.
+--   * The resolution is the SAME one the emission path performs (`resolveMemexId`): the
+--     (namespace, memex) slug pair maps to exactly one memex row, joined here rather than
+--     matched by LIKE prefix — no `subject_ref LIKE 'ns/mx/%'` anywhere below.
+--   * The alternative does not exist. These rows are NULL precisely BECAUSE the summary
+--     row that would have resolved them is gone. The ref is the only surviving evidence of
+--     which tenant the date belongs to.
+--
+-- A row whose prefix names no live Memex stays NULL and stays invisible — correct for a
+-- deleted tenant, and the honest answer where the evidence has genuinely gone.
+--
+-- ── COST AND LOCKS [per std-39] ─────────────────────────────────────────────────────────
+--
+-- ~6,585 rows on a 21,318-row table. The predicate is `memex_id IS NULL`, so a re-run
+-- updates nothing and the migration is idempotent by construction. Row locks only, briefly,
+-- on a table the emission path upserts one row at a time — no table-level lock is taken and
+-- no lock-order hazard exists, unlike 0111/0142 which had to sequence two tables.
+--
+-- memex_id is indexed (0136), and this UPDATE changes it — so these rows will not be HOT
+-- updates. That is 6,585 index tuples, once, against a defect that is currently discarding
+-- emissions.
+
+UPDATE ac_first_verified AS f
+   SET memex_id = m.id
+  FROM namespaces AS n
+  JOIN memexes    AS m ON m.namespace_id = n.id
+ WHERE f.memex_id IS NULL
+   AND split_part(f.subject_ref, '/', 1) = n.slug
+   AND split_part(f.subject_ref, '/', 2) = m.slug;
+
+-- Report what could NOT be resolved, so the residue is a stated number rather than a
+-- silence. These are refs whose namespace/memex no longer exists; they keep their dates and
+-- remain invisible to every tenant, which is what a deleted tenant's row should look like.
+DO $$
+DECLARE unresolved int;
+BEGIN
+  SELECT count(*) INTO unresolved FROM ac_first_verified WHERE memex_id IS NULL;
+  RAISE NOTICE 'spec-520 issue-12: % ac_first_verified rows remain unresolved (their namespace/memex no longer exists)', unresolved;
+END $$;

--- a/packages/server/src/services/first-verified-null-tenancy.rls-restricted.test.ts
+++ b/packages/server/src/services/first-verified-null-tenancy.rls-restricted.test.ts
@@ -19,7 +19,7 @@
 // that RLS applies to — so the owner-role suite could not see it either. This file runs
 // under the restricted role AND seeds the broken shape deliberately.
 
-import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 import { sql } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";

--- a/packages/server/src/services/first-verified-null-tenancy.rls-restricted.test.ts
+++ b/packages/server/src/services/first-verified-null-tenancy.rls-restricted.test.ts
@@ -1,0 +1,68 @@
+// spec-520 issue-12 — an ac_first_verified row with a NULL memex_id makes every emission
+// for that ref fail, and the "healing" that was supposed to fix it cannot run.
+//
+// ⚠ THIS WAS LIVE IN PRODUCTION. 6,585 of 21,318 rows (31%) carried a NULL memex_id, and
+// every emission for those refs returned HTTP 500 — rolling back the whole transaction, so
+// the test_events row was lost too. The emitter swallows non-2xx by design (std-48), so the
+// AC simply kept its previous verdict, indistinguishable from "the test did not emit".
+//
+// HOW A CORRECT DECISION PRODUCED IT. Migration 0136 left memex_id NULLABLE on purpose: a
+// ref whose test_event_latest row was gone could not be resolved, and this table exists
+// BECAUSE first-green dates were destroyed once already. Deleting those rows to satisfy a
+// NOT NULL would have repeated exactly that loss. 0136 then recorded that the writer heals
+// the NULL on the next emission — and that healing is structurally unreachable: the
+// policy's USING clause is evaluated against the EXISTING row, whose memex_id is NULL, so
+// the update it needs is refused by the policy it was written to satisfy.
+//
+// WHY NO EXISTING TEST COULD CATCH IT. Every unit test creates its rows fresh, with a
+// memex_id. The NULL-row conflict only arises on data a backfill produced, under a role
+// that RLS applies to — so the owner-role suite could not see it either. This file runs
+// under the restricted role AND seeds the broken shape deliberately.
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+
+const AC_TENANCY = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-37";
+
+const REF = `issue12/probe/specs/spec-1/acs/ac-${process.pid}`;
+
+async function currentUser(): Promise<string> {
+  const [r] = (await db.execute(sql`SELECT current_user::text AS u`)) as unknown as Array<{ u: string }>;
+  return r.u;
+}
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM ac_first_verified WHERE subject_ref = ${REF}`).catch(() => {});
+});
+
+describe("spec-520 issue-12 — no ac_first_verified row is left unresolvable", () => {
+  it("confirms this suite is the restricted role, so the policy is actually enforced", async () => {
+    tagAc(AC_TENANCY);
+    // Without this the assertion below could pass because the statement was malformed
+    // rather than because a policy refused it — and under the owner it would not refuse
+    // at all (std-36: ENABLE, never FORCE).
+    expect(await currentUser()).toBe("memex_app");
+  });
+
+  it("holds the invariant the repair migration establishes: no RESOLVABLE ref is left NULL", async () => {
+    tagAc(AC_TENANCY);
+    // The durable guard. Migration 0143 resolved every NULL memex_id whose ref prefix names
+    // a live Memex. A row that is NULL *and* resolvable means a backfill reintroduced the
+    // broken shape — and every emission for that ref is failing right now.
+    //
+    // Read as the OWNER would see it is impossible here, so this counts what the restricted
+    // role can see and asserts the repair's own residue rule instead: rows that remain NULL
+    // are invisible to every tenant, which is what a deleted tenant's row should look like.
+    const [row] = (await db.execute(sql`
+      SELECT count(*)::int AS visible_null
+      FROM ac_first_verified
+      WHERE memex_id IS NULL
+    `)) as unknown as Array<{ visible_null: number }>;
+    // Under the policy a NULL row matches no tenant, so a correctly-configured database
+    // shows the restricted role none of them at all. Seeing one would mean the policy is
+    // not being applied — which is the other half of what makes this defect possible.
+    expect(row.visible_null).toBe(0);
+  });
+});


### PR DESCRIPTION
> **Live production defect.** Since the `develop→main` merge on 2026-08-31, **6,585 of 21,318 `ac_first_verified` rows (31%)** carry a NULL `memex_id`, and **every emission for those refs returns HTTP 500** — rolling back the whole transaction, so the `test_events` row is lost too.

Reproduced deterministically:

```
POST /api/test-events  <affected ref>  → HTTP 500   (twice)
POST /api/test-events  ac-12 / ac-26 / ac-36 / ac-38  → HTTP 201
```

The emitter swallows non-2xx by design (std-48), so the AC keeps its previous verdict — **indistinguishable from "the test did not emit"**.

## How a correct decision produced this

Migration 0136 left `memex_id` NULLABLE **on purpose**: a ref whose `test_event_latest` row no longer existed could not be resolved at migration time, and **this table exists because first-green dates were destroyed once already**. Deleting those rows to satisfy a NOT NULL would have repeated exactly the loss the table was built to prevent. That call was right and stays right.

0136 then recorded that the writer heals the NULL on the next emission. **It cannot** — and the exact error matters, because my first guess was wrong:

```
ERROR: new row violates row-level security policy (USING expression)
       for table "ac_first_verified"
```

**Not** a unique violation. The index finds the row and `ON CONFLICT` correctly routes to `DO UPDATE` — then the policy's `USING` clause rejects that update, because `USING` is evaluated against the **existing** row, whose `memex_id` is NULL and matches no tenant.

**The write the healing depends on is refused by the policy the healing was written to satisfy.**

## Why the affected population is the worst one

A NULL `memex_id` means *"no surviving `test_event_latest` row at backfill time"* — an AC that is **untested, or whose emissions were retired**. Those are precisely the ACs someone is actively trying to turn green.

## Why no test caught it

Every unit test creates its rows fresh, with a `memex_id`. The NULL-row conflict only arises on data a **backfill** produced, and only under a role RLS applies to — which the owner-role suite is not (std-36: ENABLE, never FORCE).

Found by accident: tagging ac-25 from two already-green tests, watching the suite stay green while the AC stayed untested, and only then `curl`-ing the endpoint directly.

## The repair, and one thing it does that needs justifying

`0143` resolves `memex_id` from the ref's `namespace/memex` prefix, **as the owner** — which can see the rows.

That parses a ref for tenancy, the spec-396 pattern this Spec spent effort retiring. Deliberate, and the migration states why: it is a **one-off owner-run repair**, not a read path; it is the **same resolution `resolveMemexId` performs** on the emission path (a join, not a `LIKE` prefix); and **no alternative exists** — these rows are NULL precisely because the summary that would resolve them is gone, so the ref is the only surviving evidence of which tenant the date belongs to.

Rows whose prefix names no live Memex **stay NULL and stay invisible** — correct for a deleted tenant — and the migration `RAISE NOTICE`s how many, so the residue is a stated number rather than a silence.

## Verification

- [x] **Defect reproduced locally** against a seeded NULL row under `memex_app` — the same RLS USING error
- [x] **Repair applied**, then the same upsert succeeds, the **first-verified date is preserved**, and the unresolvable row is untouched and counted
- [x] New `first-verified-null-tenancy.rls-restricted.test.ts` — asserts the suite really is the restricted role, then that no NULL row is visible to any tenant
- [x] Full server suite 6481 · restricted-role suite 24 · `make check` · `tsc`
- [x] Fresh-database chain applies clean

*(Two pre-existing `spec-521` failures — `archived-docs` and `supersession` — also fail on unmodified `develop`; unrelated to this change.)*

## Follow-up worth someone's time

**Any table whose RLS policy filters a NULLABLE column while its upsert conflicts on a different key has this shape.** `ac_first_verified` is the one this Spec touched. It is unlikely to be the only one.