### PR TITLE
fix(spec-521): date assertions fail for the whole month of September

### DIFF
--- a/packages/server/src/services/archived-docs.spec-521.integration.test.ts
+++ b/packages/server/src/services/archived-docs.spec-521.integration.test.ts
@@ -393,7 +393,13 @@ describe("ac-2 — the archived Spec's own ref returns a stub, not its content",
     // handle, title, archived-at, actor, phase-at-archive, reason
     expect(stub).toContain(archivedRef);
     expect(stub).toContain("Parked work with decisions an agent must not read");
-    expect(stub).toMatch(/ARCHIVED \d{1,2} \w{3} \d{4}/);
+    // ⚠ {3,4} AND NOT {3} — DO NOT "TIDY" THIS BACK.
+    // `en-GB` with month:'short' renders SEPTEMBER as "Sept" — four letters. Every other
+    // month is three: Jan Feb Mar Apr May Jun Jul Aug **Sept** Oct Nov Dec. A \w{3} match
+    // therefore fails for the whole month of September, every year, and passes the other
+    // eleven. It broke every PR in the repo at midnight on 2026-09-01 with the same commit
+    // that had been green all August.
+    expect(stub).toMatch(/ARCHIVED \d{1,2} \w{3,4} \d{4}/);
     expect(stub).toContain("phase at archive:");
     expect(stub).toContain(ARCHIVE_REASON);
     // The archiving actor resolved from the threaded ctx, denormalised at write.

--- a/packages/server/src/services/search-recency.spec-521.integration.test.ts
+++ b/packages/server/src/services/search-recency.spec-521.integration.test.ts
@@ -210,7 +210,16 @@ describe("ac-9 — every hit states how old its content is", () => {
     // The shared timeAgo() vocabulary: "just now", "Nm/h/d/w ago", or an absolute
     // date past ~8 weeks. Whichever it is, it must be human-readable prose and never
     // a raw ISO timestamp — that is the ac-9 requirement, not a particular unit.
-    expect(heading).toMatch(/(resolved|updated) (just now|\d+[mhdw] ago|\d{1,2} \w{3} \d{4})/);
+    // ⚠ {3,4} AND NOT {3} — DO NOT "TIDY" THIS BACK.
+    // `en-GB` with month:'short' renders SEPTEMBER as "Sept" — four letters. Every other
+    // month is three: Jan Feb Mar Apr May Jun Jul Aug **Sept** Oct Nov Dec. A \w{3} match
+    // therefore fails for the whole month of September, every year, and passes the other
+    // eleven. It broke every PR in the repo at midnight on 2026-09-01 with the same commit
+    // that had been green all August.
+    // Latent here rather than firing today: the alternation usually takes the
+    // relative-date branch, so this one only breaks when the absolute branch is
+    // reached in September. Fixed with the others so it cannot surface later.
+    expect(heading).toMatch(/(resolved|updated) (just now|\d+[mhdw] ago|\d{1,2} \w{3,4} \d{4})/);
     expect(heading).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 });

--- a/packages/server/src/services/supersession.spec-521.integration.test.ts
+++ b/packages/server/src/services/supersession.spec-521.integration.test.ts
@@ -311,7 +311,13 @@ describe("ac-7 — every read of a superseded Spec leads with the pointer", () =
     expect(out).toContain("SUPERSEDED BY");
     expect(out).toContain(succ.handle);
     expect(out).toContain(NOTE);
-    expect(out).toMatch(/\d{1,2} \w{3} \d{4}/);
+    // ⚠ {3,4} AND NOT {3} — DO NOT "TIDY" THIS BACK.
+    // `en-GB` with month:'short' renders SEPTEMBER as "Sept" — four letters. Every other
+    // month is three: Jan Feb Mar Apr May Jun Jul Aug **Sept** Oct Nov Dec. A \w{3} match
+    // therefore fails for the whole month of September, every year, and passes the other
+    // eleven. It broke every PR in the repo at midnight on 2026-09-01 with the same commit
+    // that had been green all August.
+    expect(out).toMatch(/\d{1,2} \w{3,4} \d{4}/);
   });
 
   it("get_doc STILL SERVES the content — a superseded Spec is history, not a secret", async () => {


### PR DESCRIPTION
> **Every PR in the repo is blocked, and no code changed.** Commit `8f4d4eb3` passed at 13:13 on 2026-08-31 and failed at 06:03 on 2026-09-01 — same SHA, same tree, different verdict.

## The cause

`en-GB` with `month: 'short'` renders **September as "Sept"** — four letters. Every other month is three:

```
Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sept  Oct  Nov  Dec
```

So `/\d{1,2} \w{3} \d{4}/` requires exactly three word characters followed by a space, meets `Sept `, and fails.

```
Received: '⚠ SUPERSEDED BY spec-23 (1 Sept 2026)…'
Expected to match: /\d{1,2} \w{3} \d{4}/
```

**It matches eleven months and fails the twelfth**, every year. It passed all August and broke at midnight.

## The fix

`\w{3}` → `\w{3,4}`, at three sites, each with a comment naming the month so nobody tidies it back.

**Three, not two.** `supersession` and `archived-docs` are red right now. `search-recency` carries the same pattern inside an alternation that usually takes the relative-date branch (`just now`, `3d ago`), so it is **latent** rather than failing — it would surface the first time that assertion met data old enough to render an absolute date in September. Fixed alongside, since leaving it means the same bug fires later under different data and looks unrelated.

## Verification

- [x] The three affected suites: **81 passed**
- [x] `make check`
- [x] Formatter output enumerated month by month to confirm September is the only four-letter case — not inferred from the one failure

Unrelated to spec-520; found while diagnosing why that Spec's PRs would not merge.