### PR TITLE
fix(spec-545): make the architecture facet describe everyday work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ mcp__memex__get_doc({ref: "mindset-prod/memex-building-itself/standards/std-N"})
 | std-40 | Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer. |
 | std-41 | Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8). |
 | std-42 | Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published. |
+| std-51 | Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index. |
 <!-- END generated: standards-index -->
 
 If a Standard contradicts the code, the Standard is probably right and the code has drifted — flag it.

--- a/packages/server/scripts/backfill-facet-tags.ts
+++ b/packages/server/scripts/backfill-facet-tags.ts
@@ -18,6 +18,15 @@
 // add_clause hard-fail landed). Run this ONCE per memex just before the Phase 2 deploy
 // serves, so no clause is left silently unclassified.
 //
+// ⚠ THE DEFAULT IS LOAD-BEARING (spec-545 ac-4 / ac-10). Without `--gap-only` this
+// re-classifies EVERY clause in the memex against the CURRENT facet descriptions —
+// tagClause deletes then re-inserts — so a bare run after a description is reworded
+// silently re-tags the whole corpus under the new wording. spec-545 changed the
+// `architecture` and `code-style` descriptions on that understanding and forbids a
+// non-gap-only run; a regression guard pins this default so that warning cannot go
+// stale (src/__regression__/facet-backfill-gap-only-default.spec-545.regression.test.ts).
+// If you deliberately flip the default, revise spec-545's Operations lens too.
+//
 // Usage:
 //   pnpm --filter @memex/server tsx scripts/backfill-facet-tags.ts <memexId> [--gap-only]
 

--- a/packages/server/src/__regression__/facet-backfill-gap-only-default.spec-545.regression.test.ts
+++ b/packages/server/src/__regression__/facet-backfill-gap-only-default.spec-545.regression.test.ts
@@ -1,0 +1,79 @@
+// spec-545 t-3 / ac-10 — pin that the facet-tags backfill re-tags EVERYTHING unless
+// `--gap-only` is passed explicitly.
+//
+// THIS IS A PIN, NOT AN ENDORSEMENT. spec-545 broadened the `architecture` facet
+// description, and that description is the rubric the LLM classifier reads. Existing
+// clause tags are safe from the reword because they are stored rows that nothing
+// re-evaluates on read — with exactly one exception: a bare run of this script, which
+// deletes and re-inserts a tag for every clause in the memex under the new wording.
+// The Spec's Operations lens and ac-4 forbid that run. Those are prose, and prose goes
+// stale silently; this guard fails the moment the flag's semantics change, so the
+// warning gets revisited instead of quietly becoming a lie.
+//
+// WHY A SUBPROCESS rather than a source scan. The script calls main() at module scope,
+// so it cannot be imported without running a backfill, and grepping for the literal
+// "--gap-only" would pass against `const gapOnly = !argv.includes("--all")` — an
+// inverted default with the same string in it. Running it is the only way to observe
+// the DEFAULT rather than the spelling. The script prints its mode banner BEFORE it
+// touches anything, so a nonexistent memex id gives a real reading for ~1s and a
+// single failed read query; nothing is written and no model is called.
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC_10 = "mindset-prod/memex-building-itself/specs/spec-545/acs/ac-10";
+
+const SERVER_ROOT = join(__dirname, "..", "..");
+const TSX = join(SERVER_ROOT, "node_modules", ".bin", "tsx");
+const SCRIPT = join("scripts", "backfill-facet-tags.ts");
+
+/** The script's mode banner, run against a memex id that matches nothing. */
+function bannerFor(args: readonly string[]): string {
+  // A fresh id per call (std-37): nothing is inserted, but a shared literal is the
+  // habit that bites the next test that does insert.
+  const result = spawnSync(TSX, [SCRIPT, randomUUID(), ...args], {
+    cwd: SERVER_ROOT,
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, MEMEX_EMIT: "false" },
+  });
+  // The run exits non-zero once it reaches the database — irrelevant, and deliberately
+  // not asserted on: the banner is already flushed by then, and pinning the exit code
+  // would couple this guard to whether a throwaway id happens to resolve.
+  const banner = (result.stdout ?? "")
+    .split("\n")
+    .find((line) => line.includes("[facet-backfill] classifying"));
+  if (!banner) {
+    throw new Error(
+      `spec-545 ac-10: no mode banner on stdout — the script's output shape changed, so ` +
+        `this guard can no longer read the default.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    );
+  }
+  return banner;
+}
+
+describe("spec-545: the facet-tags backfill defaults to re-tagging everything (ac-10)", () => {
+  it("without the flag, runs in FULL mode — the corpus-wide hazard ac-4 forbids", () => {
+    tagAc(AC_10);
+    expect(
+      bannerFor([]),
+      "a bare invocation no longer reports full mode; if the default was deliberately " +
+        "flipped to gap-only, spec-545 ac-4 and its Operations warning must be revised, not this test",
+    ).not.toContain("UNTAGGED");
+  });
+
+  it("with --gap-only, runs in gap mode", () => {
+    tagAc(AC_10);
+    expect(bannerFor(["--gap-only"])).toContain("UNTAGGED");
+  });
+
+  it("the flag is opt-in, so an unrelated argument does not enable gap mode", () => {
+    tagAc(AC_10);
+    // Guards against a loose match (e.g. `argv.some(a => a.includes("gap"))`) quietly
+    // widening what counts as the flag.
+    expect(bannerFor(["--gap"])).not.toContain("UNTAGGED");
+  });
+});

--- a/packages/server/src/__regression__/licence-marker.ts
+++ b/packages/server/src/__regression__/licence-marker.ts
@@ -1,0 +1,29 @@
+// The licence-tier predicate, shared by the per-Spec fair-code guards.
+//
+// In this repo THE FILE PATH IS THE LICENCE MARKER: a `.ee.` filename or a `.ee`
+// directory segment puts a file under the Memex Enterprise License; everything else is
+// the Sustainable Use License. Adding or removing the marker re-licenses the file, so
+// every Spec makes an explicit fair-code/EE call up front [per std-25], and a PR
+// touching EE files needs a signed CLA.
+//
+// Extracted from spec-500's guard when spec-545 became its second consumer. Four lines
+// is a thin module, and normally the deletion test would say inline it — but this
+// particular predicate decides which licence a file ships under, and two copies that
+// drift on a detail (is `.ee` an exact path segment, or any segment containing it?)
+// disagree about something with legal consequences rather than merely cosmetic ones
+// [per std-51]. One definition, many callers.
+
+/** True when a repo-relative path carries the EE marker in its filename or a dirname. */
+export function isEeMarked(repoRelPath: string): boolean {
+  const segments = repoRelPath.split("/");
+  const base = segments.pop() ?? "";
+  // `.ee.` filename marker OR `.ee` as an exact directory segment. An exact segment
+  // match on purpose: a directory merely CONTAINING ".ee" (say `packages/tree.ee-old`)
+  // is not the marker, and treating it as one would mis-report a fair-code file as EE.
+  return base.includes(".ee.") || segments.includes(".ee");
+}
+
+/** The EE-marked subset of `paths` — empty when every path is fair-code. */
+export function eeMarkedAmong(paths: readonly string[]): string[] {
+  return paths.filter(isEeMarked);
+}

--- a/packages/server/src/__regression__/spec-500-fair-code.static-scan.regression.test.ts
+++ b/packages/server/src/__regression__/spec-500-fair-code.static-scan.regression.test.ts
@@ -4,11 +4,16 @@
 // regression guard that every file spec-500 introduced/edited stays fair-code:
 // none is EE-marked. If a future edit moves any of them across the license line,
 // this fails loudly and names the file.
+//
+// The marker predicate itself lives in ./licence-marker.ts — spec-545 became its second
+// consumer, and one definition of "which licence does this file ship under" is worth
+// more than two copies that can drift.
 
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { eeMarkedAmong } from "./licence-marker.js";
 
 const AC_FAIR_CODE = "mindset-prod/memex-building-itself/specs/spec-500/acs/ac-15";
 
@@ -33,13 +38,6 @@ const SPEC_500_FILES = [
   "packages/ui/e2e/journey-65-spec-500-explore-memex.spec.ts",
 ];
 
-function isEeMarked(repoRelPath: string): boolean {
-  const base = repoRelPath.split("/").pop() ?? "";
-  const dirs = repoRelPath.split("/").slice(0, -1);
-  // `.ee.` filename marker OR `.ee` as any directory segment.
-  return base.includes(".ee.") || dirs.includes(".ee");
-}
-
 describe("spec-500 is fair-code — no EE markers (ac-15)", () => {
   it("every spec-500 file exists and carries no .ee. / .ee marker", () => {
     tagAc(AC_FAIR_CODE);
@@ -47,7 +45,7 @@ describe("spec-500 is fair-code — no EE markers (ac-15)", () => {
     const missing = SPEC_500_FILES.filter((f) => !existsSync(join(REPO_ROOT, f)));
     expect(missing, `spec-500 files not found (path drift?): ${missing.join(", ")}`).toEqual([]);
 
-    const eeMarked = SPEC_500_FILES.filter(isEeMarked);
+    const eeMarked = eeMarkedAmong(SPEC_500_FILES);
     expect(eeMarked, `spec-500 files must stay fair-code, but these are EE-marked: ${eeMarked.join(", ")}`).toEqual([]);
   });
 });

--- a/packages/server/src/__regression__/spec-545-fair-code.static-scan.regression.test.ts
+++ b/packages/server/src/__regression__/spec-545-fair-code.static-scan.regression.test.ts
@@ -1,0 +1,83 @@
+// spec-545 dec-3 (ac-14) — this Spec is fair-code (Sustainable Use License), NOT
+// Enterprise Edition. The licence marker in this repo IS the file path, so the guard is
+// a scan of the paths this Spec touched. Mirrors spec-500's guard and shares its
+// predicate (./licence-marker.ts).
+//
+// WHY A FILE LIST AND NOT `git diff develop...HEAD`. ac-14 was written during specify
+// naming a diff-based check, on the reasoning that a diff catches a RENAME across the
+// licence line as well as an edit. Building it showed the diff is the weaker mechanism:
+// it reads as vacuously green once this branch merges (develop...develop is empty), it
+// depends on the `develop` ref being present, which a shallow CI checkout does not
+// guarantee, and it therefore stops guarding anything the moment it matters most —
+// later, when someone moves one of these files.
+//
+// The list-based form keeps the rename coverage the diff was chosen for, by a different
+// route: moving a listed file into a `.ee/` directory makes its old path stop existing,
+// and the existence assertion reds. It also keeps working forever, on any branch, with
+// no git dependency. ac-14 was updated to describe this.
+//
+// Note the guard deliberately does NOT assert "no PR may touch EE files" — EE work is
+// legitimate, it just needs a signed CLA. The claim here is narrower and true: the
+// files THIS Spec owns are fair-code and stay that way.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { eeMarkedAmong } from "./licence-marker.js";
+
+const AC_14 = "mindset-prod/memex-building-itself/specs/spec-545/acs/ac-14";
+
+// Repo root from this file: packages/server/src/__regression__ → ../../../..
+const REPO_ROOT = join(__dirname, "../../../..");
+
+// Every file spec-545 introduced or edited, repo-relative. All must be fair-code.
+// (CLAUDE.md and standards.manifest.json also move on this branch, as regenerated
+// standards-index output carried over from develop — not this Spec's own change, and
+// neither can carry a path marker anyway.)
+const SPEC_545_FILES = [
+  "packages/server/src/db/default-facets.fixture.ts",
+  "packages/server/src/db/default-facets.wording.spec-545.test.ts",
+  "packages/server/src/db/default-facets.portability.test.ts",
+  "packages/server/src/db/default-standards.portability.test.ts",
+  "packages/server/src/db/portability-scan.ts",
+  "packages/server/scripts/backfill-facet-tags.ts",
+  "packages/server/src/services/default-facets-no-overwrite.spec-545.integration.test.ts",
+  "packages/server/src/__regression__/facet-backfill-gap-only-default.spec-545.regression.test.ts",
+  "packages/server/src/__regression__/licence-marker.ts",
+  "packages/server/src/__regression__/spec-545-fair-code.static-scan.regression.test.ts",
+];
+
+describe("spec-545 is fair-code — no EE markers (ac-14)", () => {
+  it("every spec-545 file exists and carries no .ee. / .ee marker", () => {
+    tagAc(AC_14);
+
+    // Existence first: this is what catches a later MOVE across the licence line, and
+    // it also keeps the list honest against ordinary path drift.
+    const missing = SPEC_545_FILES.filter((f) => !existsSync(join(REPO_ROOT, f)));
+    expect(missing, `spec-545 files not found (moved or renamed?): ${missing.join(", ")}`).toEqual([]);
+
+    const eeMarked = eeMarkedAmong(SPEC_545_FILES);
+    expect(
+      eeMarked,
+      `spec-545 is fair-code (dec-3), but these paths are EE-marked: ${eeMarked.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("the marker predicate actually recognises both marker shapes (guards the guard)", () => {
+    tagAc(AC_14);
+    // Without this, a predicate that always returned false would keep every fair-code
+    // assertion green forever.
+    expect(
+      eeMarkedAmong([
+        "packages/server/src/services/.ee/slack/client.ts", // dirname marker
+        "packages/server/src/routes/auth/thing.ee.ts", // filename marker
+        "packages/server/src/db/default-facets.fixture.ts", // fair-code
+        "packages/server/src/tree.ee-old/thing.ts", // NOT the marker — segment must be exactly .ee
+      ]),
+    ).toEqual([
+      "packages/server/src/services/.ee/slack/client.ts",
+      "packages/server/src/routes/auth/thing.ee.ts",
+    ]);
+  });
+});

--- a/packages/server/src/db/default-facets.fixture.ts
+++ b/packages/server/src/db/default-facets.fixture.ts
@@ -57,13 +57,13 @@ export const DEFAULT_FACETS: readonly DefaultFacet[] = [
     key: "architecture",
     name: "Architecture",
     description:
-      "System and module structure, boundaries, and design patterns — how components are separated and how they communicate. Governs a clause about where logic belongs or how pieces fit together. Distinct from code-style, which is about local conventions (naming, formatting, typing) rather than structural decomposition.",
+      "System and module structure, boundaries, and design patterns — how components are separated and how they communicate. Everyday work counts: creating a new module or file, adding to what a module exposes to its callers, or moving code from one place to another. Governs a clause about where logic belongs or how pieces fit together. Distinct from code-style, which is about local conventions (naming, formatting, typing) rather than structural decomposition.",
   },
   {
     key: "code-style",
     name: "Code style",
     description:
-      "Local code conventions: naming, formatting, lint rules, typing idioms, and file organization. Governs a clause prescribing how code is written at the line or file level. On a typing rule, prefer code-style unless the rule is really about module boundaries — then it is architecture.",
+      "Local code conventions: naming, formatting, lint rules, typing idioms, and how code is laid out inside a file. Governs a clause prescribing how code is written at the line or file level. Where a rule is about structure or placement — what a module offers its callers, where logic lives, or which file something belongs in — prefer architecture; code-style keeps only how code is written inside a file.",
   },
   {
     key: "db-migrations",

--- a/packages/server/src/db/default-facets.portability.test.ts
+++ b/packages/server/src/db/default-facets.portability.test.ts
@@ -1,0 +1,47 @@
+// spec-545 t-2 — std-22 portability guard over the default facet vocabulary (ac-8).
+//
+// The sibling of default-standards.portability.test.ts, sharing its deny-list via
+// ./portability-scan.ts. The facet vocabulary is seeded into every owner at
+// provisioning and its descriptions are handed verbatim to an agent working on a
+// codebase we cannot see, so the same std-22 rule binds: no language, framework, file
+// path, tool, project symbol, or entity handle.
+//
+// SCOPED TO THE WHOLE FIXTURE, not the two entries spec-545 edits. The point of a guard
+// is the edit it catches AFTER this Spec ships — a check that only looked at
+// `architecture` and `code-style` would wave through the next description someone
+// writes.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { DEFAULT_FACETS } from "./default-facets.fixture.js";
+import { scanForNonPortableTokens, type Scannable } from "./portability-scan.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-545/acs/ac-${n}`;
+
+// This fixture's adapter: a facet contributes its display name and its description.
+// The stable `key` is deliberately NOT scanned — it is a slug, not prose, and it is
+// pinned separately as a contract (ac-9).
+function scannableStrings(): Scannable[] {
+  return DEFAULT_FACETS.flatMap((facet) => [
+    { where: `${facet.key} / name`, text: facet.name },
+    { where: `${facet.key} / description`, text: facet.description },
+  ]);
+}
+
+describe("spec-545: the default facet vocabulary is std-22-portable (ac-8)", () => {
+  it("contains no path, tooling, language, project-symbol, or handle tokens", () => {
+    tagAc(AC(8));
+
+    const violations = scanForNonPortableTokens(scannableStrings());
+
+    expect(violations, `Non-portable tokens found:\n${violations.join("\n")}`).toEqual([]);
+  });
+
+  it("scans every entry, so a future description edit trips it too", () => {
+    tagAc(AC(8));
+    // Guards the guard's SCOPE rather than its patterns (the shared canary covers
+    // those): if someone narrows the adapter to the entries this Spec touched, the
+    // string count collapses and this fails.
+    expect(scannableStrings()).toHaveLength(DEFAULT_FACETS.length * 2);
+  });
+});

--- a/packages/server/src/db/default-facets.wording.spec-545.test.ts
+++ b/packages/server/src/db/default-facets.wording.spec-545.test.ts
@@ -1,0 +1,104 @@
+// spec-545 t-1 — the `architecture` / `code-style` wording contract (ac-6, ac-7).
+//
+// WHY THIS EXISTS. The facet `description` is the rubric an agent reads before casting
+// the forced ballot on create_task, and the ballot is what routes a Standard's clauses
+// into the agent's response. `architecture` described only a redesign ("how components
+// are separated and how they communicate"), so an agent creating a file or widening
+// what a module exposes honestly voted false — and std-51, which governs exactly that
+// moment and is advisory (no check gates a merge on it), was never delivered.
+//
+// The reword lands on ground `code-style` already claimed ("file organization") whose
+// tie-break arbitrated typing rules ONLY. Shipping the `architecture` half alone would
+// leave two descriptions on the same ground with no arbiter — an inconsistent vote is
+// worse than a consistently wrong one, so dec-1 made this a two-entry change.
+//
+// Assertions are over the imported constant: no DB, no network, no fixtures.
+// The LIVE rows an agent actually reads are a separate, manual change (spec-545 t-5) —
+// this file deliberately does NOT tag the scope ACs, because a fixture cannot prove
+// anything about what is served.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { DEFAULT_FACETS } from "./default-facets.fixture.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-545/acs/ac-${n}`;
+
+function descriptionOf(key: string): string {
+  const entry = DEFAULT_FACETS.find((f) => f.key === key);
+  if (!entry) throw new Error(`spec-545: no facet with key '${key}' in DEFAULT_FACETS`);
+  return entry.description;
+}
+
+describe("spec-545: the architecture facet describes everyday work (ac-6)", () => {
+  it("names all three everyday cases the old wording excluded", () => {
+    tagAc(AC(6));
+    const description = descriptionOf("architecture");
+
+    // One assertion per case, so a failure names WHICH case went missing rather than
+    // reporting that a long string stopped matching.
+    const everydayCases: { label: string; pattern: RegExp }[] = [
+      { label: "creating a module or file", pattern: /creating a new module or file/i },
+      {
+        label: "adding to what a module exposes to its callers",
+        pattern: /adding to what a module exposes to its callers/i,
+      },
+      { label: "moving code between places", pattern: /moving code from one place to another/i },
+    ];
+
+    const missing = everydayCases
+      .filter(({ pattern }) => !pattern.test(description))
+      .map(({ label }) => label);
+
+    expect(
+      missing,
+      `architecture description does not name: ${missing.join("; ")}\n\nGot: ${description}`,
+    ).toEqual([]);
+  });
+
+  it("leaves the governs-a-clause sentence byte-identical", () => {
+    tagAc(AC(6));
+    // The description serves the ballot AND the clause classifier, and every reader
+    // gets the whole string (formatFacetList / renderFacetBallotBlock /
+    // classifierSystemPrompt all interpolate it verbatim). Broadening the topic half
+    // while leaving this half untouched is what keeps the change to one hypothesis.
+    expect(descriptionOf("architecture")).toContain(
+      "Governs a clause about where logic belongs or how pieces fit together.",
+    );
+  });
+});
+
+describe("spec-545: code-style arbitrates placement, not only typing (ac-7)", () => {
+  it("no longer scopes its tie-break to typing rules alone", () => {
+    tagAc(AC(7));
+    const description = descriptionOf("code-style");
+
+    // The exact sentence that made the collision unarbitrable: it sent typing rules to
+    // architecture when they were about module boundaries, and said nothing at all
+    // about where a file or a moved function belongs.
+    expect(
+      description,
+      "code-style still carries the typing-only tie-break; placement remains unarbitrated",
+    ).not.toMatch(/On a typing rule, prefer code-style unless/i);
+  });
+
+  it("sends structure and placement to architecture", () => {
+    tagAc(AC(7));
+    const description = descriptionOf("code-style");
+
+    expect(
+      description,
+      "code-style's tie-break must name `architecture` as the destination for structural rules",
+    ).toMatch(/architecture/);
+    expect(
+      description,
+      "code-style's tie-break must speak to structure/placement, not only line-level style",
+    ).toMatch(/structure|placement|where logic lives|offers its callers/i);
+  });
+
+  it("keeps code-style to what happens inside a file", () => {
+    tagAc(AC(7));
+    // The residual claim has to be narrow enough that the two descriptions stop
+    // competing: `code-style` owns how code is written within a file, nothing wider.
+    expect(descriptionOf("code-style")).toMatch(/inside a file|within a file/i);
+  });
+});

--- a/packages/server/src/db/default-facets.wording.spec-545.test.ts
+++ b/packages/server/src/db/default-facets.wording.spec-545.test.ts
@@ -102,3 +102,50 @@ describe("spec-545: code-style arbitrates placement, not only typing (ac-7)", ()
     expect(descriptionOf("code-style")).toMatch(/inside a file|within a file/i);
   });
 });
+
+// The 16 slugs as they stand. Pinned as a LITERAL on purpose: derived from the fixture
+// this assertion would be a tautology that passes through any rename.
+const PINNED_KEYS = [
+  "test-coverage",
+  "e2e-testing",
+  "post-deploy-smoke",
+  "deploy-release",
+  "security",
+  "architecture",
+  "code-style",
+  "db-migrations",
+  "api-design",
+  "observability",
+  "performance",
+  "accessibility",
+  "ci-pr-process",
+  "documentation",
+  "dependencies",
+  "feature-flags",
+] as const;
+
+describe("spec-545: the reword changes wording only, never the key contract (ac-9)", () => {
+  it("still defines exactly the pinned 16 keys, in order", () => {
+    tagAc(AC(9));
+    // WHY THIS IS THE SHARPEST GUARD IN THE SPEC. Keys are the ballot contract:
+    // `taskFacetBallots.vocabularyKeys` stores them, every persisted `verdict` map is
+    // keyed on them, and `validateBallot` decides completeness by comparing against
+    // them. Adding, removing or renaming one invalidates ballots already in the
+    // database — while every wording assertion above keeps passing, because the prose
+    // would still read correctly. Nothing else in this Spec would notice.
+    expect(DEFAULT_FACETS.map((f) => f.key)).toEqual([...PINNED_KEYS]);
+  });
+
+  it("holds the vocabulary at 16 entries", () => {
+    tagAc(AC(9));
+    expect(DEFAULT_FACETS).toHaveLength(16);
+  });
+
+  it("gives every entry a non-empty name and description", () => {
+    tagAc(AC(9));
+    // A blank description is the one way to break the ballot rubric without tripping
+    // any pattern-based guard: the agent is simply handed a slug and no criterion.
+    const blank = DEFAULT_FACETS.filter((f) => !f.name.trim() || !f.description.trim()).map((f) => f.key);
+    expect(blank, `facets with a blank name or description: ${blank.join(", ")}`).toEqual([]);
+  });
+});

--- a/packages/server/src/db/default-standards.portability.test.ts
+++ b/packages/server/src/db/default-standards.portability.test.ts
@@ -7,56 +7,21 @@
 // workspace. This test scans every title + clause and fails on any such token, so the
 // fixture can't drift out of portability on a later edit. Verifies spec-184 ac-17.
 //
-// Precision over recall: the forbidden patterns are chosen to catch the std-22 example
-// violations WITHOUT flagging ordinary English. In particular we do NOT match bare
-// words that are also prose ("make", "go", "build", "react") — only unambiguous tool
-// tokens, proper-noun framework names, handle literals, and path shapes.
+// The deny-list itself moved to ./portability-scan.ts when spec-545 gave it a second
+// consumer (the default facet vocabulary). What stays here is this fixture's adapter —
+// how a Standard flattens into scannable strings — and this Spec's AC tags.
 
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { DEFAULT_STANDARDS } from "./default-standards.fixture.js";
+import { canarySamplesNotFlagged, scanForNonPortableTokens, type Scannable } from "./portability-scan.js";
 
 const AC = (n: number) =>
   `mindset-prod/memex-building-itself/specs/spec-184/acs/ac-${n}`;
 
-interface ForbiddenRule {
-  label: string;
-  pattern: RegExp;
-}
-
-// Each pattern is high-precision. Comments note why a token is safe to match as-is
-// (unambiguous) vs. why a prose-colliding token (make/go/build/react) is deliberately
-// NOT matched bare.
-const FORBIDDEN: ForbiddenRule[] = [
-  // ── File paths & repo layout ────────────────────────────────────────────────
-  { label: "repo directory path", pattern: /\b(packages|src|dist|node_modules|tests?)\//i },
-  { label: "dunder test dir (e.g. __regression__)", pattern: /__[a-z]+__/i },
-  { label: "source file with code extension", pattern: /\b[\w-]+\.(ts|tsx|js|jsx|mjs|cjs|py|go|rb|rs|java|kt|php)\b/i },
-
-  // ── Test runners / build tools / package managers / runtimes (unambiguous tokens) ──
-  { label: "test runner / build / package-manager name", pattern: /\b(vitest|jest|mocha|pytest|rspec|pnpm|npm|yarn|bun|deno|webpack|vite|eslint|prettier|gradle|maven|tsc)\b/i },
-  { label: "Makefile / make target", pattern: /\bMakefile\b|\bmake\s+(test|build|dev|deploy|run)\b/i },
-
-  // ── Language / framework proper nouns (capitalised proper nouns, not prose) ──
-  { label: "language/framework name", pattern: /\b(TypeScript|JavaScript|Python|Golang|Java|Kotlin|Scala|Rust|Ruby|Hono|Drizzle|Postgres(QL)?|Django|Rails|Vue|Svelte|Angular)\b/ },
-  // "React" only as the proper noun (capital R) — avoids the verb "react".
-  { label: "React framework reference", pattern: /\bReact\b/ },
-  { label: "C-family language token", pattern: /C\+\+|C#/ },
-  // Infra / VCS proper nouns. `\bgit\b` is word-bounded so it never trips prose like
-  // "legitimate" / "digit"; the rest are unambiguous capitalised names.
-  { label: "infra / VCS proper noun", pattern: /\b(Docker|Kubernetes|Terraform|GitHub|GitLab)\b|\bgit\b/i },
-
-  // ── Project-specific symbols that only exist in memex-app ────────────────────
-  { label: "project-specific symbol", pattern: /\b(tagAc|createDocDraft|addSection|addClausesToSection|seedDefaultStandards|ensureUserNamespace)\b/ },
-  { label: "mutate() call / is_demo|is_default column", pattern: /\bmutate\(|\bis_demo\b|\bis_default\b|\bis_seed\b/ },
-
-  // ── This Memex's own handles by literal (std-N etc.) ────────────────────────
-  { label: "literal entity handle (std-N / spec-N / dec-N / ac-N / doc-N / cl-N / t-N)", pattern: /\b(std|spec|dec|ac|doc|cl|t)-\d+\b/i },
-];
-
 // Every scannable string in the fixture, with a location label for failure messages.
-function scannableStrings(): { where: string; text: string }[] {
-  const out: { where: string; text: string }[] = [];
+function scannableStrings(): Scannable[] {
+  const out: Scannable[] = [];
   for (const std of DEFAULT_STANDARDS) {
     out.push({ where: `${std.key} / title`, text: std.title });
     for (const section of std.sections) {
@@ -74,35 +39,16 @@ describe("spec-184: default Standards are std-22-portable (ac-17)", () => {
     tagAc(AC(17));
     tagAc(AC(3)); // scope ac-3: every default is portable per std-22
 
-    const violations: string[] = [];
-    for (const { where, text } of scannableStrings()) {
-      for (const rule of FORBIDDEN) {
-        const m = text.match(rule.pattern);
-        if (m) {
-          violations.push(`[${where}] ${rule.label}: matched "${m[0]}" in: ${text}`);
-        }
-      }
-    }
+    const violations = scanForNonPortableTokens(scannableStrings());
 
     expect(violations, `Non-portable tokens found:\n${violations.join("\n")}`).toEqual([]);
   });
 
   it("the forbidden-token list itself catches a known-bad sample (guards the guard)", () => {
     tagAc(AC(17));
-    // If a future refactor neuters the patterns, this canary fails.
-    const bad = [
-      "grep packages/server/src/__regression__ for the test",
-      "run pnpm vitest",
-      "tag the assertion with tagAc",
-      "see std-17 for the rule",
-      "edit the TypeScript file",
-      "build the Docker image and commit with git",
-      "the Ruby on Rails service",
-      "written in Rust, deployed via deno",
-    ];
-    for (const sample of bad) {
-      const hit = FORBIDDEN.some((r) => r.pattern.test(sample));
-      expect(hit, `expected to flag: ${sample}`).toBe(true);
-    }
+    // If a future refactor neuters the patterns, this canary names the sample that
+    // stopped being caught.
+    const unflagged = canarySamplesNotFlagged();
+    expect(unflagged, `deny-list stopped flagging: ${unflagged.join("; ")}`).toEqual([]);
   });
 });

--- a/packages/server/src/db/portability-scan.ts
+++ b/packages/server/src/db/portability-scan.ts
@@ -1,0 +1,125 @@
+// std-22 portability scanning for the product-default fixtures.
+//
+// Extracted from default-standards.portability.test.ts (spec-184 t-5) when spec-545
+// gave it a second consumer: the default FACET vocabulary needs the same scan, over a
+// different fixture shape. One deny-list with two adapters is a seam; two copies of
+// thirteen regexes is drift waiting to happen — the first edit to one list silently
+// stops protecting the other fixture [per std-51].
+//
+// WHAT THIS ENFORCES. Everything seeded into a stranger's Memex sits on a codebase we
+// cannot see. Per std-22 its text MUST NOT name a file path or layout, a language or
+// framework, a test runner / build tool / package manager, a project-specific symbol,
+// or one of this Memex's own entity handles — every one of those is meaningless, or
+// actively wrong, in a customer's workspace.
+//
+// The interface is two functions that each return a list of problems (empty = clean).
+// The patterns and the canary corpus stay private: a caller that could reach the raw
+// deny-list would be tempted to filter it per fixture, which is exactly the divergence
+// this module exists to prevent.
+
+/** One scannable string plus a location label used in failure messages. */
+export interface Scannable {
+  readonly where: string;
+  readonly text: string;
+}
+
+interface ForbiddenRule {
+  readonly label: string;
+  readonly pattern: RegExp;
+}
+
+// Precision over recall: each pattern catches the std-22 example violations WITHOUT
+// flagging ordinary English. In particular bare words that are also prose — "make",
+// "go", "build", "react" — are deliberately NOT matched; only unambiguous tool tokens,
+// proper-noun framework names, handle literals, and path shapes.
+const FORBIDDEN: readonly ForbiddenRule[] = [
+  // ── File paths & repo layout ────────────────────────────────────────────────
+  { label: "repo directory path", pattern: /\b(packages|src|dist|node_modules|tests?)\//i },
+  { label: "dunder test dir (e.g. __regression__)", pattern: /__[a-z]+__/i },
+  {
+    label: "source file with code extension",
+    pattern: /\b[\w-]+\.(ts|tsx|js|jsx|mjs|cjs|py|go|rb|rs|java|kt|php)\b/i,
+  },
+
+  // ── Test runners / build tools / package managers / runtimes ────────────────
+  {
+    label: "test runner / build / package-manager name",
+    pattern:
+      /\b(vitest|jest|mocha|pytest|rspec|pnpm|npm|yarn|bun|deno|webpack|vite|eslint|prettier|gradle|maven|tsc)\b/i,
+  },
+  { label: "Makefile / make target", pattern: /\bMakefile\b|\bmake\s+(test|build|dev|deploy|run)\b/i },
+
+  // ── Language / framework proper nouns (capitalised proper nouns, not prose) ──
+  {
+    label: "language/framework name",
+    pattern:
+      /\b(TypeScript|JavaScript|Python|Golang|Java|Kotlin|Scala|Rust|Ruby|Hono|Drizzle|Postgres(QL)?|Django|Rails|Vue|Svelte|Angular)\b/,
+  },
+  // "React" only as the proper noun (capital R) — avoids the verb "react".
+  { label: "React framework reference", pattern: /\bReact\b/ },
+  { label: "C-family language token", pattern: /C\+\+|C#/ },
+  // Infra / VCS proper nouns. `\bgit\b` is word-bounded so it never trips prose like
+  // "legitimate" / "digit"; the rest are unambiguous capitalised names.
+  { label: "infra / VCS proper noun", pattern: /\b(Docker|Kubernetes|Terraform|GitHub|GitLab)\b|\bgit\b/i },
+
+  // ── Language-specific module keywords (spec-545 ac-8) ───────────────────────
+  // A description that says "what a module exports" reads as neutral English but names
+  // a keyword that does not exist in every language; "what a module offers its callers"
+  // is the portable phrasing. Word-bounded, so "important" and "importance" are safe.
+  { label: "language-specific module keyword", pattern: /\bexports?\b|\bimports?\b/i },
+
+  // ── Project-specific symbols that only exist in this codebase ───────────────
+  {
+    label: "project-specific symbol",
+    pattern:
+      /\b(tagAc|createDocDraft|addSection|addClausesToSection|seedDefaultStandards|ensureUserNamespace)\b/,
+  },
+  { label: "mutate() call / is_demo|is_default column", pattern: /\bmutate\(|\bis_demo\b|\bis_default\b|\bis_seed\b/ },
+
+  // ── This Memex's own handles by literal (std-N etc.) ────────────────────────
+  {
+    label: "literal entity handle (std-N / spec-N / dec-N / ac-N / doc-N / cl-N / t-N)",
+    pattern: /\b(std|spec|dec|ac|doc|cl|t)-\d+\b/i,
+  },
+];
+
+// Known-bad strings that the deny-list MUST flag. If a future refactor neuters a
+// pattern, `canarySamplesNotFlagged()` names the sample that stopped being caught —
+// without which a guard can quietly degrade to always-green.
+const CANARY_SAMPLES: readonly string[] = [
+  "grep packages/server/src/__regression__ for the test",
+  "run pnpm vitest",
+  "tag the assertion with tagAc",
+  "see std-17 for the rule",
+  "edit the TypeScript file",
+  "build the Docker image and commit with git",
+  "the Ruby on Rails service",
+  "written in Rust, deployed via deno",
+  "adding to what a module exports",
+  "the symbols a file imports",
+];
+
+/**
+ * Scan fixture strings for non-portable tokens. Returns one readable violation line per
+ * (string, rule) hit — empty when the fixture is clean. Callers supply the adapter that
+ * flattens their own fixture shape into `Scannable`s.
+ */
+export function scanForNonPortableTokens(items: readonly Scannable[]): string[] {
+  const violations: string[] = [];
+  for (const { where, text } of items) {
+    for (const rule of FORBIDDEN) {
+      const match = text.match(rule.pattern);
+      if (match) violations.push(`[${where}] ${rule.label}: matched "${match[0]}" in: ${text}`);
+    }
+  }
+  return violations;
+}
+
+/**
+ * Guards the guard: returns any known-bad sample the deny-list FAILS to flag. Empty is
+ * the healthy state. A caller asserts on this rather than on the patterns themselves,
+ * so the rules stay private and the assertion survives a rewrite of them.
+ */
+export function canarySamplesNotFlagged(): string[] {
+  return CANARY_SAMPLES.filter((sample) => !FORBIDDEN.some((rule) => rule.pattern.test(sample)));
+}

--- a/packages/server/src/services/default-facets-no-overwrite.spec-545.integration.test.ts
+++ b/packages/server/src/services/default-facets-no-overwrite.spec-545.integration.test.ts
@@ -1,0 +1,173 @@
+// spec-545 t-4 — seeding and backfill CANNOT overwrite an edited facet description
+// (ac-11, ac-12).
+//
+// WHY THIS IS THE LOAD-BEARING TEST OF THE SPEC. spec-545 changes two facet
+// descriptions in two places that do not talk to each other: the product default in the
+// fixture, and the LIVE rows an agent actually reads. No code path can write the live
+// rows — the `facets` tool exposes only `list`, facet-vocab.ts has no writer, and
+// default-facets.ts only inserts — so the live change is a manual UPDATE (t-5).
+//
+// That manual write is only sane because re-seeding provably cannot revert it:
+// seedDefaultFacetsForOwner early-returns on the zero-row guard and its insert is
+// onConflictDoNothing, and backfillDefaultFacetsAllOwners just loops that same guarded
+// seed. Both facts were established by READING the code during specify. Reading is not
+// a guarantee — a later refactor to onConflictDoUpdate would silently revert production
+// data on the next provisioning run, with nothing failing. These tests make that
+// refactor loud.
+//
+// The sentinel stands in for the hand-edited production description; nothing here
+// depends on spec-545's actual wording, so the guard outlives this Spec.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import { facets, namespaces, memexes } from "../db/schema.js";
+import { DEFAULT_FACETS } from "../db/default-facets.fixture.js";
+import { seedDefaultFacetsForOwner, backfillDefaultFacetsAllOwners } from "./default-facets.js";
+import { makeTestMemex, makePersonalTestMemex } from "./test-helpers.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-545/acs/ac-${n}`;
+
+/** The facet whose description spec-545 actually rewords in production. */
+const EDITED_KEY = "architecture";
+
+type Owner = { ownerType: "org" | "memex"; ownerId: string };
+
+async function orgIdFor(memexId: string): Promise<string> {
+  const [row] = await db
+    .select({ orgId: namespaces.ownerOrgId })
+    .from(memexes)
+    .innerJoin(namespaces, eq(memexes.namespaceId, namespaces.id))
+    .where(eq(memexes.id, memexId))
+    .limit(1);
+  if (!row?.orgId) throw new Error("spec-545: could not resolve org for test memex");
+  return row.orgId;
+}
+
+async function rowsFor(owner: Owner): Promise<{ key: string; description: string }[]> {
+  return db
+    .select({ key: facets.key, description: facets.description })
+    .from(facets)
+    .where(and(eq(facets.ownerType, owner.ownerType), eq(facets.ownerId, owner.ownerId)));
+}
+
+async function descriptionOf(owner: Owner, key: string): Promise<string | undefined> {
+  return (await rowsFor(owner)).find((r) => r.key === key)?.description;
+}
+
+/** Hand-edit one description, the way t-5 will in int and prod. */
+async function writeSentinel(owner: Owner, key: string): Promise<string> {
+  // Unique per call (std-37): a shared literal is the habit that bites the next test.
+  const sentinel = `spec-545 sentinel ${randomUUID()}`;
+  await db
+    .update(facets)
+    .set({ description: sentinel })
+    .where(
+      and(
+        eq(facets.ownerType, owner.ownerType),
+        eq(facets.ownerId, owner.ownerId),
+        eq(facets.key, key),
+      ),
+    );
+  return sentinel;
+}
+
+let editedOwner: Owner; // an org whose description is hand-edited
+let untouchedOwner: Owner; // a second org, seeded, never edited
+let emptyMemexId: string; // a personal memex with NO vocabulary yet
+
+beforeAll(async () => {
+  editedOwner = { ownerType: "org", ownerId: await orgIdFor(await makeTestMemex("s545edit")) };
+  untouchedOwner = { ownerType: "org", ownerId: await orgIdFor(await makeTestMemex("s545keep")) };
+  emptyMemexId = await makePersonalTestMemex("s545empty");
+});
+
+afterAll(async () => {
+  // Scoped to what this file created, and idempotent (std-37).
+  for (const owner of [editedOwner, untouchedOwner, { ownerType: "memex" as const, ownerId: emptyMemexId }]) {
+    await db
+      .delete(facets)
+      .where(and(eq(facets.ownerType, owner.ownerType), eq(facets.ownerId, owner.ownerId)))
+      .catch(() => {});
+  }
+});
+
+describe("spec-545: re-seeding one owner cannot revert a hand-edited description (ac-11)", () => {
+  it("the sentinel survives a re-seed, and no rows are added", async () => {
+    tagAc(AC(11));
+
+    await seedDefaultFacetsForOwner(editedOwner);
+    const countAfterSeed = (await rowsFor(editedOwner)).length;
+    expect(countAfterSeed).toBe(DEFAULT_FACETS.length);
+
+    const sentinel = await writeSentinel(editedOwner, EDITED_KEY);
+    expect(await descriptionOf(editedOwner, EDITED_KEY)).toBe(sentinel);
+
+    // The provisioning path, run again against an owner that already has a vocabulary.
+    await seedDefaultFacetsForOwner(editedOwner);
+
+    expect(
+      await descriptionOf(editedOwner, EDITED_KEY),
+      "re-seeding reverted a hand-edited description — spec-545's live-row change (t-5) " +
+        "would be silently undone on the next provisioning run",
+    ).toBe(sentinel);
+    expect(await rowsFor(editedOwner)).toHaveLength(countAfterSeed);
+  });
+
+  it("leaves the owner's other descriptions alone too", async () => {
+    tagAc(AC(11));
+    // Scoped narrowly on purpose: a re-seed that rewrote every row EXCEPT the edited one
+    // would still be a data-loss bug, and the sentinel assertion alone would miss it.
+    const rows = await rowsFor(editedOwner);
+    const others = rows.filter((r) => r.key !== EDITED_KEY);
+    const fixtureByKey = new Map(DEFAULT_FACETS.map((f) => [f.key, f.description]));
+    for (const row of others) {
+      expect(row.description).toBe(fixtureByKey.get(row.key));
+    }
+  });
+});
+
+describe("spec-545: the all-owners backfill is equally non-destructive (ac-12)", () => {
+  it("keeps the sentinel, adds no rows, and still seeds an owner that had none", async () => {
+    tagAc(AC(12));
+
+    await seedDefaultFacetsForOwner(untouchedOwner);
+    const sentinel = await writeSentinel(untouchedOwner, EDITED_KEY);
+
+    const emptyOwner: Owner = { ownerType: "memex", ownerId: emptyMemexId };
+    // The precondition that makes the last assertion meaningful.
+    expect(await rowsFor(emptyOwner)).toHaveLength(0);
+
+    // The operator action most likely to be run after this Spec's deploy.
+    await backfillDefaultFacetsAllOwners();
+
+    expect(
+      await descriptionOf(untouchedOwner, EDITED_KEY),
+      "the all-owners backfill reverted a hand-edited description",
+    ).toBe(sentinel);
+    expect(await rowsFor(untouchedOwner)).toHaveLength(DEFAULT_FACETS.length);
+
+    // NOT just "nothing happened": a no-op implementation would pass every assertion
+    // above. The backfill must still do its job for an owner with no vocabulary.
+    expect(
+      (await rowsFor(emptyOwner)).map((r) => r.key).sort(),
+      "the backfill skipped an owner with zero facets — this test would otherwise pass " +
+        "against a function that does nothing at all",
+    ).toEqual(DEFAULT_FACETS.map((f) => f.key).sort());
+  });
+
+  it("survives a second backfill — idempotent, not merely first-run-safe", async () => {
+    tagAc(AC(12));
+    const before = await descriptionOf(untouchedOwner, EDITED_KEY);
+
+    await backfillDefaultFacetsAllOwners();
+
+    expect(await descriptionOf(untouchedOwner, EDITED_KEY)).toBe(before);
+    expect(await rowsFor(untouchedOwner)).toHaveLength(DEFAULT_FACETS.length);
+    expect(await rowsFor({ ownerType: "memex", ownerId: emptyMemexId })).toHaveLength(
+      DEFAULT_FACETS.length,
+    );
+  });
+});

--- a/standards.manifest.json
+++ b/standards.manifest.json
@@ -169,6 +169,10 @@
     {
       "handle": "std-42",
       "summary": "Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published."
+    },
+    {
+      "handle": "std-51",
+      "summary": "Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index."
     }
   ]
 }


### PR DESCRIPTION
Spec: [spec-545](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-545) · fair-code (dec-3)

## Why

When an agent creates a task, Memex forces a facet ballot and inlines the governing Standard clauses in the response. It is the strongest push channel the platform has — and its accuracy rests entirely on one string per facet: the `description` the agent reads to cast its vote.

`architecture` described only a redesign: *"how components are separated and how they communicate."* An agent adding a handler, creating a file, or widening what a module exposes honestly votes `false` — it isn't separating components, it's writing ordinary code. That is exactly the moment std-51 (module shape) governs. std-51 is advisory by design: no check gates a merge on it, so this channel is its **only** route to an agent. The rule was correctly written, correctly tagged, and never delivered.

Observable in this PR's own history: std-51 surfaced on 4 of the 6 tasks I created — always via `test-coverage`, never via `architecture`. I voted `architecture: false` on all of them, honestly, under the old wording.

## What changes

**Two descriptions, not one (dec-1).** The new `architecture` wording lands on ground `code-style` already claimed ("file organization"), whose tie-break arbitrated *typing rules only*. Shipping the `architecture` half alone would leave two descriptions on the same ground with no arbiter — trading a consistently wrong vote for an inconsistent one, and a delta measured over noise measures nothing.

- `architecture` — adds the everyday-work sentence; the `Governs a clause about where logic belongs` half is untouched.
- `code-style` — topic narrowed to how code is laid out *inside* a file; tie-break widened from typing rules to structure/placement generally.

**This is the product default only.** The live `facets` rows an agent actually reads are a separate manual change — no code path can write them (`facets` exposes only `list`, `facet-vocab.ts` has no writer, `default-facets.ts` only inserts). See "Not done here".

## Guards added

Each was proved non-vacuous by planting the regression it exists to catch, then reverting.

| Guard | Planted regression that reds it |
|---|---|
| `architecture` / `code-style` wording (ac-6, ac-7) | — (TDD: 4 red → 5 green) |
| std-22 portability over **all 16** entries (ac-8) | `"what a module exports"` in a description |
| The 16 keys pinned as a **literal** (ac-9) | renaming `architecture` → `architectures` |
| `--gap-only` defaults to false (ac-10) | `!argv.includes("--all")` |
| Re-seed can't revert an edit (ac-11, ac-12) | zero-row guard → delete-then-insert |
| Licence boundary (ac-14) | neutered predicate; `mv` into `.ee/` |

**ac-9 is the sharpest of these.** Keys are the ballot contract — `taskFacetBallots.vocabularyKeys`, every persisted `verdict` map, and `validateBallot`'s completeness check all key off them. A rename invalidates ballots already in the database *while every wording assertion keeps passing*, because the prose still reads correctly. Pinned as a literal on purpose: derived from the fixture, the assertion is a tautology that passes through any rename.

**ac-11/ac-12 are load-bearing for the manual write.** That write is only sane because re-seeding provably cannot revert it. That was established by *reading* the code during specify; reading is not a guarantee. A later refactor to an authoritative re-seed would silently revert production data on the next provisioning run with nothing failing.

## Deviations from the Spec, folded back

- **ac-14** named a `git diff develop...HEAD --name-status` check. Building it showed the diff is weaker: vacuously green once this branch merges, and dependent on a `develop` ref a shallow CI checkout need not have — so it stops guarding exactly when it would matter. Replaced with the list form spec-500 already uses, which keeps rename coverage by a different route (a moved file's old path stops existing). ac-14 updated to describe this.
- **dec-1** said "extend `code-style`'s tie-break". I also narrowed its *topic* phrase, because otherwise it kept claiming the contested ground at the topic level while the arbitration said the opposite. dec-1 left exact wording to build.

## Two shared modules extracted (std-51)

- `db/portability-scan.ts` — the std-22 deny-list, previously local to spec-184's standards guard, now with two adapters. Patterns and canary corpus stay private: a caller that could reach the raw list would filter it per fixture, which is the divergence the module prevents.
- `__regression__/licence-marker.ts` — the EE-marker predicate, shared with spec-500's guard. Four lines, and normally the deletion test says inline it — but this one decides which licence a file ships under, and two copies drifting on "is `.ee` an exact segment?" disagree about something with legal consequences.

## Test plan

- [x] Full server suite — **6510 passed, 0 failed** (699 files, 193s)
- [x] `make check` — green (43 standards)
- [x] `tsc --noEmit` — clean
- [x] Every guard proved non-vacuous by planting + reverting its regression
- [x] AC emission confirmed via `list_acs`, not inferred from a green suite — **8/10 implementation ACs verified**
- [x] Facet-adjacent suites re-run (handlers, autoseed, classifier, bootstrap-verdict, knowledge-graph, pills-projection): 53/53
- [x] spec-184 + spec-500 guards re-run green after their refactors
- [ ] **No e2e journey — deliberate, not an oversight.** std-28 requires one for user-facing flow changes. `packages/ui/src/api/types.ts` models a facet as `facetKeys?: string[]` only; there is no description field anywhere in the UI type surface and `FacetPills.tsx` renders keys. This string is agent-facing copy, never UI copy. Flag it if you read that differently.

## Not done here

- **The live-row `UPDATE` (t-5, ac-13).** int first as the rehearsal, then prod, scoped to the resolved owner — the `facets` table is owner-scoped, so a predicate keyed on `key` alone would cross every tenant. Requires this to be deployed first. **Until it runs, agents still read the old wording** — the fixture alone reaches only owners provisioned after the deploy.
- **Do not run `scripts/backfill-facet-tags.ts` without `--gap-only`** before or after this lands. A bare run re-tags every clause in the memex under the new descriptions (ac-4). ac-10 pins the flag so this warning can't go stale.
- **The other 14 descriptions.** dec-1 defers that audit to a follow-up informed by this change's measured delta — 16 changed at once is not measurable.
- **Fixture↔live parity check.** dec-4 defers it as *downstream* of the missing facet-description edit surface: a check can't define a legitimate divergence until the surface does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
