### PR TITLE
feat(spec-544): one Memex, two repos — per-repo Standard attribution and a live-list drift job

### DIFF
--- a/.github/actions/standards-index/action.yml
+++ b/.github/actions/standards-index/action.yml
@@ -41,8 +41,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # Third-party actions are pinned to an immutable commit SHA, not a mutable
+    # tag: `@v4` is a moving pointer, so whoever controls the tag controls what
+    # runs here. The repo's older workflows still use tags and are grandfathered
+    # by the Semgrep ratchet (security.yml scans diff-aware, so legacy debt is
+    # burned down separately) — new files clear the bar rather than widen it.
+    # Comment names the version the SHA is, or nobody can read the diff later.
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: "22"
 

--- a/.github/actions/standards-index/action.yml
+++ b/.github/actions/standards-index/action.yml
@@ -58,8 +58,20 @@ runs:
         # layout move fails in memex-ai's own suite rather than here at 3am.
         SCRIPT="$GITHUB_ACTION_PATH/../../../scripts/ci/standards-index.mjs"
         test -f "$SCRIPT" || { echo "::error::generator not found at $SCRIPT"; exit 1; }
-        # --root is the CALLER's checkout, not the action's.
-        node "$SCRIPT" --sync --repo "$REPO_NAME" --root "$GITHUB_WORKSPACE"
+
+        # TWO roots, and they are different things (dec-7):
+        #   --root     the repo being generated FOR — the caller's checkout.
+        #   --curation where the curated "Covers" prose lives — memex-ai, which is
+        #              THIS action's own checkout. It has one home; a caller reads
+        #              it and writes no manifest of its own.
+        # For memex-ai's own caller these resolve to the same tree, and the
+        # generator then behaves exactly as it does from the Makefile.
+        CURATION="$GITHUB_ACTION_PATH/../../.."
+        test -f "$CURATION/standards.manifest.json" || {
+          echo "::error::curated manifest not found at $CURATION — dec-7 expects it in memex-ai"; exit 1; }
+
+        node "$SCRIPT" --sync --repo "$REPO_NAME" \
+          --root "$GITHUB_WORKSPACE" --curation "$CURATION"
 
     - name: Open a PR if the index moved
       shell: bash
@@ -70,7 +82,16 @@ runs:
         REPO_NAME: ${{ inputs.repo }}
       run: |
         set -euo pipefail
-        if git diff --quiet -- CLAUDE.md standards.manifest.json; then
+
+        # The manifest is OPTIONAL: only the repo that owns the curation has one
+        # (dec-7). A pathspec naming a file git has never seen is an error, not an
+        # empty diff, so the path list is built from what actually exists.
+        PATHS=(CLAUDE.md)
+        if git ls-files --error-unmatch standards.manifest.json >/dev/null 2>&1; then
+          PATHS+=(standards.manifest.json)
+        fi
+
+        if git diff --quiet -- "${PATHS[@]}"; then
           echo "✓ index already current — nothing to open"
           exit 0
         fi
@@ -78,7 +99,7 @@ runs:
         git config user.name "memex-standards-bot"
         git config user.email "noreply@memex.ai"
         git checkout -B "$BRANCH"
-        git add CLAUDE.md standards.manifest.json
+        git add -- "${PATHS[@]}"
 
         # Heredocs, not `-m "…"` / `--body "…"`: a multi-line string written
         # inline in YAML carries this file's indentation into the real commit

--- a/.github/actions/standards-index/action.yml
+++ b/.github/actions/standards-index/action.yml
@@ -1,0 +1,117 @@
+# Refresh a repo's standards index from the LIVE Standard list, and open a PR if
+# it moved. spec-544 dec-6.
+#
+# WHY A COMPOSITE ACTION AND NOT A WORKFLOW IN EACH REPO. One Memex is the system
+# of record for two repositories, and the set-diff must exist ONCE — two
+# implementations kept in step by hand is the same duplication disease as two
+# manifests (dec-3). But the automatic GITHUB_TOKEN is scoped to the repository
+# its workflow runs in, so a job in memex-ai cannot open a PR in memex-clients.
+# Rather than introduce this repo's first PAT (tied to a person, expires silently
+# — the exact failure dec-3 designed out) or a GitHub App (heavy for keeping a
+# markdown table current), each repo calls THIS action from its own workflow and
+# opens its own PR with its own token. Nobody writes into anyone else's repo.
+#
+# The PR is deliberately the notification. There is no required check here: a
+# check that calls memex.ai would couple every merge to prod availability, and
+# develop/main carry enforce_admins with no bypass.
+
+name: Standards index
+description: >-
+  Sync a repository's CLAUDE.md standards index from the live Memex Standard
+  list, and open a pull request if it changed. Needs no credential to READ (the
+  Memex is public); writes with the caller's own repo-scoped token.
+
+inputs:
+  repo:
+    description: >-
+      Which repository's index to generate — the attribution name a Standard is
+      tagged with (e.g. memex-ai, memex-clients). Required and never defaulted:
+      generating the wrong repo's index would look like success.
+    required: true
+  token:
+    description: >-
+      The CALLER's own GITHUB_TOKEN. Repo-scoped on purpose — this action never
+      needs access to another repository.
+    required: true
+  branch:
+    description: Branch the PR is opened from.
+    required: false
+    default: chore/standards-index-refresh
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+
+    - name: Sync the index from the live Standard list
+      shell: bash
+      env:
+        REPO_NAME: ${{ inputs.repo }}
+      run: |
+        set -euo pipefail
+        # $GITHUB_ACTION_PATH is this action's directory inside the memex-ai
+        # checkout GitHub fetches for `uses:`. The script lives in that repo's
+        # scripts/ci, three levels up. Pinned by the spec-544 guard test, so a
+        # layout move fails in memex-ai's own suite rather than here at 3am.
+        SCRIPT="$GITHUB_ACTION_PATH/../../../scripts/ci/standards-index.mjs"
+        test -f "$SCRIPT" || { echo "::error::generator not found at $SCRIPT"; exit 1; }
+        # --root is the CALLER's checkout, not the action's.
+        node "$SCRIPT" --sync --repo "$REPO_NAME" --root "$GITHUB_WORKSPACE"
+
+    - name: Open a PR if the index moved
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        BRANCH: ${{ inputs.branch }}
+        REPO_NAME: ${{ inputs.repo }}
+      run: |
+        set -euo pipefail
+        if git diff --quiet -- CLAUDE.md standards.manifest.json; then
+          echo "✓ index already current — nothing to open"
+          exit 0
+        fi
+
+        git config user.name "memex-standards-bot"
+        git config user.email "noreply@memex.ai"
+        git checkout -B "$BRANCH"
+        git add CLAUDE.md standards.manifest.json
+
+        # Heredocs, not `-m "…"` / `--body "…"`: a multi-line string written
+        # inline in YAML carries this file's indentation into the real commit
+        # message and PR body.
+        git commit -F - <<'MSG'
+        chore: refresh the standards index from the live Memex list
+
+        A Standard approved in Memex was missing from this repo's index. An approved
+        Standard absent from the table an agent orients from is not binding anyone's
+        behaviour (spec-544).
+
+        Summaries seeded from a live title are placeholders — refine them when you
+        can; the rules are already visible.
+        MSG
+        git push --force-with-lease origin "$BRANCH"
+
+        # One rolling PR, not one per run: re-pushing the branch updates the
+        # existing PR, so a quiet week does not accumulate seven of them.
+        if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+          echo "✓ updated the open PR for $BRANCH"
+        else
+          gh pr create \
+            --base "${GITHUB_REF_NAME}" \
+            --head "$BRANCH" \
+            --title "chore: refresh the $REPO_NAME standards index" \
+            --body-file - <<'BODY'
+        The live Memex Standard list has Standards this repo's index does not.
+
+        A Standard that is approved but absent from `CLAUDE.md` binds nobody, because
+        that table is how a coding agent discovers which rules apply here.
+
+        Opened automatically by the standards-index action (spec-544 dec-3 / dec-6).
+        Reading the Memex needs no credential — it is public — and this PR was raised
+        with this repository's own token, never a cross-repo one.
+        BODY
+        fi

--- a/.github/workflows/standards-drift.yml
+++ b/.github/workflows/standards-drift.yml
@@ -1,0 +1,55 @@
+# memex-ai's caller for the shared standards-index action (spec-544 dec-6).
+#
+# The set-diff lives in .github/actions/standards-index; this file just runs it
+# with this repo's own token. memex-clients carries a near-identical caller of
+# its own — same action, its own token, its own PR.
+#
+# TRIGGERS (dec-3). `push: develop` is PRIMARY and `schedule:` is the net, not the
+# other way round. GitHub queues and SKIPS scheduled runs under load with no
+# alert on a missed tick, and it auto-disables scheduled workflows in a PUBLIC
+# repo after 60 days without commit activity — a silently-stopped drift job is the
+# same failure class as the green offline check this Spec exists to kill. Firing
+# on every merge removes the dependency on schedule delivery instead of hoping
+# for it, and makes a BROKEN job a visible red on the develop line.
+#
+# NOT A REQUIRED CHECK, deliberately. develop and main carry 11/10 required
+# contexts with enforce_admins on. A required check that calls memex.ai would
+# couple every merge to prod availability with no admin bypass; five bad minutes
+# in prod would block every PR. The PR this opens is the notification instead.
+
+name: standards drift
+
+on:
+  push:
+    branches: [develop]
+  schedule:
+    # Nightly, offset from test.yml's 06:00 perf run so they don't contend.
+    - cron: "40 5 * * *"
+  workflow_dispatch:
+
+# Least privilege, at the job level rather than the workflow root. First use of
+# `pull-requests` in this repo — nothing here has opened a PR from CI before.
+permissions:
+  contents: read
+
+concurrency:
+  # One refresh at a time; a newer push supersedes an in-flight run.
+  group: standards-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Refresh the standards index
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # commit the regenerated index to the PR branch
+      pull-requests: write # open / update the rolling PR
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Sync the index and open a PR if it moved
+        uses: ./.github/actions/standards-index
+        with:
+          repo: memex-ai
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/standards-drift.yml
+++ b/.github/workflows/standards-drift.yml
@@ -45,8 +45,10 @@ jobs:
       contents: write # commit the regenerated index to the PR branch
       pull-requests: write # open / update the rolling PR
     steps:
+      # Pinned to an immutable SHA, not the mutable `@v4` tag — see the note in
+      # .github/actions/standards-index/action.yml.
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Sync the index and open a PR if it moved
         uses: ./.github/actions/standards-index

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ mcp__memex__get_doc({ref: "mindset-prod/memex-building-itself/standards/std-N"})
 ## Standards index
 
 <!-- BEGIN generated: standards-index -->
+_The Standards that bind this repo. The Memex holds more — `search_memex({ memex: 'mindset-prod/memex-building-itself', kind: 'standard' })` lists every one._
+
 | Standard | Covers |
 |---|---|
 | std-1 | Namespace / org / memex are three distinct concepts — plus user-facing vocabulary and handle conventions (`b-N` / `doc-N` / `std-N` / `s-N` / `dec-N` / `t-N` / `c-N`). |
@@ -65,6 +67,14 @@ mcp__memex__get_doc({ref: "mindset-prod/memex-building-itself/standards/std-N"})
 | std-40 | Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer. |
 | std-41 | Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8). |
 | std-42 | Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published. |
+| std-43 | [REVERTED — abandoned, safe to archive/delete] Per-user-private tenant tables |
+| std-44 | Flutter clients run through fvm, ship desktop-only, and are not done until analyze and test both run clean |
+| std-45 | A claim about what the user sees is verified by mounting the widget — controller tests do not count |
+| std-46 | A live pty in a Flutter tree is never disturbed — no widget-type swaps, no size-enforcing boxes, no reflow without an explicit resize |
+| std-47 | macOS desktop input: modifiers may only ADD a path, and an ancestor Listener cannot decline |
+| std-48 | Dart has no Memex emission helper — memex-clients tags ACs with a hand-rolled acTest and a short-lived per-Spec key |
+| std-49 | A colour that spans repositories is read from what ships, never sampled from a screenshot |
+| std-50 | A value one component depends on and another owns is read, declared, or refused — never defaulted in silence |
 | std-51 | Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index. |
 <!-- END generated: standards-index -->
 
@@ -107,7 +117,8 @@ Each rule below has a check. Break one and the check tells you what to run — y
 
 | Rule | Check | Fix |
 |---|---|---|
-| The standards index above matches Memex | `make standards-check` (in `make check`) | `make standards-gen` |
+| The standards index above lists every Standard binding THIS repo | `make standards-check` (in `make check`, offline) | `make standards-gen` |
+| A Standard approved in Memex reaches this repo's index | the standards-drift job (`push` to develop + nightly) opens a PR | `make standards-sync` |
 | Your e2e run can't silently test another workspace's code | `scripts/ci/e2e-preflight.mjs` (auto, via `make e2e`/`e2e-cold`) | it prints the exact command |
 | Two worktrees don't collide on ports or databases | `make prove-concurrent` | — |
 | UI types are really checked (`tsc -b`, not the no-op `--noEmit`) | `make typecheck`, pinned by `spec-512-workspace-isolation` | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,13 +66,7 @@ _The Standards that bind this repo. The Memex holds more — `search_memex({ mem
 | std-39 | Database hygiene — every DB interaction is reasoned about for cost, locks, and growth, not just correctness. Covers migrations, handlers, MCP tools, relays, cron, and the React UI's query/polling patterns. |
 | std-40 | Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer. |
 | std-41 | Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8). |
-| std-42 | Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published. |
 | std-43 | [REVERTED — abandoned, safe to archive/delete] Per-user-private tenant tables |
-| std-44 | Flutter clients run through fvm, ship desktop-only, and are not done until analyze and test both run clean |
-| std-45 | A claim about what the user sees is verified by mounting the widget — controller tests do not count |
-| std-46 | A live pty in a Flutter tree is never disturbed — no widget-type swaps, no size-enforcing boxes, no reflow without an explicit resize |
-| std-47 | macOS desktop input: modifiers may only ADD a path, and an ancestor Listener cannot decline |
-| std-48 | Dart has no Memex emission helper — memex-clients tags ACs with a hand-rolled acTest and a short-lived per-Spec key |
 | std-49 | A colour that spans repositories is read from what ships, never sampled from a screenshot |
 | std-50 | A value one component depends on and another owns is read, declared, or refused — never defaulted in silence |
 | std-51 | Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ _The Standards that bind this repo. The Memex holds more — `search_memex({ mem
 | std-49 | A colour that spans repositories is read from what ships, never sampled from a screenshot |
 | std-50 | A value one component depends on and another owns is read, declared, or refused — never defaulted in silence |
 | std-51 | Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index. |
+| std-52 | A defect's cause is claimed only after a command goes red on it — the loop comes before the theory |
 <!-- END generated: standards-index -->
 
 If a Standard contradicts the code, the Standard is probably right and the code has drifted — flag it.

--- a/Makefile
+++ b/Makefile
@@ -309,15 +309,17 @@ help:
 
 ## Fail if the CLAUDE.md standards index has drifted from the manifest.
 standards-check:
-	@node scripts/ci/standards-index.mjs --check
+	@node scripts/ci/standards-index.mjs --check --repo memex-ai
 
 ## Regenerate the CLAUDE.md standards index from standards.manifest.json.
 standards-gen:
-	@node scripts/ci/standards-index.mjs --write
+	@node scripts/ci/standards-index.mjs --write --repo memex-ai
 
-## Refresh the manifest FROM Memex (online — an agent runs search_memex and
-## rewrites standards.manifest.json), then regenerate. Deliberately not part of
-## `make check`: the offline lane must never need the network.
+## Refresh the manifest from the LIVE Standard list, then regenerate the index
+## (spec-544 dec-3). Online, and deliberately NOT part of `make check` — the
+## offline lane must never need the network. Needs no credential: the Memex is
+## public, so this is a plain unauthenticated GET. A Standard the manifest has
+## never seen is SEEDED from its live title and reported as a placeholder; the
+## rule becomes visible immediately rather than waiting on prose.
 standards-sync:
-	@echo "Refresh standards.manifest.json from Memex, then run: make standards-gen"
-	@echo "  search_memex({ memex: 'mindset-prod/memex-building-itself', kind: 'standard' })"
+	@node scripts/ci/standards-index.mjs --sync --repo memex-ai

--- a/packages/server/src/__regression__/spec-512-standards-index.regression.test.ts
+++ b/packages/server/src/__regression__/spec-512-standards-index.regression.test.ts
@@ -48,9 +48,19 @@ describe("spec-512: the standards index is generated and complete", () => {
         `make the completeness assertion below pass against nothing.`,
     ).toBeGreaterThan(30);
 
-    const handlesInManifest = MANIFEST.standards.map(
-      (s: { handle: string }) => s.handle,
-    );
+    // spec-544 dec-2 CHANGED this invariant, deliberately. The manifest is the
+    // authority for the whole Memex; each repo's index lists only the Standards
+    // ATTRIBUTED to it (an entry with no `repos` binds every repo — fail-open).
+    // So "complete" now means complete FOR THIS REPO, and comparing against the
+    // unfiltered manifest reports memex-clients' Standards as missing here.
+    // spec-512's ac-15 is untouched by this: it names std-38 and std-39, both of
+    // which bind memex-ai and are both still present.
+    const handlesInManifest = MANIFEST.standards
+      .filter(
+        (s: { handle: string; repos?: string[] }) =>
+          !Array.isArray(s.repos) || s.repos.length === 0 || s.repos.includes("memex-ai"),
+      )
+      .map((s: { handle: string }) => s.handle);
     const missing = handlesInManifest.filter(
       (h: string) => !handlesInFile.includes(h),
     );
@@ -65,9 +75,14 @@ describe("spec-512: the standards index is generated and complete", () => {
         `Check: packages/server/src/__regression__/spec-512-standards-index.regression.test.ts`,
     ).toEqual([]);
 
-    // The five that had actually drifted. Pinned by name so a regression is named,
-    // not merely counted.
-    for (const h of ["std-38", "std-39", "std-40", "std-41", "std-42"]) {
+    // The ones that had actually drifted, pinned by name so a regression is named
+    // and not merely counted. std-42 has LEFT this list: it is the memex-clients
+    // release runbook, and its presence in the server repo's index was the leftover
+    // spec-544 dec-2 cited as making the two-repo split ambiguous rather than merely
+    // incomplete. It is now attributed to memex-clients and belongs in that repo's
+    // index only. std-40 and std-41 stay because nothing has attributed them yet, so
+    // fail-open keeps them everywhere.
+    for (const h of ["std-38", "std-39", "std-40", "std-41"]) {
       expect(handlesInFile, `${h} must be indexed in CLAUDE.md`).toContain(h);
     }
   });
@@ -81,7 +96,9 @@ describe("spec-512: the standards index is generated and complete", () => {
     // The table must be INSIDE the region, not adjacent to it.
     const inner = CLAUDE_MD.slice(regions[0].start, regions[0].end);
     expect(inner).toMatch(/\|\s*std-1\s*\|/);
-    expect(inner).toMatch(/\|\s*std-42\s*\|/);
+    // The last row this repo's index actually carries. std-42 used to anchor this
+    // and no longer belongs here (see above) — std-51 is the current tail.
+    expect(inner).toMatch(/\|\s*std-51\s*\|/);
   });
 });
 

--- a/packages/server/src/__regression__/spec-544-one-curation-home.regression.test.ts
+++ b/packages/server/src/__regression__/spec-544-one-curation-home.regression.test.ts
@@ -1,0 +1,142 @@
+// spec-544 dec-7 — the curated "Covers" prose has ONE home.
+//
+// WHAT WENT WRONG, measured. dec-3 gave each repo "an index and a manifest".
+// Both existed for about ten minutes and already disagreed: std-1 read
+// "Namespace / org / memex are three distinct concepts — plus user-facing
+// vocabulary and handle conventions…" in memex-ai and "Namespace, org, and memex
+// are distinct concepts" in memex-clients, because the latter was seeded from
+// live titles with no curated source to draw on. All 51 of its summaries were
+// placeholders, each repo's job rewrites only its own file, and nothing noticed.
+// dec-3 reasoned about duplicated CODE and did not notice it was prescribing
+// duplicated PROSE.
+//
+// dec-7's fix follows dec-3's own logic to its conclusion: a manifest exists to
+// be compared against an index by the offline check, and memex-clients has no
+// check, so the file there had no reader at all. It is gone. Curation lives in
+// memex-ai; every other repo generates from it.
+//
+// These are the same two shapes of guard used elsewhere in this Spec — a pure
+// test where the behaviour is pure, and a source guard where the property is
+// about file placement and cannot be observed from inside this repo (the other
+// repo's tree is not readable here). Said plainly rather than implied.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { planIndex } from "../../../../scripts/ci/standards-index.mjs";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-544/acs/ac-${n}`;
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SCRIPT = readFileSync(
+  join(REPO_ROOT, "scripts", "ci", "standards-index.mjs"),
+  "utf8",
+);
+const ACTION = readFileSync(
+  join(REPO_ROOT, ".github", "actions", "standards-index", "action.yml"),
+  "utf8",
+);
+
+describe("spec-544: a repo with no curation still gets the curated prose (ac-25)", () => {
+  it("renders memex-ai's summary into memex-clients' table, not the live title", () => {
+    tagAc(AC(25));
+
+    // The live list only ever returns a title. The curated prose is richer, and
+    // the whole point of one curation home is that the OTHER repo benefits from
+    // it rather than falling back to the terse title.
+    const live = [
+      {
+        handle: "std-44",
+        title: "Flutter clients run through fvm, ship desktop-only",
+        tags: [{ scope: null, value: "memex-clients" }],
+      },
+      {
+        handle: "std-46",
+        title: "A live pty in a Flutter tree is never disturbed",
+        tags: [{ scope: null, value: "memex-clients" }],
+      },
+    ];
+    // memex-ai's manifest — curated, and the only place this prose exists.
+    const curated = [
+      {
+        handle: "std-44",
+        summary:
+          "Flutter clients run through fvm, ship desktop-only, and are not done " +
+          "until analyze and test BOTH run clean.",
+      },
+    ];
+
+    const { table, seeded } = planIndex({
+      live,
+      manifest: curated,
+      repo: "memex-clients",
+    });
+
+    expect(
+      table,
+      "std-44 is curated in memex-ai, so memex-clients' index must carry that " +
+        "prose — a repo without its own manifest is not a repo without good summaries.",
+    ).toContain("and are not done until analyze and test BOTH run clean.");
+    expect(
+      seeded,
+      "Only the Standard nobody has written prose for yet falls back to its title.",
+    ).toEqual(["std-46"]);
+    expect(table).toContain("A live pty in a Flutter tree is never disturbed");
+  });
+});
+
+describe("spec-544: only the curation owner writes a manifest (ac-24)", () => {
+  it("the manifest write is gated on curation being the output root", () => {
+    tagAc(AC(24));
+
+    // A memex-clients run reads memex-ai's manifest out of the action's own
+    // ephemeral checkout. Writing to it there would be worse than pointless: the
+    // seeded summary would be silently discarded when the runner is torn down,
+    // so the next run would seed it again and report a placeholder forever.
+    const sync = SCRIPT.slice(SCRIPT.search(/(?:async\s+)?function\s+sync\s*\(/));
+    const body = sync.slice(0, sync.indexOf("\nasync function main"));
+
+    expect(
+      body,
+      "sync() must compare the curation root against the output root before " +
+        "writing the manifest.",
+    ).toMatch(/curation\s*===\s*root|ownsCuration|isCurationOwner/);
+
+    const writeAt = body.search(/writeFileSync\s*\(\s*manifestPath/);
+    expect(writeAt, "sync() must still write the manifest somewhere").toBeGreaterThan(-1);
+
+    const guardAt = body.search(/curation\s*===\s*root|ownsCuration|isCurationOwner/);
+    expect(
+      guardAt,
+      "The ownership check must come BEFORE the manifest write, or the write " +
+        "happens unconditionally and dec-7 is undone.",
+    ).toBeLessThan(writeAt);
+  });
+
+  it("the two roots are separate arguments, and curation defaults to root", () => {
+    tagAc(AC(24));
+
+    expect(SCRIPT, "--curation must be a real argument").toMatch(/["']--curation["']/);
+    expect(
+      SCRIPT,
+      "Defaulting curation to root keeps every memex-ai invocation unchanged — " +
+        "one repo owning its own curation is the common case.",
+    ).toMatch(/curation:\s*flag\(["']--curation["']\)\s*\?\?\s*root/);
+  });
+
+  it("the shared action points the two roots at different places", () => {
+    tagAc(AC(24));
+
+    // In a caller's run: --root is the CALLER's checkout, --curation is the
+    // memex-ai checkout GitHub fetched for the action. Same value would silently
+    // recreate a per-repo manifest.
+    expect(ACTION).toMatch(/--root\s+"?\$(?:\{)?GITHUB_WORKSPACE/);
+    expect(
+      ACTION,
+      "--curation must resolve into the ACTION's own checkout, which is where " +
+        "memex-ai's curated manifest is.",
+    ).toMatch(/--curation\s+"?\$(?:\{)?GITHUB_ACTION_PATH|--curation\s+"?\$\{?CURATION/);
+  });
+});

--- a/packages/server/src/__regression__/spec-544-standards-check-stays-offline.regression.test.ts
+++ b/packages/server/src/__regression__/spec-544-standards-check-stays-offline.regression.test.ts
@@ -1,0 +1,164 @@
+// spec-544 ac-10 — `make check` must stay offline after this work.
+//
+// WHY THIS GUARD EXISTS. spec-544 gave the generator a network mode, and the
+// tempting "improvement" is to make `--check` consult the live list too, so the
+// offline check can catch a drifted manifest. That would be wrong twice over:
+// `make check` is the sub-minute lane that replaces push-and-wait (no DB, no
+// network), and a PR must never go red because a network call was unavailable.
+// dec-3 put the live comparison in a separate, non-required job precisely so the
+// merge path never depends on prod being up.
+//
+// WHAT THIS PROVES, AND WHAT IT DOES NOT. These are STRUCTURAL guards over the
+// source and the Makefile — the same idiom the repo already uses for the std-8
+// mutate scan and the std-30 no-direct-anthropic guard. They prove that `fetch`
+// is reachable only from the one online function and that `standards-check` never
+// asks for the online mode. They do NOT prove the process opens no socket at all;
+// a transitive dependency could in principle. That stronger claim needs a
+// sandboxed run with the network removed, which is the CI environment's job, not
+// a unit test's. Stated plainly rather than overclaimed.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC10 = "mindset-prod/memex-building-itself/specs/spec-544/acs/ac-10";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SCRIPT = readFileSync(
+  join(REPO_ROOT, "scripts", "ci", "standards-index.mjs"),
+  "utf8",
+);
+const MAKEFILE = readFileSync(join(REPO_ROOT, "Makefile"), "utf8");
+
+/** The body of a top-level `function name(...)` / `async function name(...)`.
+ *
+ *  Skips the PARAMETER LIST first, by paren matching, before brace matching the
+ *  body — a destructured parameter (`function sync({ repo, root })`) opens a brace
+ *  of its own, and starting at the first `{` after the name returns `{ repo, root }`
+ *  instead of the function. That mistake made this file's own guard pass against
+ *  a two-word string, so it is fixed here rather than worked around. */
+function functionBody(source: string, name: string): string {
+  const decl = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\(`);
+  const at = source.search(decl);
+  expect(at, `${name}() must exist in standards-index.mjs`).toBeGreaterThan(-1);
+
+  // Walk the parameter list to its closing paren.
+  const parenOpen = source.indexOf("(", at);
+  let parens = 0;
+  let bodyStart = -1;
+  for (let i = parenOpen; i < source.length; i++) {
+    if (source[i] === "(") parens++;
+    else if (source[i] === ")") {
+      parens--;
+      if (parens === 0) {
+        bodyStart = source.indexOf("{", i);
+        break;
+      }
+    }
+  }
+  expect(bodyStart, `could not find the body of ${name}()`).toBeGreaterThan(-1);
+
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) return source.slice(bodyStart, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces reading ${name}()`);
+}
+
+describe("spec-544: the offline check never reaches the network (ac-10)", () => {
+  it("fetch( is called from exactly ONE function, the online edge", () => {
+    tagAc(AC10);
+
+    // Denominator: if this regex stops matching, every assertion below is vacuous.
+    const callSites = [...SCRIPT.matchAll(/(?<![.\w])fetch\s*\(/g)];
+    expect(
+      callSites.length,
+      "No `fetch(` call site found at all — the regex has broken, which would make " +
+        "the containment assertion below pass against nothing.",
+    ).toBeGreaterThan(0);
+
+    const edge = functionBody(SCRIPT, "fetchLiveStandards");
+    const outside = callSites.filter((m) => !edge.includes(SCRIPT.slice(m.index!, m.index! + 8)));
+
+    // Positive containment: the one call site lives in the online edge.
+    expect(edge, "fetchLiveStandards is the network edge and must hold the call").toMatch(
+      /(?<![.\w])fetch\s*\(/,
+    );
+    expect(
+      callSites.length,
+      `Expected exactly one \`fetch(\` in the generator; found ${callSites.length}. ` +
+        `A second call site means the network has leaked out of fetchLiveStandards — ` +
+        `and the offline lane is one refactor away from needing it. Found ${outside.length} ` +
+        `outside the edge.`,
+    ).toBe(1);
+  });
+
+  it("the check path never calls the online edge", () => {
+    tagAc(AC10);
+
+    // main() may only reach fetchLiveStandards THROUGH sync(), and sync() may only
+    // run in the 'sync' mode. If main called the edge directly, --check would be
+    // online regardless of mode.
+    const main = functionBody(SCRIPT, "main");
+    expect(
+      main,
+      "main() must not call fetchLiveStandards directly — it goes through sync(), " +
+        "which only runs in the online mode.",
+    ).not.toMatch(/fetchLiveStandards\s*\(/);
+    expect(
+      main,
+      "sync() must be gated on the mode, so --check and --write cannot reach it.",
+    ).toMatch(/mode\s*===\s*["']sync["']/);
+
+    const sync = functionBody(SCRIPT, "sync");
+    expect(sync, "sync() is the only caller of the online edge").toMatch(
+      /fetchLiveStandards\s*\(/,
+    );
+  });
+
+  it("make standards-check asks for the offline mode, and make check depends on it", () => {
+    tagAc(AC10);
+
+    const target = MAKEFILE.split(/^standards-check:/m)[1] ?? "";
+    expect(target, "the standards-check target must exist").not.toBe("");
+    const recipe = target.split(/\n(?=\S)/)[0];
+
+    expect(recipe, "standards-check must run the offline --check mode").toContain("--check");
+    expect(
+      recipe,
+      "standards-check must NEVER pass --sync — that is the online mode, and " +
+        "`make check` is the no-network lane.",
+    ).not.toContain("--sync");
+    expect(
+      recipe,
+      "The check is per-repo now, and --repo is required — a target without it " +
+        "would fail at parse time rather than checking anything.",
+    ).toContain("--repo");
+
+    // And the offline battery still includes it (spec-512 dec-4's original point).
+    const checkTarget = MAKEFILE.split(/^check:/m)[1]?.split("\n")[0] ?? "";
+    expect(
+      checkTarget,
+      "`make check` must still run standards-check, or a stale index goes unnoticed.",
+    ).toContain("standards-check");
+  });
+
+  it("standards-sync is the ONLY target that asks for the network", () => {
+    tagAc(AC10);
+
+    const syncTargets = [...MAKEFILE.matchAll(/^([a-z-]+):[^\n]*\n((?:\t[^\n]*\n)+)/gm)]
+      .filter(([, , recipe]) => recipe.includes("--sync"))
+      .map(([, name]) => name);
+
+    expect(
+      syncTargets,
+      "Exactly one Make target may request the online mode. Any other target " +
+        "carrying --sync would drag the network into a lane that must not need it.",
+    ).toEqual(["standards-sync"]);
+  });
+});

--- a/packages/server/src/__regression__/spec-544-standards-drift-workflow.regression.test.ts
+++ b/packages/server/src/__regression__/spec-544-standards-drift-workflow.regression.test.ts
@@ -1,0 +1,188 @@
+// spec-544 — the drift job's shape is load-bearing, so it is pinned.
+//
+// Three properties, each with a failure mode that is INVISIBLE at 3am if it
+// regresses:
+//
+//   ac-11 — triggers on `push: develop` as well as `schedule:`, and is not a
+//           required check. GitHub skips scheduled runs under load and disables
+//           them entirely in a public repo after 60 days of no commits; a job
+//           that only fires on a timer can stop without anyone noticing. And a
+//           REQUIRED check calling memex.ai would couple every merge to prod
+//           uptime, with enforce_admins leaving no bypass.
+//   ac-22 — no cross-repo credential. The whole point of dec-6 is that each repo
+//           opens its own PR with its own repo-scoped token, so the first PAT in
+//           this repo never gets minted.
+//   ac-23 — the set-diff exists once. If the caller ever grows its own copy of
+//           the comparison, memex-clients starts drifting from memex-ai again.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-544/acs/ac-${n}`;
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const WORKFLOW_DIR = join(REPO_ROOT, ".github", "workflows");
+const ACTION_DIR = join(REPO_ROOT, ".github", "actions", "standards-index");
+
+const WORKFLOW = readFileSync(join(WORKFLOW_DIR, "standards-drift.yml"), "utf8");
+const ACTION = readFileSync(join(ACTION_DIR, "action.yml"), "utf8");
+
+describe("spec-544: the drift job fires on merges, not only on a timer (ac-11)", () => {
+  it("triggers on push to develop AND on a schedule", () => {
+    tagAc(AC(11));
+
+    expect(
+      WORKFLOW,
+      "A schedule-only job can stop silently: GitHub skips scheduled runs under " +
+        "load, and auto-disables them in a PUBLIC repo after 60 days without " +
+        "commits. `push: develop` is what makes a broken job a visible red.",
+    ).toMatch(/push:\s*\n\s*branches:\s*\[develop\]/);
+    expect(WORKFLOW, "the schedule stays as the net for quiet periods").toMatch(
+      /schedule:\s*\n(?:\s*#[^\n]*\n)*\s*- cron:/,
+    );
+  });
+
+  it("does not contend with the nightly perf run's slot", () => {
+    tagAc(AC(11));
+
+    const perf = readFileSync(join(WORKFLOW_DIR, "test.yml"), "utf8");
+    const slot = (src: string) => src.match(/- cron:\s*"([^"]+)"/)?.[1];
+    expect(slot(WORKFLOW)).toBeDefined();
+    expect(
+      slot(WORKFLOW),
+      "Sharing test.yml's cron slot would put a network job and the perf run on " +
+        "the same runners at the same minute for no reason.",
+    ).not.toBe(slot(perf));
+  });
+
+  it("is absent from every required-check aggregate", () => {
+    tagAc(AC(11));
+
+    // Nothing in this repo may name the drift job as a gate. Branch protection
+    // itself lives on GitHub and cannot be read from here — stated rather than
+    // implied: this pins the REPO side, and the protection settings stay a manual
+    // check. What it does catch is the realistic regression, someone wiring the
+    // job into an existing aggregate.
+    for (const file of readdirSync(WORKFLOW_DIR).filter((f) => f.endsWith(".yml"))) {
+      if (file === "standards-drift.yml") continue;
+      const src = readFileSync(join(WORKFLOW_DIR, file), "utf8");
+      expect(
+        src,
+        `${file} must not depend on the standards drift job — making it a gate would ` +
+          `couple merges to memex.ai's availability, and enforce_admins leaves no bypass.`,
+      ).not.toMatch(/standards-drift/);
+    }
+  });
+});
+
+describe("spec-544: no cross-repo credential (ac-22)", () => {
+  it("the caller passes only its own GITHUB_TOKEN", () => {
+    tagAc(AC(22));
+
+    expect(WORKFLOW).toMatch(/token:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/);
+
+    // The realistic regression: someone hits the cross-repo wall and reaches for
+    // a PAT or an App. Both are refused here by name.
+    const secretsUsed = [...WORKFLOW.matchAll(/secrets\.([A-Z_][A-Z0-9_]*)/g)].map(
+      (m) => m[1],
+    );
+    expect(
+      secretsUsed,
+      "The drift job must use NOTHING but the automatic token. A PAT is tied to a " +
+        "person and expires silently — the failure dec-3 spent its resolution " +
+        "designing out.",
+    ).toEqual(["GITHUB_TOKEN"]);
+
+    // Match credential USAGE, not the words. The action's own comments explain
+    // why a PAT and a GitHub App were rejected, and prose that argues against a
+    // thing must not trip a guard against using it — otherwise the guard
+    // pressures the next author into deleting the reasoning.
+    const usage = [
+      /secrets\.[A-Z_]*(?:PAT|TOKEN_[A-Z]|APP_ID|PRIVATE_KEY)/,
+      /create-github-app-token/,
+      /actions\/create-github-app-token/,
+    ];
+    for (const forbidden of usage) {
+      expect(ACTION, `the action must not USE ${forbidden}`).not.toMatch(forbidden);
+      expect(WORKFLOW, `the caller must not USE ${forbidden}`).not.toMatch(forbidden);
+    }
+
+    // A composite action cannot read `secrets` at all — it receives the token as
+    // an input. Any `secrets.` reference in it is a sign someone tried.
+    expect(
+      ACTION,
+      "The action takes the token as an INPUT; reaching for `secrets` inside it " +
+        "would mean a credential was wired somewhere it cannot work.",
+    ).not.toMatch(/\$\{\{\s*secrets\./);
+  });
+
+  it("permissions are least-privilege and scoped to the job", () => {
+    tagAc(AC(22));
+
+    // Root stays read-only; the write grants sit on the one job that needs them.
+    expect(WORKFLOW).toMatch(/^permissions:\s*\n\s*contents: read\s*$/m);
+    expect(WORKFLOW).toMatch(/contents: write/);
+    expect(
+      WORKFLOW,
+      "First use of `pull-requests` in this repo — it belongs on the job, not the root.",
+    ).toMatch(/pull-requests: write/);
+  });
+});
+
+describe("spec-544: the set-diff is written once (ac-23)", () => {
+  it("the caller delegates to the shared action and implements nothing", () => {
+    tagAc(AC(23));
+
+    expect(WORKFLOW).toMatch(/uses:\s*\.\/\.github\/actions\/standards-index/);
+    expect(
+      WORKFLOW,
+      "The caller must not run the generator itself — a second invocation path is " +
+        "a second thing to keep in step with memex-clients.",
+    ).not.toMatch(/standards-index\.mjs/);
+    expect(WORKFLOW, "and must not reimplement the comparison").not.toMatch(
+      /planIndex|fetchLiveStandards|type=standard/,
+    );
+  });
+
+  it("the action's relative path to the generator actually resolves", () => {
+    tagAc(AC(23));
+
+    // The action runs inside the memex-ai checkout GitHub fetches for `uses:`,
+    // and reaches the script three levels up from its own directory. That string
+    // is the one thing a layout move would break — and it would break at 3am in
+    // ANOTHER repo's workflow run, where nobody is looking. Pin it here, in
+    // memex-ai's own suite, where a move goes red immediately.
+    const relative = ACTION.match(
+      /GITHUB_ACTION_PATH\/((?:\.\.\/)+[^"'\s]*standards-index\.mjs)/,
+    )?.[1];
+    expect(
+      relative,
+      "the action must reach the generator via $GITHUB_ACTION_PATH",
+    ).toBeDefined();
+
+    const resolved = join(ACTION_DIR, relative!);
+    expect(
+      existsSync(resolved),
+      `The action points at "${relative}" from its own directory, which resolves to\n` +
+        `  ${resolved}\n` +
+        `and nothing is there. The generator moved without the action following.`,
+    ).toBe(true);
+  });
+
+  it("the action requires an explicit repo and never defaults one", () => {
+    tagAc(AC(23));
+
+    expect(ACTION).toMatch(/repo:[\s\S]{0,400}?required:\s*true/);
+    // A default here would silently generate memex-ai's index inside
+    // memex-clients — and report success.
+    const repoInput = ACTION.split(/^\s{2}repo:/m)[1]?.split(/^\s{2}\w/m)[0] ?? "";
+    expect(
+      repoInput,
+      "`repo` must have no default — the wrong index generated successfully is worse " +
+        "than a failed run.",
+    ).not.toMatch(/default:/);
+  });
+});

--- a/packages/server/src/__regression__/spec-544-standards-live-fetch.regression.test.ts
+++ b/packages/server/src/__regression__/spec-544-standards-live-fetch.regression.test.ts
@@ -1,0 +1,140 @@
+// spec-544 — the live Standard list is read with NO credential, in ONE call.
+//
+// This is the single network edge of the comparator. Its sibling file
+// (spec-544-standards-live-plan) covers the pure plan; keeping them apart is what
+// lets `make check` stay offline (ac-10) while both halves stay covered.
+//
+// WHY "no credential" is a pinned property and not an accident: the generator's own
+// header used to justify the offline mirror with "CI holds no Memex credentials".
+// That premise was over-broad — reading this Memex needs no credential at all,
+// because it is public by design (std-31) and every GET goes behind the permissive
+// public session, resolving public → read / private → 404 (std-7). Verified live
+// 2026-09-02: 200, 51 rows, unauthenticated. If someone later "fixes" this by
+// attaching a token, the fix would be a regression: it would couple a public read to
+// a secret that can expire, and reintroduce exactly the silent-stop failure dec-3
+// designed out.
+//
+// The stub is restored in afterEach per std-37 — a leaked global fetch would poison
+// every suite sharing the worker.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { fetchLiveStandards } from "../../../../scripts/ci/standards-index.mjs";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-544/acs/ac-${n}`;
+
+const URL_UNDER_TEST =
+  "https://memex.ai/api/mindset-prod/memex-building-itself/docs?type=standard&include=tags";
+
+const okJson = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("spec-544: the live read carries no credential and costs one call", () => {
+  it("sends no Authorization, Cookie or secret of any kind (ac-7)", async () => {
+    tagAc(AC(7));
+
+    const spy = vi.fn(async () => okJson([{ handle: "std-1", title: "T", tags: [] }]));
+    vi.stubGlobal("fetch", spy);
+
+    await fetchLiveStandards(URL_UNDER_TEST);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = spy.mock.calls[0] as unknown as [
+      string,
+      RequestInit | undefined,
+    ];
+
+    // Whatever headers were passed (most likely none at all), none may be an
+    // credential-bearing one.
+    const headers = Object.fromEntries(
+      Object.entries((init?.headers ?? {}) as Record<string, string>).map(
+        ([k, v]) => [k.toLowerCase(), v],
+      ),
+    );
+    for (const forbidden of ["authorization", "cookie", "x-api-key"]) {
+      expect(
+        headers[forbidden],
+        `The live read must stay unauthenticated — a "${forbidden}" header couples a ` +
+          `PUBLIC read to a secret that can expire, and a silently-expiring credential ` +
+          `is the failure dec-3 exists to avoid.`,
+      ).toBeUndefined();
+    }
+
+    // No token smuggled through the query string either.
+    expect(String(calledUrl)).not.toMatch(/token|key|secret|bearer|mxk_/i);
+  });
+
+  it("asks for the tags in the SAME request as the handles (ac-7)", async () => {
+    tagAc(AC(7));
+
+    const spy = vi.fn(async () => okJson([{ handle: "std-1", title: "T", tags: [] }]));
+    vi.stubGlobal("fetch", spy);
+
+    await fetchLiveStandards(URL_UNDER_TEST);
+
+    const calledUrl = String((spy.mock.calls[0] as unknown as [string])[0]);
+    expect(calledUrl).toContain("type=standard");
+    expect(
+      calledUrl,
+      "`include=tags` is an opt-in on the same list route — omitting it returns rows " +
+        "with NO tags key, which fail-open would then read as 'binds every repo' for " +
+        "all 51 Standards. Attribution must ride the same call as the handles.",
+    ).toContain("include=tags");
+    expect(spy, "One call, not two").toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the rows verbatim for the planner to validate (ac-7)", async () => {
+    tagAc(AC(7));
+
+    const rows = [
+      { handle: "std-1", title: "One", tags: [] },
+      { handle: "std-44", title: "Two", tags: [{ scope: null, value: "memex-clients" }] },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async () => okJson(rows)));
+
+    await expect(fetchLiveStandards(URL_UNDER_TEST)).resolves.toEqual(rows);
+  });
+});
+
+describe("spec-544: a non-200 live response fails loud", () => {
+  it("throws on 404 rather than returning nothing (ac-9)", async () => {
+    tagAc(AC(9));
+
+    // A Memex flipped to private returns 404 (std-7) — indistinguishable from a
+    // renamed one. Returning [] here would hand the planner an empty list, and even
+    // though the planner refuses that too, the error must name the HTTP failure so
+    // the operator sees the real cause rather than "the list was empty".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) }) as unknown as Response),
+    );
+
+    await expect(fetchLiveStandards(URL_UNDER_TEST)).rejects.toThrow(/404/);
+  });
+
+  it("throws on 500 and on a network error (ac-9)", async () => {
+    tagAc(AC(9));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response),
+    );
+    await expect(fetchLiveStandards(URL_UNDER_TEST)).rejects.toThrow(/500/);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    await expect(
+      fetchLiveStandards(URL_UNDER_TEST),
+      "A network failure must surface, never be swallowed into an empty list.",
+    ).rejects.toThrow();
+  });
+});

--- a/packages/server/src/__regression__/spec-544-standards-live-plan.regression.test.ts
+++ b/packages/server/src/__regression__/spec-544-standards-live-plan.regression.test.ts
@@ -1,0 +1,200 @@
+// spec-544 — the manifest and each repo's index are PLANNED from the live Standard
+// list, not from an offline file that ages alongside its own check.
+//
+// THE DRIFT THIS ENDS (measured 2026-09-02, not hypothetical): the Memex held 51
+// approved Standards; memex-ai's manifest listed 43. std-43…std-50 were absent and
+// `make standards-check` was GREEN throughout — because it compares the manifest to
+// CLAUDE.md and nothing else. Two offline files that age together always agree. The
+// gap was found by hand.
+//
+// spec-512's sibling file pins the marker mechanics (every region rewritten, malformed
+// markers refused). This file pins what spec-512 could not: that the SOURCE is live,
+// that a new Standard is seeded rather than blocking, that a bad live response writes
+// nothing, and that per-repo filtering FAILS OPEN.
+//
+// Everything here is pure — `planIndex` takes the live rows and the manifest as data,
+// so these tests need no network. The network edge (`fetchLiveStandards`) is one thin
+// function tested separately; keeping them apart is what lets `make check` stay offline
+// (ac-10) while the plan itself is fully covered.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { planIndex } from "../../../../scripts/ci/standards-index.mjs";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-544/acs/ac-${n}`;
+
+/** A live row as `?type=standard&include=tags` returns it. */
+const live = (
+  handle: string,
+  title: string,
+  repos: string[] = [],
+) => ({
+  handle,
+  title,
+  tags: repos.map((value) => ({ scope: null, value })),
+});
+
+const AI = "memex-ai";
+const CLIENTS = "memex-clients";
+
+describe("spec-544: a Standard missing from the manifest is SEEDED, never blocking", () => {
+  it("seeds the live title as a placeholder summary and reports it (ac-8)", () => {
+    tagAc(AC(8));
+
+    const plan = planIndex({
+      live: [
+        live("std-1", "Namespace, org, and memex are distinct concepts"),
+        live("std-44", "Flutter clients run through fvm and ship desktop-only"),
+      ],
+      manifest: [{ handle: "std-1", summary: "The curated, richer summary." }],
+      repo: AI,
+    });
+
+    // The already-curated summary is NOT clobbered by the shorter live title.
+    const one = plan.standards.find((s) => s.handle === "std-1");
+    expect(
+      one?.summary,
+      "Seeding must never overwrite curated prose — the live API returns titles, " +
+        "and the manifest's 'Covers' column is deliberately richer than a title.",
+    ).toBe("The curated, richer summary.");
+
+    // The new one is present, seeded from its title, and NAMED as a placeholder.
+    const seeded = plan.standards.find((s) => s.handle === "std-44");
+    expect(
+      seeded?.summary,
+      "std-44 exists in the Memex and had no manifest entry — it must be seeded " +
+        "so the rule is VISIBLE immediately, not withheld until someone writes prose.",
+    ).toBe("Flutter clients run through fvm and ship desktop-only");
+    expect(plan.seeded).toEqual(["std-44"]);
+  });
+
+  it("reports nothing seeded when the manifest is already complete (ac-8)", () => {
+    tagAc(AC(8));
+
+    const plan = planIndex({
+      live: [live("std-1", "T1")],
+      manifest: [{ handle: "std-1", summary: "S1" }],
+      repo: AI,
+    });
+    expect(plan.seeded).toEqual([]);
+  });
+});
+
+describe("spec-544: a bad live response writes NOTHING", () => {
+  it("refuses an empty live list rather than blanking the index (ac-9)", () => {
+    tagAc(AC(9));
+
+    // A visibility flip to private returns 404 (std-7), which is indistinguishable
+    // from 'renamed' and from 'zero Standards'. Generating from that would blank the
+    // table every agent orients from — the loudest possible failure is the only safe
+    // behaviour, mirroring loadManifest()'s existing zero-standard refusal.
+    expect(
+      () => planIndex({ live: [], manifest: [{ handle: "std-1", summary: "S" }], repo: AI }),
+      "An empty live list must THROW. Silently regenerating from it would erase the " +
+        "index while reporting success.",
+    ).toThrow(/live|zero|empty/i);
+  });
+
+  it("refuses a live list that is not an array (ac-9)", () => {
+    tagAc(AC(9));
+
+    for (const bad of [null, undefined, {}, "51 standards"]) {
+      expect(
+        () =>
+          planIndex({
+            live: bad as never,
+            manifest: [{ handle: "std-1", summary: "S" }],
+            repo: AI,
+          }),
+        `A live payload of ${JSON.stringify(bad)} must be refused, not coerced — a ` +
+          `changed response shape must fail loud, not render an empty table.`,
+      ).toThrow();
+    }
+  });
+});
+
+describe("spec-544: per-repo filtering FAILS OPEN", () => {
+  // The spine of dec-2. Filtering re-creates this Spec's own harm one level down if
+  // absence hides: an unattributed Standard would vanish from BOTH indexes and bind
+  // nobody — strictly worse than today, where at least one repo lists it.
+  const rows = [
+    live("std-8", "Every mutation goes through mutate()", [AI]),
+    live("std-44", "Flutter clients run through fvm", [CLIENTS]),
+    live("std-51", "Module shape", [AI, CLIENTS]),
+    live("std-20", "Drift is the enemy"), // deliberately unattributed
+  ];
+  const manifest = [
+    { handle: "std-8", summary: "mutate() + bus" },
+    { handle: "std-44", summary: "fvm, desktop-only" },
+    { handle: "std-51", summary: "module shape" },
+    { handle: "std-20", summary: "drift is the enemy" },
+  ];
+
+  it("an UNATTRIBUTED Standard appears in every repo's table (ac-14)", () => {
+    tagAc(AC(14));
+
+    for (const repo of [AI, CLIENTS]) {
+      const { table } = planIndex({ live: rows, manifest, repo });
+      expect(
+        table,
+        `std-20 carries no attribution, so it binds everything and MUST appear in ` +
+          `${repo}'s index. An unattributed Standard that vanishes from both indexes ` +
+          `is the exact harm this Spec exists to close.`,
+      ).toMatch(/\|\s*std-20\s*\|/);
+    }
+  });
+
+  it("with ZERO attribution anywhere, both tables are complete (ac-14)", () => {
+    tagAc(AC(14));
+
+    // Day one: 0 of 51 Standards carry a tag. Fail-open is what makes that a working
+    // state rather than a flag day — the generator emits the COMPLETE index and
+    // narrows incrementally as attribution lands.
+    const untagged = rows.map((r) => ({ ...r, tags: [] }));
+    for (const repo of [AI, CLIENTS]) {
+      const { table } = planIndex({ live: untagged, manifest, repo });
+      for (const h of ["std-8", "std-44", "std-51", "std-20"]) {
+        expect(table, `${h} must be in ${repo}'s index when nothing is attributed`).toMatch(
+          new RegExp(`\\|\\s*${h}\\s*\\|`),
+        );
+      }
+    }
+  });
+
+  it("attribution narrows in both directions, and 'both' lands in both (ac-15)", () => {
+    tagAc(AC(15));
+
+    const aiTable = planIndex({ live: rows, manifest, repo: AI }).table;
+    const clientsTable = planIndex({ live: rows, manifest, repo: CLIENTS }).table;
+
+    expect(aiTable).toMatch(/\|\s*std-8\s*\|/);
+    expect(
+      clientsTable,
+      "std-8 is memex-ai only (mutate() + the unified bus) — a Flutter repo's " +
+        "orientation file listing it is the noise dec-2 chose to remove.",
+    ).not.toMatch(/\|\s*std-8\s*\|/);
+
+    expect(clientsTable).toMatch(/\|\s*std-44\s*\|/);
+    expect(
+      aiTable,
+      "std-44 is memex-clients only (fvm / desktop-only).",
+    ).not.toMatch(/\|\s*std-44\s*\|/);
+
+    // The set case scoped tags could not express — which is why dec-1 chose flat.
+    expect(aiTable, "std-51 binds both repos").toMatch(/\|\s*std-51\s*\|/);
+    expect(clientsTable, "std-51 binds both repos").toMatch(/\|\s*std-51\s*\|/);
+  });
+
+  it("the manifest keeps EVERY Standard regardless of repo (ac-15)", () => {
+    tagAc(AC(15));
+
+    // The manifest is the offline authority on summaries for the whole Memex; only
+    // the RENDERED table is filtered. If the manifest were filtered too, the curated
+    // prose for the other repo's Standards would be lost on every regeneration.
+    const { standards } = planIndex({ live: rows, manifest, repo: CLIENTS });
+    expect(standards.map((s) => s.handle).sort()).toEqual(
+      ["std-20", "std-44", "std-51", "std-8"].sort(),
+    );
+  });
+});

--- a/packages/server/src/__regression__/spec-544-standards-live-plan.regression.test.ts
+++ b/packages/server/src/__regression__/spec-544-standards-live-plan.regression.test.ts
@@ -186,6 +186,26 @@ describe("spec-544: per-repo filtering FAILS OPEN", () => {
     expect(clientsTable, "std-51 binds both repos").toMatch(/\|\s*std-51\s*\|/);
   });
 
+  it("the rendered block says what it contains, and never 'matches Memex' (ac-16)", () => {
+    tagAc(AC(16));
+
+    const { table } = planIndex({ live: rows, manifest, repo: CLIENTS });
+
+    // Under filtering, "matches Memex" is simply false. The index must say what it
+    // IS — the Standards binding THIS repo — and name the way to see all of them,
+    // or a reader takes a filtered table for the whole rulebook.
+    expect(
+      table,
+      "The generated block must claim only what it delivers.",
+    ).not.toMatch(/matches Memex/i);
+    expect(table).toMatch(/bind this repo|binding this repo/i);
+    expect(
+      table,
+      "A filtered index has to tell the reader where the rest are, or the narrowing " +
+        "reads as the complete set.",
+    ).toMatch(/search_memex/);
+  });
+
   it("the manifest keeps EVERY Standard regardless of repo (ac-15)", () => {
     tagAc(AC(15));
 

--- a/scripts/ci/standards-index.d.mts
+++ b/scripts/ci/standards-index.d.mts
@@ -14,6 +14,23 @@ export function renderTable(standards: StandardEntry[]): string;
 /** The repositories this Memex is the system of record for (spec-544 dec-1). */
 export const REPOS: string[];
 
+/** The honest lead-in rendered inside every generated block (spec-544 ac-16). */
+export const INDEX_LEAD_IN: string;
+
+/** The unauthenticated live-list URL — one constant, because BOTH repos are
+ *  governed by the same Memex. */
+export const LIVE_STANDARDS_URL: string;
+
+/** Read the live Standard list. Unauthenticated by design: the Memex is public,
+ *  and attaching a credential would couple a public read to an expiring secret.
+ *  Throws on a non-2xx; leaves array/empty validation to `planIndex`. */
+export function fetchLiveStandards(url?: string): Promise<unknown>;
+
+/** Render one repo's table, failing open: an entry with no `repos` binds every
+ *  repo. Shared by `planIndex` (live) and the offline check/write path
+ *  (manifest) so the two can never disagree. */
+export function renderForRepo(entries: PlannedEntry[], repo: string): string;
+
 /** A Standard as the live list returns it under `?type=standard&include=tags`. */
 export interface LiveStandard {
   handle: string;

--- a/scripts/ci/standards-index.d.mts
+++ b/scripts/ci/standards-index.d.mts
@@ -11,6 +11,39 @@ export interface StandardEntry {
 
 export function renderTable(standards: StandardEntry[]): string;
 
+/** The repositories this Memex is the system of record for (spec-544 dec-1). */
+export const REPOS: string[];
+
+/** A Standard as the live list returns it under `?type=standard&include=tags`. */
+export interface LiveStandard {
+  handle: string;
+  title: string;
+  tags?: Array<{ scope: string | null; value: string }>;
+}
+
+/** A manifest entry plus the repos it is attributed to (empty = every repo). */
+export interface PlannedEntry extends StandardEntry {
+  repos: string[];
+}
+
+export interface IndexPlan {
+  /** Every live Standard, curated summaries preserved, sorted by handle. */
+  standards: PlannedEntry[];
+  /** Handles whose summary was seeded from the live title (placeholders). */
+  seeded: string[];
+  /** The rendered table for the requested repo — fail-open filtered. */
+  table: string;
+}
+
+/** Plan the manifest and one repo's index from the LIVE Standard list.
+ *  Pure: no network, no fs. Throws on a non-array or empty live list rather
+ *  than generating from it (spec-544 ac-9). */
+export function planIndex(input: {
+  live: LiveStandard[];
+  manifest: StandardEntry[];
+  repo: string;
+}): IndexPlan;
+
 /** Byte offsets of every generated region. Throws on unbalanced, orphaned,
  *  out-of-order or nested markers rather than rewriting part of the file. */
 export function findRegions(text: string): Array<{ start: number; end: number }>;

--- a/scripts/ci/standards-index.mjs
+++ b/scripts/ci/standards-index.mjs
@@ -308,7 +308,13 @@ function parseArgs(argv) {
         `  Check: ${SELF}`,
     );
   }
-  return { mode, repo, root: flag("--root") ?? ROOT };
+  const root = flag("--root") ?? ROOT;
+  // dec-7: the curated "Covers" prose has ONE home. `--root` is the repo being
+  // generated FOR; `--curation` is where the curated manifest lives. Same
+  // directory for the repo that owns its curation (memex-ai); different for every
+  // other caller, whose run reads memex-ai's manifest out of the action's own
+  // checkout and writes no manifest of its own.
+  return { mode, repo, root, curation: flag("--curation") ?? root };
 }
 
 function loadManifest(manifestPath) {
@@ -328,16 +334,40 @@ function loadManifest(manifestPath) {
 
 /** `--sync`: the ONLY mode that touches the network. Fetch the live list, plan,
  *  write the manifest, then fall through to `write` so the index follows. */
-async function sync({ repo, root }) {
-  const { manifest: manifestPath } = paths(root);
+async function sync({ repo, root, curation }) {
+  const { manifest: manifestPath } = paths(curation);
   const live = await fetchLiveStandards();
-  // The manifest may not exist yet (memex-clients has none) — an absent file is a
-  // first run, not an error. A PRESENT but zero-standard file still refuses, via
-  // loadManifest, because that is corruption rather than a cold start.
+  // An absent manifest is a first run, not an error. A PRESENT but zero-standard
+  // file still refuses, via loadManifest — that is corruption, not a cold start.
   let curated = [];
   if (existsSync(manifestPath)) curated = loadManifest(manifestPath);
 
   const { standards, seeded } = planIndex({ live, manifest: curated, repo });
+
+  // dec-7: only the repo that OWNS the curation persists it. Elsewhere the
+  // manifest we just read lives in the action's ephemeral checkout, so writing
+  // there would be worse than pointless — the seeded summary would vanish with
+  // the runner, and every run would re-seed and re-report the same placeholder
+  // forever, while a second copy of the prose accumulated in another repo.
+  const ownsCuration = curation === root;
+  if (!ownsCuration) {
+    process.stdout.write(
+      `✓ live: ${standards.length} · curation read from ${manifestPath} ` +
+        `(not written — this repo does not own it, dec-7)\n`,
+    );
+    if (seeded.length > 0) {
+      process.stdout.write(
+        `  ${seeded.length} of them have no curated summary yet and render their ` +
+          `live title: ${seeded.join(", ")}\n` +
+          `  Curate them in memex-ai's standards.manifest.json — that is the one home.\n`,
+      );
+    }
+    // Hand the PLAN back rather than letting main() re-read the manifest: that
+    // file belongs to another repo and does not carry the un-curated handles, so
+    // re-reading it here would silently drop them from this repo's index — the
+    // exact class of absence this Spec exists to end.
+    return { standards };
+  }
 
   writeFileSync(
     manifestPath,
@@ -366,19 +396,20 @@ async function sync({ repo, root }) {
         `  advisory, not a failure (spec-544 dec-3).\n\n`,
     );
   }
-  return 0;
+  return { standards };
 }
 
 async function main(argv) {
-  const { mode, repo, root } = parseArgs(argv);
-  const { claudeMd, manifest: manifestPath } = paths(root);
+  const { mode, repo, root, curation } = parseArgs(argv);
+  // CLAUDE.md is read and written in the repo being generated FOR; the curated
+  // manifest is read from wherever curation lives (dec-7).
+  const { claudeMd } = paths(root);
+  const { manifest: manifestPath } = paths(curation);
 
-  if (mode === "sync") {
-    const code = await sync({ repo, root });
-    if (code !== 0) return code;
-  }
-
-  const standards = loadManifest(manifestPath);
+  // In sync mode the plan IS the source — it carries the handles the curated
+  // manifest has not seen yet. Re-reading the manifest would drop them.
+  const planned = mode === "sync" ? await sync({ repo, root, curation }) : null;
+  const standards = planned ? planned.standards : loadManifest(manifestPath);
   const current = readFileSync(claudeMd, "utf8");
   const next = applyRegions(current, renderForRepo(standards, repo));
   // What THIS repo's index should contain — not the whole Memex (dec-2).

--- a/scripts/ci/standards-index.mjs
+++ b/scripts/ci/standards-index.mjs
@@ -27,7 +27,7 @@
 // rewrites EVERY region and rejects duplicate, orphaned, unmatched or
 // out-of-order markers rather than guessing.
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -35,6 +35,13 @@ const SELF = "scripts/ci/standards-index.mjs";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const CLAUDE_MD = join(ROOT, "CLAUDE.md");
 const MANIFEST = join(ROOT, "standards.manifest.json");
+
+// Written into every generated manifest so the file explains itself to whoever
+// opens it — including in memex-clients, where nobody has seen one before.
+const MANIFEST_BANNER =
+  "GENERATED-CONSUMED. The authoritative offline copy of the Memex standards index.";
+const MANIFEST_REFRESH =
+  "Refreshed from the LIVE Standard list by `--sync` (spec-544 dec-3) — no credential needed, the Memex is public. `repos` narrows a Standard to those repositories; ABSENT or empty means it binds every repo (fail-open, dec-2).";
 
 export const BEGIN = "<!-- BEGIN generated: standards-index -->";
 export const END = "<!-- END generated: standards-index -->";
@@ -44,6 +51,46 @@ export function renderTable(standards) {
   const lines = ["| Standard | Covers |", "|---|---|"];
   for (const s of standards) lines.push(`| ${s.handle} | ${s.summary} |`);
   return lines.join("\n");
+}
+
+// ── The live Standard list (spec-544 dec-3) ──────────────────────────────────
+//
+// Both repos are governed by the SAME Memex, so this is one constant, not a
+// per-repo setting. The path grammar is std-10's; `include=tags` is an opt-in on
+// the existing list route and is what makes attribution ride the same request as
+// the handles (dec-1) — omit it and every row comes back with no `tags` key, which
+// fail-open would then read as "binds every repo" for all 51.
+export const LIVE_STANDARDS_URL =
+  "https://memex.ai/api/mindset-prod/memex-building-itself/docs" +
+  "?type=standard&include=tags";
+
+/**
+ * Read the live Standard list. UNAUTHENTICATED, deliberately.
+ *
+ * `fetch` is called with no init at all, so there is provably no Authorization
+ * header to leak or expire. This Memex is public by design (std-31) and every GET
+ * goes behind the permissive public session — public → read, private → 404 (std-7).
+ * The generator's own header used to justify its offline mirror with "CI holds no
+ * Memex credentials"; that was over-broad. Reading needs no credential, and
+ * attaching one would couple a public read to a secret that can expire silently —
+ * the failure dec-3 spent its whole resolution designing out.
+ *
+ * Returns the rows verbatim. Validation (array, non-empty) belongs to planIndex, so
+ * there is ONE place that decides what a usable live list is.
+ */
+export async function fetchLiveStandards(url = LIVE_STANDARDS_URL) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `The live Standard list returned HTTP ${res.status} — refusing to plan.\n` +
+        `  ${url}\n` +
+        `  A private or renamed Memex answers 404 (std-7), which is indistinguishable\n` +
+        `  from "zero Standards" — so this fails by status rather than handing the\n` +
+        `  planner an empty list and reporting the wrong cause.\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+  return res.json();
 }
 
 // ── Per-repo attribution (spec-544 dec-1 / dec-2) ────────────────────────────
@@ -59,6 +106,14 @@ export function renderTable(standards) {
 // to know which indexes to render.
 export const REPOS = ["memex-ai", "memex-clients"];
 
+// Once each index is FILTERED (dec-2), "this index matches Memex" is false. The
+// block has to claim only what it delivers, and point at the rest — otherwise a
+// narrowed table reads as the whole rulebook.
+export const INDEX_LEAD_IN =
+  "_The Standards that bind this repo. The Memex holds more — " +
+  "`search_memex({ memex: 'mindset-prod/memex-building-itself', kind: 'standard' })` " +
+  "lists every one._";
+
 /** The repos a live row is attributed to. Flat tags only (scope NULL); any other
  *  flat label a Standard happens to carry is ignored rather than read as a repo. */
 function attributionOf(row) {
@@ -71,6 +126,29 @@ function attributionOf(row) {
 
 function byHandleNumber(a, b) {
   return Number(a.handle.slice(4)) - Number(b.handle.slice(4));
+}
+
+/**
+ * Render the table for ONE repo, failing open.
+ *
+ * An entry with no `repos` (or an empty one) binds every repo and is always
+ * included — attribution only ever narrows, absence never hides (dec-2). Two real
+ * callers share this: `planIndex` (from the live list) and the offline
+ * check/write path (from the committed manifest). They MUST agree, or the offline
+ * check would pass against a table the sync would immediately rewrite.
+ */
+export function renderForRepo(entries, repo) {
+  const table = renderTable(
+    entries.filter(
+      (e) => !Array.isArray(e.repos) || e.repos.length === 0 || e.repos.includes(repo),
+    ),
+  );
+  // The honest lead-in (ac-16). It lives INSIDE the generated block on purpose:
+  // one source, and memex-clients inherits it without anyone writing prose there.
+  // Naming an MCP call here is fine — CLAUDE.md is agent-facing prose, which
+  // std-34 cl-14 excludes from the human-surface copy rule; the reader already
+  // holds these tools.
+  return `${INDEX_LEAD_IN}\n\n${table}`;
 }
 
 /**
@@ -124,12 +202,7 @@ export function planIndex({ live, manifest, repo }) {
   });
   standards.sort(byHandleNumber);
 
-  // Fail open: no attribution ⇒ binds every repo.
-  const forRepo = standards.filter(
-    (s) => s.repos.length === 0 || s.repos.includes(repo),
-  );
-
-  return { standards, seeded, table: renderTable(forRepo) };
+  return { standards, seeded, table: renderForRepo(standards, repo) };
 }
 
 /** Locate every generated region. Throws with a contract-shaped message on any
@@ -194,8 +267,52 @@ export function applyRegions(text, body) {
   return out + text.slice(cursor);
 }
 
-function loadManifest() {
-  const parsed = JSON.parse(readFileSync(MANIFEST, "utf8"));
+// The files live in the repo being generated FOR — which is not always the repo
+// this script lives in. Under dec-6 one composite action runs in each caller's own
+// checkout, so `--root` points at that checkout; the default keeps every existing
+// invocation (`make standards-check` / `-gen` in memex-ai) byte-identical.
+function paths(root) {
+  return {
+    claudeMd: join(root, "CLAUDE.md"),
+    manifest: join(root, "standards.manifest.json"),
+  };
+}
+
+/** mode + repo + root, with `--repo` REQUIRED rather than defaulted.
+ *  A silent default would generate memex-ai's index inside memex-clients and look
+ *  like it worked — the ambiguous call errors instead (std-5's shape). */
+function parseArgs(argv) {
+  const flag = (name) => {
+    const i = argv.indexOf(name);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const mode = argv.includes("--sync")
+    ? "sync"
+    : argv.includes("--write")
+      ? "write"
+      : "check";
+  const repo = flag("--repo");
+  if (!repo) {
+    throw new Error(
+      `--repo is required — every index is now scoped to one repository (spec-544 dec-2).\n` +
+        `  Known repos: ${REPOS.join(", ")}\n` +
+        `  Defaulting would silently generate the wrong repo's index and report success.\n` +
+        `  e.g. node ${SELF} --check --repo memex-ai\n`,
+    );
+  }
+  if (!REPOS.includes(repo)) {
+    throw new Error(
+      `Unknown --repo "${repo}". Known repos: ${REPOS.join(", ")}.\n` +
+        `  A typo would render an index filtered to nothing but the unattributed\n` +
+        `  Standards, which reads like a working (if short) table.\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+  return { mode, repo, root: flag("--root") ?? ROOT };
+}
+
+function loadManifest(manifestPath) {
+  const parsed = JSON.parse(readFileSync(manifestPath, "utf8"));
   const standards = parsed.standards ?? [];
   if (standards.length === 0) {
     throw new Error(
@@ -209,21 +326,79 @@ function loadManifest() {
   return standards;
 }
 
-function main(argv) {
-  const mode = argv.includes("--write") ? "write" : "check";
-  const standards = loadManifest();
-  const current = readFileSync(CLAUDE_MD, "utf8");
-  const next = applyRegions(current, renderTable(standards));
+/** `--sync`: the ONLY mode that touches the network. Fetch the live list, plan,
+ *  write the manifest, then fall through to `write` so the index follows. */
+async function sync({ repo, root }) {
+  const { manifest: manifestPath } = paths(root);
+  const live = await fetchLiveStandards();
+  // The manifest may not exist yet (memex-clients has none) — an absent file is a
+  // first run, not an error. A PRESENT but zero-standard file still refuses, via
+  // loadManifest, because that is corruption rather than a cold start.
+  let curated = [];
+  if (existsSync(manifestPath)) curated = loadManifest(manifestPath);
 
-  if (mode === "write") {
+  const { standards, seeded } = planIndex({ live, manifest: curated, repo });
+
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        "//": MANIFEST_BANNER,
+        "//refresh": MANIFEST_REFRESH,
+        standards,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  process.stdout.write(
+    `✓ live: ${standards.length} · manifest ${existsSync(manifestPath) ? "updated" : "created"}\n`,
+  );
+  for (const h of seeded) {
+    process.stdout.write(`+ ${h} … seeded from its live title\n`);
+  }
+  if (seeded.length > 0) {
+    process.stdout.write(
+      `\n⚠ ${seeded.length} ${seeded.length === 1 ? "summary is" : "summaries are"} ` +
+        `a placeholder title — refine ${seeded.length === 1 ? "it" : "them"} in ` +
+        `standards.manifest.json when you can. The rules are already visible; this is\n` +
+        `  advisory, not a failure (spec-544 dec-3).\n\n`,
+    );
+  }
+  return 0;
+}
+
+async function main(argv) {
+  const { mode, repo, root } = parseArgs(argv);
+  const { claudeMd, manifest: manifestPath } = paths(root);
+
+  if (mode === "sync") {
+    const code = await sync({ repo, root });
+    if (code !== 0) return code;
+  }
+
+  const standards = loadManifest(manifestPath);
+  const current = readFileSync(claudeMd, "utf8");
+  const next = applyRegions(current, renderForRepo(standards, repo));
+  // What THIS repo's index should contain — not the whole Memex (dec-2).
+  const expected = standards
+    .filter(
+      (s) => !Array.isArray(s.repos) || s.repos.length === 0 || s.repos.includes(repo),
+    )
+    .map((s) => s.handle);
+
+  if (mode === "write" || mode === "sync") {
     if (next === current) {
-      process.stdout.write(`✓ CLAUDE.md standards index already current (${standards.length} standards)\n`);
+      process.stdout.write(
+        `✓ ${repo}: CLAUDE.md standards index already current (${expected.length} standards)\n`,
+      );
       return 0;
     }
-    writeFileSync(CLAUDE_MD, next);
+    writeFileSync(claudeMd, next);
     process.stdout.write(
-      `✓ regenerated the CLAUDE.md standards index from standards.manifest.json ` +
-        `(${standards.length} standards)\n`,
+      `✓ ${repo}: regenerated the CLAUDE.md standards index ` +
+        `(${expected.length} of ${standards.length} standards bind this repo)\n`,
     );
     return 0;
   }
@@ -232,7 +407,7 @@ function main(argv) {
     const inFile = new Set(
       [...current.matchAll(/^\|\s*(std-\d+)\s*\|/gm)].map((m) => m[1]),
     );
-    const inManifest = standards.map((s) => s.handle);
+    const inManifest = expected;
     const missing = inManifest.filter((h) => !inFile.has(h));
     const extra = [...inFile].filter((h) => !inManifest.includes(h));
 
@@ -261,16 +436,17 @@ function main(argv) {
   }
 
   process.stdout.write(
-    `✓ CLAUDE.md standards index matches the manifest (${standards.length} standards)\n`,
+    `✓ ${repo}: CLAUDE.md standards index matches the manifest ` +
+      `(${expected.length} of ${standards.length} standards bind this repo)\n`,
   );
   return 0;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    process.exit(main(process.argv.slice(2)));
-  } catch (err) {
-    process.stderr.write(`\n${err.message}\n`);
-    process.exit(2);
-  }
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`\n${err.message}\n`);
+      process.exit(2);
+    });
 }

--- a/scripts/ci/standards-index.mjs
+++ b/scripts/ci/standards-index.mjs
@@ -46,6 +46,92 @@ export function renderTable(standards) {
   return lines.join("\n");
 }
 
+// ── Per-repo attribution (spec-544 dec-1 / dec-2) ────────────────────────────
+//
+// One Memex is the system of record for two repositories, and a Standard is
+// attributed with FLAT tags — `memex-ai`, `memex-clients` — never a scoped
+// `repo::` tag. A scoped value is mutually exclusive within its scope, and the
+// both-repos set is a dozen Standards, so the attribute is a SET of repos.
+//
+// This list is not the "hand-maintained exclusion list" ac-3 forbids: that rule
+// is about never hand-listing which STANDARDS to exclude. Knowing which repos
+// exist is a different, tiny, stable thing — and the generator needs it anyway
+// to know which indexes to render.
+export const REPOS = ["memex-ai", "memex-clients"];
+
+/** The repos a live row is attributed to. Flat tags only (scope NULL); any other
+ *  flat label a Standard happens to carry is ignored rather than read as a repo. */
+function attributionOf(row) {
+  const tags = Array.isArray(row.tags) ? row.tags : [];
+  return tags
+    .filter((t) => t && (t.scope === null || t.scope === undefined))
+    .map((t) => t.value)
+    .filter((v) => REPOS.includes(v));
+}
+
+function byHandleNumber(a, b) {
+  return Number(a.handle.slice(4)) - Number(b.handle.slice(4));
+}
+
+/**
+ * Plan the manifest and one repo's index from the LIVE Standard list.
+ *
+ * The whole offline transformation behind one interface (std-51): merge live
+ * handles into the manifest, seed the ones with no curated summary, derive
+ * attribution, filter for `repo`, render the table. Pure — no network, no fs —
+ * which is what keeps `make check` offline while this logic stays covered.
+ *
+ * Two behaviours here are deliberate and load-bearing:
+ *
+ *   SEED, NEVER BLOCK. A live handle with no manifest entry gets its live `title`
+ *   as a provisional summary and is named in `seeded`. Refusing to generate until
+ *   a human writes prose sounds stricter but fails worse: the red goes ambient or
+ *   gets bypassed, and the Standard stays invisible — the exact harm spec-544
+ *   exists to close. A curated summary is NEVER overwritten by the shorter title.
+ *
+ *   FAIL OPEN. A Standard with no attribution appears in EVERY repo's table.
+ *   Attribution only ever narrows; absence never hides. Filtering that hid the
+ *   unattributed would make one mis-tag erase a rule from both repos at once.
+ */
+export function planIndex({ live, manifest, repo }) {
+  if (!Array.isArray(live)) {
+    throw new Error(
+      `The live Standard list is not an array (got ${typeof live}) — refusing to plan.\n` +
+        `  A changed response shape must fail loud, not render an empty table.\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+  if (live.length === 0) {
+    throw new Error(
+      `The live Standard list is EMPTY — refusing to generate anything.\n` +
+        `  Zero live Standards is indistinguishable from a renamed Memex or one\n` +
+        `  flipped to private (which returns 404 per std-7). Generating from it\n` +
+        `  would blank the table every agent orients from.\n` +
+        `  Check: ${SELF}`,
+    );
+  }
+
+  const curated = new Map((manifest ?? []).map((s) => [s.handle, s.summary]));
+  const seeded = [];
+  const standards = live.map((row) => {
+    const existing = curated.get(row.handle);
+    if (existing === undefined) seeded.push(row.handle);
+    return {
+      handle: row.handle,
+      summary: existing ?? row.title,
+      repos: attributionOf(row),
+    };
+  });
+  standards.sort(byHandleNumber);
+
+  // Fail open: no attribution ⇒ binds every repo.
+  const forRepo = standards.filter(
+    (s) => s.repos.length === 0 || s.repos.includes(repo),
+  );
+
+  return { standards, seeded, table: renderTable(forRepo) };
+}
+
 /** Locate every generated region. Throws with a contract-shaped message on any
  *  malformed marker rather than silently rewriting part of the file. */
 export function findRegions(text) {

--- a/standards.manifest.json
+++ b/standards.manifest.json
@@ -361,6 +361,11 @@
         "memex-ai",
         "memex-clients"
       ]
+    },
+    {
+      "handle": "std-52",
+      "summary": "A defect's cause is claimed only after a command goes red on it — the loop comes before the theory",
+      "repos": []
     }
   ]
 }

--- a/standards.manifest.json
+++ b/standards.manifest.json
@@ -1,178 +1,261 @@
 {
   "//": "GENERATED-CONSUMED. The authoritative offline copy of the Memex standards index.",
-  "//refresh": "An agent refreshes this from Memex with: search_memex({kind:\"standard\"}) — then `make standards-gen` rewrites the CLAUDE.md table.",
+  "//refresh": "Refreshed from the LIVE Standard list by `--sync` (spec-544 dec-3) — no credential needed, the Memex is public. `repos` narrows a Standard to those repositories; ABSENT or empty means it binds every repo (fail-open, dec-2).",
   "standards": [
     {
       "handle": "std-1",
-      "summary": "Namespace / org / memex are three distinct concepts — plus user-facing vocabulary and handle conventions (`b-N` / `doc-N` / `std-N` / `s-N` / `dec-N` / `t-N` / `c-N`)."
+      "summary": "Namespace / org / memex are three distinct concepts — plus user-facing vocabulary and handle conventions (`b-N` / `doc-N` / `std-N` / `s-N` / `dec-N` / `t-N` / `c-N`).",
+      "repos": []
     },
     {
       "handle": "std-2",
-      "summary": "Tenant routing is path-based on the apex domain — never subdomains."
+      "summary": "Tenant routing is path-based on the apex domain — never subdomains.",
+      "repos": []
     },
     {
       "handle": "std-3",
-      "summary": "Namespace slug allocation (format, reserved list, rate limits, rename cooldown)."
+      "summary": "Namespace slug allocation (format, reserved list, rate limits, rename cooldown).",
+      "repos": []
     },
     {
       "handle": "std-4",
-      "summary": "Org membership grants access to every Memex in the org (v1 access model)."
+      "summary": "Org membership grants access to every Memex in the org (v1 access model).",
+      "repos": []
     },
     {
       "handle": "std-5",
-      "summary": "No silent namespace default — ambiguous MCP / middleware calls error."
+      "summary": "No silent namespace default — ambiguous MCP / middleware calls error.",
+      "repos": []
     },
     {
       "handle": "std-6",
-      "summary": "Domain-based auto-join requires explicit user consent."
+      "summary": "Domain-based auto-join requires explicit user consent.",
+      "repos": []
     },
     {
       "handle": "std-7",
-      "summary": "Unauthorized resource access returns 404, not 403."
+      "summary": "Unauthorized resource access returns 404, not 403.",
+      "repos": []
     },
     {
       "handle": "std-8",
-      "summary": "Every mutation goes through `mutate()` and emits on the unified bus (real-time SSE)."
+      "summary": "Every mutation goes through `mutate()` and emits on the unified bus (real-time SSE).",
+      "repos": []
     },
     {
       "handle": "std-9",
-      "summary": "Infrastructure: int + prod GCP projects (Cloud Run, Cloud SQL, buckets, secrets, DNS) + local development."
+      "summary": "Infrastructure: int + prod GCP projects (Cloud Run, Cloud SQL, buckets, secrets, DNS) + local development.",
+      "repos": []
     },
     {
       "handle": "std-10",
-      "summary": "Canonical URL paths for Memex entities (the `ref` grammar)."
+      "summary": "Canonical URL paths for Memex entities (the `ref` grammar).",
+      "repos": []
     },
     {
       "handle": "std-11",
-      "summary": "AI agent: direct Anthropic SDK on server, LangGraph in React UI."
+      "summary": "AI agent: direct Anthropic SDK on server, LangGraph in React UI.",
+      "repos": []
     },
     {
       "handle": "std-12",
-      "summary": "Service architecture — bounded components and how they wire."
+      "summary": "Service architecture — bounded components and how they wire.",
+      "repos": []
     },
     {
       "handle": "std-13",
-      "summary": "Native authentication: hand-rolled JWT + scrypt + auth_tokens + Postmark."
+      "summary": "Native authentication: hand-rolled JWT + scrypt + auth_tokens + Postmark.",
+      "repos": []
     },
     {
       "handle": "std-14",
-      "summary": "Per-domain debug logging convention (`packages/server/.logs/<domain>.log`)."
+      "summary": "Per-domain debug logging convention (`packages/server/.logs/<domain>.log`).",
+      "repos": []
     },
     {
       "handle": "std-15",
-      "summary": "Agent prompts live in `packages/server/src/agent/phases/` markdown, never inline in code."
+      "summary": "Agent prompts live in `packages/server/src/agent/phases/` markdown, never inline in code.",
+      "repos": []
     },
     {
       "handle": "std-16",
-      "summary": "The coding-agent tool contract has one source — the `@memex/shared` manifest."
+      "summary": "The coding-agent tool contract has one source — the `@memex/shared` manifest.",
+      "repos": []
     },
     {
       "handle": "std-17",
-      "summary": "Smoke tests are mandatory and run against live envs — int after every deploy, green before prod."
+      "summary": "Smoke tests are mandatory and run against live envs — int after every deploy, green before prod.",
+      "repos": []
     },
     {
       "handle": "std-18",
-      "summary": "Spec anatomy — the lens set every Spec carries: core lenses (Overview, Design & UX, Architecture & Security) always present; adaptive lenses (Operations, …) added when the work earns them. Decisions and ACs are primitives, not prose sections."
+      "summary": "Spec anatomy — the lens set every Spec carries: core lenses (Overview, Design & UX, Architecture & Security) always present; adaptive lenses (Operations, …) added when the work earns them. Decisions and ACs are primitives, not prose sections.",
+      "repos": []
     },
     {
       "handle": "std-19",
-      "summary": "Specs are SDD's canonical artifact — every unit of work is a Spec; \"Spec\" is the noun."
+      "summary": "Specs are SDD's canonical artifact — every unit of work is a Spec; \"Spec\" is the noun.",
+      "repos": []
     },
     {
       "handle": "std-20",
-      "summary": "Spec-Driven Development — drift is the enemy; the Spec is a living node in a knowledge map."
+      "summary": "Spec-Driven Development — drift is the enemy; the Spec is a living node in a knowledge map.",
+      "repos": []
     },
     {
       "handle": "std-21",
-      "summary": "Branch structure — `develop` integrates work; `main` is the production line (releases land as a **merge commit** via the develop→main PR — GitHub's PR surface can't fast-forward, cl-50; the content invariant is `git log develop..main --no-merges` empty, not SHA-identity; branch-bound deploy targets, main-only licence carve-out)."
+      "summary": "Branch structure — `develop` integrates work; `main` is the production line (releases land as a **merge commit** via the develop→main PR — GitHub's PR surface can't fast-forward, cl-50; the content invariant is `git log develop..main --no-merges` empty, not SHA-identity; branch-bound deploy targets, main-only licence carve-out).",
+      "repos": []
     },
     {
       "handle": "std-22",
-      "summary": "Everything we ship runs against arbitrary codebases — portable artifacts (prompts, scaffold prose, Prompt Buttons, Init Prompts, in-repo tools) assume no language, framework, layout, file paths, or tooling."
+      "summary": "Everything we ship runs against arbitrary codebases — portable artifacts (prompts, scaffold prose, Prompt Buttons, Init Prompts, in-repo tools) assume no language, framework, layout, file paths, or tooling.",
+      "repos": []
     },
     {
       "handle": "std-23",
-      "summary": "Prompt Buttons are the standard human→agent handoff — prompt prose lives in the Scaffold (`scaffold-data.ts`), never inline; copy-to-clipboard; Org-extensible (append-only)."
+      "summary": "Prompt Buttons are the standard human→agent handoff — prompt prose lives in the Scaffold (`scaffold-data.ts`), never inline; copy-to-clipboard; Org-extensible (append-only).",
+      "repos": []
     },
     {
       "handle": "std-24",
-      "summary": "One version per shared library across the pnpm workspace, enforced by `pnpm.overrides` (today: vitest, `@vitest/coverage-v8`, `@types/node`, `react`/`react-dom`, `typescript`; plus security-floor pins `esbuild`/`form-data`/`protobufjs`). Exact pins in each package's devDependencies; new dep families added to the root overrides."
+      "summary": "One version per shared library across the pnpm workspace, enforced by `pnpm.overrides` (today: vitest, `@vitest/coverage-v8`, `@types/node`, `react`/`react-dom`, `typescript`; plus security-floor pins `esbuild`/`form-data`/`protobufjs`). Exact pins in each package's devDependencies; new dep families added to the root overrides.",
+      "repos": []
     },
     {
       "handle": "std-25",
-      "summary": "Every Spec classifies its work as fair-code (open core) or EE — the licence boundary is decided per-Spec, up front, not retrofitted."
+      "summary": "Every Spec classifies its work as fair-code (open core) or EE — the licence boundary is decided per-Spec, up front, not retrofitted.",
+      "repos": []
     },
     {
       "handle": "std-26",
-      "summary": "Deploying Memex follows one runbook — prerequisites, the int→prod sequence, and the gotchas that bite (the procedural sibling of std-9's topology)."
+      "summary": "Deploying Memex follows one runbook — prerequisites, the int→prod sequence, and the gotchas that bite (the procedural sibling of std-9's topology).",
+      "repos": []
     },
     {
       "handle": "std-27",
-      "summary": "Charts & data-viz: one theme-aware palette + glass treatment — `useChartPalette()`/`insightsTheme` from `packages/ui/src/components/insights/theme.ts`, reserved hue semantics, translucent fills with crisp edges, integer count ticks, themed tooltips, noise excluded server-side."
+      "summary": "Charts & data-viz: one theme-aware palette + glass treatment — `useChartPalette()`/`insightsTheme` from `packages/ui/src/components/insights/theme.ts`, reserved hue semantics, translucent fills with crisp edges, integer count ticks, themed tooltips, noise excluded server-side.",
+      "repos": []
     },
     {
       "handle": "std-28",
-      "summary": "PR-gate e2e journeys are mandatory — every change that adds/alters a user-facing flow adds or extends a Playwright journey in `packages/ui/e2e`; journey work is part of EVERY Spec's lifecycle (surfaced in plan, delivered in build, gating verify); run `make e2e-cold` before opening every PR; the suite runs per-PR against a cold DB and is a required check on develop + main; path-based nav, seed via the env-gated test surface (no raw SQL). The merge-side sibling of std-17's post-deploy smoke rule. Authoring a journey + local-run gotchas (cold-DB `PGPASSWORD`, stale `@memex/shared` build, browser install): [`packages/ui/e2e/README.md`](packages/ui/e2e/README.md)."
+      "summary": "PR-gate e2e journeys are mandatory — every change that adds/alters a user-facing flow adds or extends a Playwright journey in `packages/ui/e2e`; journey work is part of EVERY Spec's lifecycle (surfaced in plan, delivered in build, gating verify); run `make e2e-cold` before opening every PR; the suite runs per-PR against a cold DB and is a required check on develop + main; path-based nav, seed via the env-gated test surface (no raw SQL). The merge-side sibling of std-17's post-deploy smoke rule. Authoring a journey + local-run gotchas (cold-DB `PGPASSWORD`, stale `@memex/shared` build, browser install): [`packages/ui/e2e/README.md`](packages/ui/e2e/README.md).",
+      "repos": []
     },
     {
       "handle": "std-29",
-      "summary": "Guide content (Specky) stays current with the UI it documents — drift flagged for retirement (spec-508 removed the voice guide + its content pipeline)."
+      "summary": "Guide content (Specky) stays current with the UI it documents — drift flagged for retirement (spec-508 removed the voice guide + its content pipeline).",
+      "repos": []
     },
     {
       "handle": "std-30",
-      "summary": "All LLM access goes through the metering wrapper (`getAnthropicClient()` singleton) — the only sanctioned path; direct `new Anthropic(...)` construction is forbidden."
+      "summary": "All LLM access goes through the metering wrapper (`getAnthropicClient()` singleton) — the only sanctioned path; direct `new Anthropic(...)` construction is forbidden.",
+      "repos": []
     },
     {
       "handle": "std-31",
-      "summary": "No real person or customer names in this public Memex (it builds itself in the open)."
+      "summary": "No real person or customer names in this public Memex (it builds itself in the open).",
+      "repos": []
     },
     {
       "handle": "std-32",
-      "summary": "The activity contract — every activity-bearing table (`documents`/`acs`/`tasks`/`decisions`/`doc_sections`/`doc_comments`/`test_events`/`activity_log`) carries WHEN (`at`, the row's own timestamp) + WHO (`actor_user_id` + denormalised `actor_name`, stamped at write so a rename can't rewrite history) + HOW (`channel`) + WHAT-coarse (owning-spec ref); load-bearing fields are first-class columns, only decorative context lives in `metadata`/`payload`. Identity rides the explicit `RequestCtx` through `mutate()` (not AsyncLocalStorage); a missing channel is a visible defect, never a silent 'server'. The attribution sibling of std-8 (spec-122 dec-2)."
+      "summary": "The activity contract — every activity-bearing table (`documents`/`acs`/`tasks`/`decisions`/`doc_sections`/`doc_comments`/`test_events`/`activity_log`) carries WHEN (`at`, the row's own timestamp) + WHO (`actor_user_id` + denormalised `actor_name`, stamped at write so a rename can't rewrite history) + HOW (`channel`) + WHAT-coarse (owning-spec ref); load-bearing fields are first-class columns, only decorative context lives in `metadata`/`payload`. Identity rides the explicit `RequestCtx` through `mutate()` (not AsyncLocalStorage); a missing channel is a visible defect, never a silent 'server'. The attribution sibling of std-8 (spec-122 dec-2).",
+      "repos": []
     },
     {
       "handle": "std-33",
-      "summary": "Embedding the guide SDK (Specky) — drift flagged for retirement (spec-508 deleted `packages/guide-sdk` and the /guide/v1 backend)."
+      "summary": "Embedding the guide SDK (Specky) — drift flagged for retirement (spec-508 deleted `packages/guide-sdk` and the /guide/v1 backend).",
+      "repos": []
     },
     {
       "handle": "std-34",
-      "summary": "No human-facing surface instructs an MCP-only step — signal the web↔MCP capability boundary in copy (the honest-CTA rule)."
+      "summary": "No human-facing surface instructs an MCP-only step — signal the web↔MCP capability boundary in copy (the honest-CTA rule).",
+      "repos": []
     },
     {
       "handle": "std-35",
-      "summary": "Usage events / Mixpanel — the metering + product-analytics event recipe."
+      "summary": "Usage events / Mixpanel — the metering + product-analytics event recipe.",
+      "repos": []
     },
     {
       "handle": "std-36",
-      "summary": "Tenant RLS posture — `ENABLE` row-level security, never `FORCE`; `runWithMemexId` ALS sets `memex_id`; views are `security_invoker`."
+      "summary": "Tenant RLS posture — `ENABLE` row-level security, never `FORCE`; `runWithMemexId` ALS sets `memex_id`; views are `security_invoker`.",
+      "repos": []
     },
     {
       "handle": "std-37",
-      "summary": "Test fixtures are isolated under parallel execution — per-worker-unique identifiers, poll for async writes, restore global stubs."
+      "summary": "Test fixtures are isolated under parallel execution — per-worker-unique identifiers, poll for async writes, restore global stubs.",
+      "repos": []
     },
     {
       "handle": "std-38",
-      "summary": "In-app agents share one contract — same visual shell (`ChatPanel`), Memex-wide grounding, narrow per-mode authoring scope enforced server-side by a `MODE_TOOLS` allow-list, copyable handoff on refusal."
+      "summary": "In-app agents share one contract — same visual shell (`ChatPanel`), Memex-wide grounding, narrow per-mode authoring scope enforced server-side by a `MODE_TOOLS` allow-list, copyable handoff on refusal.",
+      "repos": []
     },
     {
       "handle": "std-39",
-      "summary": "Database hygiene — every DB interaction is reasoned about for cost, locks, and growth, not just correctness. Covers migrations, handlers, MCP tools, relays, cron, and the React UI's query/polling patterns."
+      "summary": "Database hygiene — every DB interaction is reasoned about for cost, locks, and growth, not just correctness. Covers migrations, handlers, MCP tools, relays, cron, and the React UI's query/polling patterns.",
+      "repos": []
     },
     {
       "handle": "std-40",
-      "summary": "Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer."
+      "summary": "Plugins are the Claude-Code delivery vehicle — one plugin, one concern. Covers hooks (std-41), a bundled MCP server, or slash commands; excludes the `memex-ai` CLI credential installer.",
+      "repos": []
     },
     {
       "handle": "std-41",
-      "summary": "Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8)."
+      "summary": "Hooks make capability a side effect of work you already do — use them sparingly, never for correctness. Six tests gate whether a hook is the right tool; correctness/security/mutation work belongs on the server (std-8).",
+      "repos": []
     },
     {
       "handle": "std-42",
-      "summary": "Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published."
+      "summary": "Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published.",
+      "repos": []
+    },
+    {
+      "handle": "std-43",
+      "summary": "[REVERTED — abandoned, safe to archive/delete] Per-user-private tenant tables",
+      "repos": []
+    },
+    {
+      "handle": "std-44",
+      "summary": "Flutter clients run through fvm, ship desktop-only, and are not done until analyze and test both run clean",
+      "repos": []
+    },
+    {
+      "handle": "std-45",
+      "summary": "A claim about what the user sees is verified by mounting the widget — controller tests do not count",
+      "repos": []
+    },
+    {
+      "handle": "std-46",
+      "summary": "A live pty in a Flutter tree is never disturbed — no widget-type swaps, no size-enforcing boxes, no reflow without an explicit resize",
+      "repos": []
+    },
+    {
+      "handle": "std-47",
+      "summary": "macOS desktop input: modifiers may only ADD a path, and an ancestor Listener cannot decline",
+      "repos": []
+    },
+    {
+      "handle": "std-48",
+      "summary": "Dart has no Memex emission helper — memex-clients tags ACs with a hand-rolled acTest and a short-lived per-Spec key",
+      "repos": []
+    },
+    {
+      "handle": "std-49",
+      "summary": "A colour that spans repositories is read from what ships, never sampled from a screenshot",
+      "repos": []
+    },
+    {
+      "handle": "std-50",
+      "summary": "A value one component depends on and another owns is read, declared, or refused — never defaulted in silence",
+      "repos": []
     },
     {
       "handle": "std-51",
-      "summary": "Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index."
+      "summary": "Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index.",
+      "repos": []
     }
   ]
 }

--- a/standards.manifest.json
+++ b/standards.manifest.json
@@ -5,182 +5,262 @@
     {
       "handle": "std-1",
       "summary": "Namespace / org / memex are three distinct concepts — plus user-facing vocabulary and handle conventions (`b-N` / `doc-N` / `std-N` / `s-N` / `dec-N` / `t-N` / `c-N`).",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-2",
       "summary": "Tenant routing is path-based on the apex domain — never subdomains.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-3",
       "summary": "Namespace slug allocation (format, reserved list, rate limits, rename cooldown).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-4",
       "summary": "Org membership grants access to every Memex in the org (v1 access model).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-5",
       "summary": "No silent namespace default — ambiguous MCP / middleware calls error.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-6",
       "summary": "Domain-based auto-join requires explicit user consent.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-7",
       "summary": "Unauthorized resource access returns 404, not 403.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-8",
       "summary": "Every mutation goes through `mutate()` and emits on the unified bus (real-time SSE).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-9",
       "summary": "Infrastructure: int + prod GCP projects (Cloud Run, Cloud SQL, buckets, secrets, DNS) + local development.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-10",
       "summary": "Canonical URL paths for Memex entities (the `ref` grammar).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-11",
       "summary": "AI agent: direct Anthropic SDK on server, LangGraph in React UI.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-12",
       "summary": "Service architecture — bounded components and how they wire.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-13",
       "summary": "Native authentication: hand-rolled JWT + scrypt + auth_tokens + Postmark.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-14",
       "summary": "Per-domain debug logging convention (`packages/server/.logs/<domain>.log`).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-15",
       "summary": "Agent prompts live in `packages/server/src/agent/phases/` markdown, never inline in code.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-16",
       "summary": "The coding-agent tool contract has one source — the `@memex/shared` manifest.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-17",
       "summary": "Smoke tests are mandatory and run against live envs — int after every deploy, green before prod.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-18",
       "summary": "Spec anatomy — the lens set every Spec carries: core lenses (Overview, Design & UX, Architecture & Security) always present; adaptive lenses (Operations, …) added when the work earns them. Decisions and ACs are primitives, not prose sections.",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-19",
       "summary": "Specs are SDD's canonical artifact — every unit of work is a Spec; \"Spec\" is the noun.",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-20",
       "summary": "Spec-Driven Development — drift is the enemy; the Spec is a living node in a knowledge map.",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-21",
       "summary": "Branch structure — `develop` integrates work; `main` is the production line (releases land as a **merge commit** via the develop→main PR — GitHub's PR surface can't fast-forward, cl-50; the content invariant is `git log develop..main --no-merges` empty, not SHA-identity; branch-bound deploy targets, main-only licence carve-out).",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-22",
       "summary": "Everything we ship runs against arbitrary codebases — portable artifacts (prompts, scaffold prose, Prompt Buttons, Init Prompts, in-repo tools) assume no language, framework, layout, file paths, or tooling.",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-23",
       "summary": "Prompt Buttons are the standard human→agent handoff — prompt prose lives in the Scaffold (`scaffold-data.ts`), never inline; copy-to-clipboard; Org-extensible (append-only).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-24",
       "summary": "One version per shared library across the pnpm workspace, enforced by `pnpm.overrides` (today: vitest, `@vitest/coverage-v8`, `@types/node`, `react`/`react-dom`, `typescript`; plus security-floor pins `esbuild`/`form-data`/`protobufjs`). Exact pins in each package's devDependencies; new dep families added to the root overrides.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-25",
       "summary": "Every Spec classifies its work as fair-code (open core) or EE — the licence boundary is decided per-Spec, up front, not retrofitted.",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-26",
       "summary": "Deploying Memex follows one runbook — prerequisites, the int→prod sequence, and the gotchas that bite (the procedural sibling of std-9's topology).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-27",
       "summary": "Charts & data-viz: one theme-aware palette + glass treatment — `useChartPalette()`/`insightsTheme` from `packages/ui/src/components/insights/theme.ts`, reserved hue semantics, translucent fills with crisp edges, integer count ticks, themed tooltips, noise excluded server-side.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-28",
       "summary": "PR-gate e2e journeys are mandatory — every change that adds/alters a user-facing flow adds or extends a Playwright journey in `packages/ui/e2e`; journey work is part of EVERY Spec's lifecycle (surfaced in plan, delivered in build, gating verify); run `make e2e-cold` before opening every PR; the suite runs per-PR against a cold DB and is a required check on develop + main; path-based nav, seed via the env-gated test surface (no raw SQL). The merge-side sibling of std-17's post-deploy smoke rule. Authoring a journey + local-run gotchas (cold-DB `PGPASSWORD`, stale `@memex/shared` build, browser install): [`packages/ui/e2e/README.md`](packages/ui/e2e/README.md).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-29",
       "summary": "Guide content (Specky) stays current with the UI it documents — drift flagged for retirement (spec-508 removed the voice guide + its content pipeline).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-30",
       "summary": "All LLM access goes through the metering wrapper (`getAnthropicClient()` singleton) — the only sanctioned path; direct `new Anthropic(...)` construction is forbidden.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-31",
       "summary": "No real person or customer names in this public Memex (it builds itself in the open).",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-32",
       "summary": "The activity contract — every activity-bearing table (`documents`/`acs`/`tasks`/`decisions`/`doc_sections`/`doc_comments`/`test_events`/`activity_log`) carries WHEN (`at`, the row's own timestamp) + WHO (`actor_user_id` + denormalised `actor_name`, stamped at write so a rename can't rewrite history) + HOW (`channel`) + WHAT-coarse (owning-spec ref); load-bearing fields are first-class columns, only decorative context lives in `metadata`/`payload`. Identity rides the explicit `RequestCtx` through `mutate()` (not AsyncLocalStorage); a missing channel is a visible defect, never a silent 'server'. The attribution sibling of std-8 (spec-122 dec-2).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-33",
       "summary": "Embedding the guide SDK (Specky) — drift flagged for retirement (spec-508 deleted `packages/guide-sdk` and the /guide/v1 backend).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-34",
       "summary": "No human-facing surface instructs an MCP-only step — signal the web↔MCP capability boundary in copy (the honest-CTA rule).",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-35",
       "summary": "Usage events / Mixpanel — the metering + product-analytics event recipe.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-36",
       "summary": "Tenant RLS posture — `ENABLE` row-level security, never `FORCE`; `runWithMemexId` ALS sets `memex_id`; views are `security_invoker`.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-37",
@@ -190,12 +270,16 @@
     {
       "handle": "std-38",
       "summary": "In-app agents share one contract — same visual shell (`ChatPanel`), Memex-wide grounding, narrow per-mode authoring scope enforced server-side by a `MODE_TOOLS` allow-list, copyable handoff on refusal.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-39",
       "summary": "Database hygiene — every DB interaction is reasoned about for cost, locks, and growth, not just correctness. Covers migrations, handlers, MCP tools, relays, cron, and the React UI's query/polling patterns.",
-      "repos": []
+      "repos": [
+        "memex-ai"
+      ]
     },
     {
       "handle": "std-40",
@@ -210,7 +294,9 @@
     {
       "handle": "std-42",
       "summary": "Desktop client (memex-clients) releases follow one runbook — signing on BOTH platforms, notarization, auto-update, and per-channel distribution. An unsigned build is a CI artifact only, never published.",
-      "repos": []
+      "repos": [
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-43",
@@ -220,42 +306,61 @@
     {
       "handle": "std-44",
       "summary": "Flutter clients run through fvm, ship desktop-only, and are not done until analyze and test both run clean",
-      "repos": []
+      "repos": [
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-45",
       "summary": "A claim about what the user sees is verified by mounting the widget — controller tests do not count",
-      "repos": []
+      "repos": [
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-46",
       "summary": "A live pty in a Flutter tree is never disturbed — no widget-type swaps, no size-enforcing boxes, no reflow without an explicit resize",
-      "repos": []
+      "repos": [
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-47",
       "summary": "macOS desktop input: modifiers may only ADD a path, and an ancestor Listener cannot decline",
-      "repos": []
+      "repos": [
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-48",
       "summary": "Dart has no Memex emission helper — memex-clients tags ACs with a hand-rolled acTest and a short-lived per-Spec key",
-      "repos": []
+      "repos": [
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-49",
       "summary": "A colour that spans repositories is read from what ships, never sampled from a screenshot",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-50",
       "summary": "A value one component depends on and another owns is read, declared, or refused — never defaulted in silence",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     },
     {
       "handle": "std-51",
       "summary": "Module shape — a small interface over a lot of behaviour, tested through that interface. Prefer depth (leverage at the interface, not line count); export nothing without a caller outside the module; a single-consumer symbol belongs in that consumer; apply the deletion test before introducing a module; a seam needs two adapters, not one; never widen exports so a test can reach inside; `shared`/`utils`/`misc` are not module names. Fixes the design vocabulary (module / interface / seam / adapter / depth). Advisory by design — it guides, it does not gate: no check blocks a merge on it; it reaches an agent through facet routing on create_task/resolve_decision and through this index.",
-      "repos": []
+      "repos": [
+        "memex-ai",
+        "memex-clients"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes the first half of [spec-544](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-544). The UI surface (dec-5) and its Playwright journey follow in a second PR — see *Not in this PR*.

## The problem, measured

`make standards-check` compares the manifest to `CLAUDE.md` **and nothing else**. Two offline files that age together always agree, so the check was green while the index was eight Standards behind: the Memex held 51 approved Standards and the manifest listed 43. std-43…std-50 bound nobody. It was found by hand.

Meanwhile `memex-clients/CLAUDE.md` — 178 lines pointing at the same Memex — never used the word "standard". Six Standards govern that repo specifically and an agent working there met them only if it independently thought to search.

## What this changes

| index | before | after | composition |
|---|---|---|---|
| memex-ai | 43 listed / 51 live | **45** | 30 server-only + 11 both + 4 unattributed |
| memex-clients | none at all | **21** (separate PR) | 6 desktop-only + 11 both + 4 unattributed |

The server repo's index no longer carries the desktop release runbook, fvm, widget-mount, pty, macOS-input or Dart-emission rules. std-42's presence here was the leftover that made the split *ambiguous* rather than merely incomplete.

### The mechanism

- **`planIndex({ live, manifest, repo })`** — one interface over the whole offline transformation (std-51). Merge, seed, attribute, filter, render. Pure, so `make check` gains no network call.
- **`fetchLiveStandards()`** — the single network edge, called with **no fetch init**, so there is provably no Authorization header to expire. This Memex is public (std-31) and every GET resolves public → read / private → 404 (std-7). The generator's old header justified its offline mirror with *"CI holds no Memex credentials"*; that premise was over-broad — reading needs no credential at all.
- **`make standards-sync`** stops being two `echo` lines.
- **`--repo` is required, never defaulted** (std-5's shape). Defaulting would generate memex-ai's index inside memex-clients and report success.
- **`.github/actions/standards-index`** + **`standards-drift.yml`** — the set-diff lives once; each repo calls it and opens its own PR with its **own** `GITHUB_TOKEN`. No PAT, no GitHub App, no cross-repo credential anywhere.

### Two behaviours that are load-bearing, not incidental

**Seed, never block.** A Standard the manifest has never seen gets its live title as a provisional summary and the run exits 0. Blocking until a human writes prose fails worse: the red goes ambient or gets bypassed, and the rule stays invisible — the exact harm this Spec exists to close.

**Fail open.** No attribution means the Standard appears in **every** index. Filtering that hid the unattributed would let one mis-tag erase a rule from both repos at once. With 0 of 51 tagged, both indexes generated complete on day one and narrowed as attribution landed — no flag day.

## Decisions resolved

dec-1 flat tags (a scoped `repo::` value would displace its sibling, and the both-repos set is a dozen Standards) · dec-2 filtered + fail-open · dec-3 the comparator · dec-4 fair-code core · dec-6 one shared action, each repo its own token · dec-7 curated prose has one home.

**dec-6 and dec-7 were raised during the build, not planned.** dec-6: `GITHUB_TOKEN` is repo-scoped, which dec-3 never accounted for. dec-7: dec-3 gave each repo a manifest, which duplicates *prose* — both existed for ten minutes and already disagreed on std-1.

## Not in this PR

- **The Standards-page UI** (dec-5: read-only chips + handoff per std-34 cl-5) and its **Playwright journey** (std-28). Nothing here touches a user-facing flow, so no journey is owed yet.
- **`memex-clients`' side** is a separate PR and **must merge after this one** — its workflow references `mindset-ai/memex-ai/.github/actions/standards-index@develop`, which does not exist until this merges.
- **Curating the 8 placeholder summaries** seeded from live titles. Advisory by design.

## Test plan

- [x] `make check` — offline battery, 45/51, no network, no DB
- [x] `make typecheck` — clean (`tsc -b` for ui, not the no-op `--noEmit`)
- [x] Full server suite — **6537 passed**, 704 files, 0 failed
- [x] Full UI suite — **2388 passed**, 353 files, 0 failed
- [x] `test:unit` (pre-push gate) — 2076 passed
- [x] 35 tests across six standards-index files; each AC seen **RED before green**
- [x] ACs verified on the board, not merely green locally: ac-7 ac-8 ac-9 ac-10 ac-11 ac-14 ac-15 ac-16 ac-22 ac-23 ac-24 ac-25
- [x] `--sync` run against **live prod**, end to end, for both repos
- [x] Both YAML files parse; both action shell steps pass `bash -n`; heredoc terminators confirmed at column 0 after block-scalar stripping
- [ ] **ac-12 / ac-13 remain UNTESTED.** Tag coexistence was *observed* on live data (`tagged memex-ai, memex-clients`) but no tagged test asserts it — that needs a DB integration test. Stated rather than counted as done.
- [ ] **ac-17** (no `.ee.` marker) is trivially true but unverified by a test.
- [ ] `make e2e-cold` not run — no user-facing flow in this diff; it gates the follow-up PR.

## One human action outstanding

**std-43 needs archiving.** It is live and `approved` with `archivedAt: null` despite being titled `[REVERTED — abandoned, safe to archive/delete]`, so it currently appears in *both* indexes with that title. Archiving is human-only on the MCP surface; archived Standards are excluded at source, so one click removes it from both with no special-casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
