### PR TITLE
test(spec-520): tag four criteria from the tests that already proved them

### DIFF
--- a/packages/server/src/__regression__/out-of-band-migrations.regression.test.ts
+++ b/packages/server/src/__regression__/out-of-band-migrations.regression.test.ts
@@ -14,6 +14,11 @@ import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
 const AC_OUT_OF_BAND = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-39";
+// ac-9 says the same thing ac-39 does — the (memex_id, subject_ref) index is built with
+// CREATE INDEX CONCURRENTLY outside the transactional runner. ac-39 was authored later
+// with the fuller reasoning; ac-9 is its earlier, terser statement. One guard proves both,
+// so both are tagged rather than leaving a true criterion reading as untested.
+const AC_CONCURRENT_INDEX = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-9";
 import { tagAc } from "@memex-ai-ac/vitest";
 
 const drizzleDir = resolve(import.meta.dirname, "../../drizzle");
@@ -21,6 +26,7 @@ const drizzleDir = resolve(import.meta.dirname, "../../drizzle");
 describe("spec-520 ac-39: out-of-band index builds stay out of the transactional runner", () => {
   it("no migration the runner picks up contains CREATE INDEX CONCURRENTLY", () => {
     tagAc(AC_OUT_OF_BAND);
+    tagAc(AC_CONCURRENT_INDEX);
     // Exactly the runner's own glob: readdirSync (non-recursive) filtered to .sql.
     const applied = readdirSync(drizzleDir).filter((f) => f.endsWith(".sql"));
     const offenders = applied.filter((f) => {
@@ -40,6 +46,7 @@ describe("spec-520 ac-39: out-of-band index builds stay out of the transactional
 
   it("the runner's directory read is NOT recursive, so out-of-band/ stays invisible", () => {
     tagAc(AC_OUT_OF_BAND);
+    tagAc(AC_CONCURRENT_INDEX);
     const runner = readFileSync(
       resolve(import.meta.dirname, "../../scripts/apply-hand-migrations.mjs"),
       "utf8",
@@ -52,6 +59,7 @@ describe("spec-520 ac-39: out-of-band index builds stay out of the transactional
 
   it("the out-of-band file exists and carries its apply + verify instructions", () => {
     tagAc(AC_OUT_OF_BAND);
+    tagAc(AC_CONCURRENT_INDEX);
     // A statement nobody knows how to run is not a migration, it is a note. The file has to
     // say how to apply it AND how to confirm the build did not leave an INVALID index —
     // invalid means never used by the planner but still maintained on every write.

--- a/packages/server/src/__regression__/spec-398-amendment.regression.test.ts
+++ b/packages/server/src/__regression__/spec-398-amendment.regression.test.ts
@@ -1,0 +1,58 @@
+// spec-520 ac-15 — spec-398's retention tests assert the time bound, not a count of 10.
+//
+// ac-15 has two halves. The first — that spec-398 ac-5 and ac-6 were AMENDED — is a fact
+// about Memex, applied on 2026-08-31 and recorded in c-17; no code test can observe it.
+// The second is a fact about THIS repository, and it is the half that rots: a future edit
+// restoring a `toBe(RETENTION_KEEP)` assertion, or reintroducing the constant, would put
+// spec-398's criteria and its tests back into contradiction with nothing to catch it.
+//
+// WHY IT MATTERS BEYOND TIDINESS. spec-398 is a DONE Spec. Its ACs are green and nobody
+// revisits them. If its tests drift back to asserting count-based retention while its
+// criteria state a time bound, the Spec reports "verified" for a property the code no
+// longer has — and it would report that for as long as nobody happened to read both.
+// That is precisely the drift SDD exists to make impossible (std-20).
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_AMENDED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-15";
+const SRC = join(__dirname, "..");
+
+function body(rel: string): string {
+  // Strip line comments: this file's own explanatory prose names the very symbols it
+  // forbids, and so does the retention test's header. Matching raw text would fail on
+  // documentation rather than on code.
+  return readFileSync(join(SRC, rel), "utf-8")
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("//"))
+    .join("\n");
+}
+
+describe("spec-520 ac-15 — spec-398's retention tests assert the time bound", () => {
+  it("no longer asserts a count of 10 via RETENTION_KEEP", () => {
+    tagAc(AC_AMENDED);
+    const t = body("services/spec-398-retention.integration.test.ts");
+    // The exact shape ac-15 names: `expect(await countFor(...)).toBe(RETENTION_KEEP)`.
+    expect(t).not.toMatch(/RETENTION_KEEP/);
+  });
+
+  it("the trim it used to call no longer exists to be called", () => {
+    tagAc(AC_AMENDED);
+    const mod = body("services/test-event-retention.ts");
+    // Both halves of "trimTestEventsForPair and RETENTION_KEEP no longer exist" — a
+    // leftover export is an invitation to reintroduce the 13.4% with a one-line edit.
+    expect(mod).not.toMatch(/export\s+(async\s+)?function\s+trimTestEventsForPair/);
+    expect(mod).not.toMatch(/export\s+const\s+RETENTION_KEEP/);
+  });
+
+  it("states retention as configuration, which is what the amended criteria now claim", () => {
+    tagAc(AC_AMENDED);
+    const mod = body("services/test-event-retention.ts");
+    // spec-398 ac-6 now reads "the window is configuration-driven, not a compiled-in
+    // constant" (c-17). This is the code side of that sentence.
+    expect(mod).toMatch(/TEST_EVENTS_RETENTION_DAYS/);
+    expect(mod).toMatch(/process\.env\.TEST_EVENTS_RETENTION_DAYS/);
+  });
+});

--- a/packages/server/src/services/ci-provenance-from-summary.integration.test.ts
+++ b/packages/server/src/services/ci-provenance-from-summary.integration.test.ts
@@ -32,6 +32,11 @@ import { seedTestEvent } from "./test-helpers.js";
 import { makeTestMemex } from "./test-helpers.js";
 
 const AC_PROVENANCE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-38";
+// ac-25 names BOTH consumers — auditCiEmissionForBrief AND verifyingAcIsGreen. Only one
+// could move at a time (dec-8 blocked the other), which is why ac-36 and ac-38 were split
+// out of it. Both are now green, so ac-25 is true as written and is tagged from BOTH
+// halves rather than either alone — the same discipline ac-24 was held to.
+const AC_BOTH_CONSUMERS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-25";
 
 let memexId: string;
 let namespaceSlug: string;
@@ -85,6 +90,7 @@ afterAll(async () => {
 describe("spec-520 ac-38: CI provenance comes from the summary", () => {
   it("flags a verified AC whose latest emission carries NO CI marker", async () => {
     tagAc(AC_PROVENANCE);
+    tagAc(AC_BOTH_CONSUMERS);
     const { docId, ref } = await specWithVerifiedAc("local", 1);
     await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
 
@@ -98,6 +104,7 @@ describe("spec-520 ac-38: CI provenance comes from the summary", () => {
 
   it("does NOT flag one whose latest emission carries a run id", async () => {
     tagAc(AC_PROVENANCE);
+    tagAc(AC_BOTH_CONSUMERS);
     const { docId, ref } = await specWithVerifiedAc("ci", 1);
     await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
 
@@ -114,6 +121,7 @@ describe("spec-520 ac-38: CI provenance comes from the summary", () => {
 
   it("does NOT flag one whose run id rides in metadata instead", async () => {
     tagAc(AC_PROVENANCE);
+    tagAc(AC_BOTH_CONSUMERS);
     const { docId, ref } = await specWithVerifiedAc("ci-md", 1);
     await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
 
@@ -133,6 +141,7 @@ describe("spec-520 ac-38: CI provenance comes from the summary", () => {
 
   it("treats a row with NO RECORDED PROVENANCE as unknown and does NOT flag it", async () => {
     tagAc(AC_PROVENANCE);
+    tagAc(AC_BOTH_CONSUMERS);
     const { docId, ref } = await specWithVerifiedAc("pre-0137", 1);
     await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
 
@@ -152,6 +161,7 @@ describe("spec-520 ac-38: CI provenance comes from the summary", () => {
 
   it("answers without the raw log — the row t-12's retention window will delete", async () => {
     tagAc(AC_PROVENANCE);
+    tagAc(AC_BOTH_CONSUMERS);
     const { docId, ref } = await specWithVerifiedAc("no-raw", 1);
     await seedTestEvent({ subjectRef: ref, status: "pass", testIdentifier: "s::t" });
 

--- a/packages/server/src/services/t11-rebased-consumers.integration.test.ts
+++ b/packages/server/src/services/t11-rebased-consumers.integration.test.ts
@@ -55,6 +55,11 @@ const AC_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-35";
 // other was blocked, and it stays as the narrower statement.
 const AC_BOTH_CHARTS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-24";
 const AC_LATEST = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-36";
+// ac-25 names BOTH consumers — auditCiEmissionForBrief AND verifyingAcIsGreen. Only one
+// could move at a time (dec-8 blocked the other), which is why ac-36 and ac-38 were split
+// out of it. Both are now green, so ac-25 is true as written and is tagged from BOTH
+// halves rather than either alone — the same discipline ac-24 was held to.
+const AC_BOTH_CONSUMERS = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-25";
 
 let memexId: string;
 let userId: string;
@@ -145,6 +150,7 @@ describe("spec-520 ac-24: testRunVolume reads the rollup, not the raw log", () =
 describe("spec-520 ac-25: the auto-resolve gate reads test_event_latest, not the raw log", () => {
   it("resolves a converted Issue from the SUMMARY alone, with the raw log empty", async () => {
     tagAc(AC_LATEST);
+    tagAc(AC_BOTH_CONSUMERS);
 
     const built = await runWithMemexId(memexId, async () => {
       const doc = await createDocDraft(memexId, `t11 gate ${process.pid}`, "", "spec");
@@ -191,6 +197,7 @@ describe("spec-520 ac-25: the auto-resolve gate reads test_event_latest, not the
 
   it("still refuses when the summary's latest is a FAIL", async () => {
     tagAc(AC_LATEST);
+    tagAc(AC_BOTH_CONSUMERS);
 
     const built = await runWithMemexId(memexId, async () => {
       const doc = await createDocDraft(memexId, `t11 gate red ${process.pid}`, "", "spec");

--- a/packages/server/src/services/test-events-partitioned.integration.test.ts
+++ b/packages/server/src/services/test-events-partitioned.integration.test.ts
@@ -24,6 +24,11 @@ import { makeTestMemex, seedTestEvent } from "./test-helpers.js";
 import { PARTITION_HORIZON_DAYS, TEST_EVENTS_RETENTION_DAYS, partitionNameFor } from "./test-event-retention.js";
 
 const AC_PARTITIONED = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-13";
+// ac-12 states the narrower half of ac-13 as its own criterion: "an emission issues no
+// DELETE against test_events — trimTestEventsForPair and RETENTION_KEEP no longer exist in
+// the codebase". Both halves are proven below, so it is tagged from exactly the two tests
+// that prove them rather than left untested beside the criterion that subsumes it.
+const AC_NO_DELETE = "mindset-prod/memex-building-itself/specs/spec-520/acs/ac-12";
 
 let memexId: string;
 let namespaceSlug: string;
@@ -145,6 +150,7 @@ describe("spec-520 ac-13: the table is partitioned by time", () => {
 describe("spec-520 ac-13: an emission deletes nothing", () => {
   it("keeps every emission for a pair — the 11th no longer evicts the oldest", async () => {
     tagAc(AC_PARTITIONED);
+    tagAc(AC_NO_DELETE);
     const ref = await seedAc("no trim");
     const base = Date.now() - 20 * 60_000;
     for (let i = 0; i < 15; i++) {
@@ -165,6 +171,7 @@ describe("spec-520 ac-13: an emission deletes nothing", () => {
 
   it("exports no per-pair trim to call any more", async () => {
     tagAc(AC_PARTITIONED);
+    tagAc(AC_NO_DELETE);
     const mod = await import("./test-event-retention.js");
     // A leftover export is an invitation to reintroduce the 13.4%: the emission path used
     // to call it, and a future edit restoring that call would be a one-line regression with


### PR DESCRIPTION
Four criteria sat **UNTESTED beside a green test doing exactly what they describe**. No new behaviour — tags and one guard.

| | |
|---|---|
| **ac-12** | the no-DELETE half of ac-13, tagged from the two tests that prove it |
| **ac-9** | a terser statement of ac-39 — one guard proves both |
| **ac-25** | names **both** consumers; ac-36 and ac-38 were split out of it while one was blocked on dec-8. Both are green now, so it is tagged from **both halves** rather than either alone — the ac-24 discipline |
| **ac-15** | its code-side half gets a real guard |

The ac-15 guard asserts spec-398's retention test no longer asserts a count of 10, that the trim does not exist to be called, and that retention is configuration. **Proven to have teeth** by reintroducing `RETENTION_KEEP` and watching it go red.

Why it matters beyond tidiness: spec-398 is a **done** Spec. If its tests drift back to asserting count-based retention while its criteria state a time bound, it reports "verified" for a property the code no longer has — for as long as nobody reads both.

## ⚠ ac-25 did not go green, and finding out why uncovered a live production defect

The tags are correct and the tests pass. The **emissions were being rejected with an HTTP 500** — `ac_first_verified` rows with a NULL `memex_id` are unwritable under their own RLS policy, affecting **6,585 of 21,318 rows**.

Filed as **issue-12**, fixed in **#661**. ac-25 will go green once that deploys.

That is also the honest reason this PR exists in the shape it does: the failure was invisible from a green suite, and only surfaced because a criterion refused to move.