### PR TITLE
fix(spec-525): phase B's refusal carries its own off-switch, and can only fire where it prevents something

### DIFF
--- a/packages/server/scripts/verify-scaling-budget.ts
+++ b/packages/server/scripts/verify-scaling-budget.ts
@@ -376,11 +376,27 @@ async function main(): Promise<void> {
   // this lands, so an on-by-default refusal would abort memex-api's own deploys: the guard
   // working exactly as designed and stopping all work. Turn it on when phase A's list above
   // is empty.
+  //
+  // TWO CONDITIONS on the refusal, both learned by asking what it would actually do:
+  //
+  // 1. `plan` MODE ONLY. This script runs twice — before the deploy (`plan`) and after the
+  //    cutover (`applied`). In `plan` a refusal PREVENTS the deploy. In `applied` traffic
+  //    has already moved, so it can only paint a successful deploy red after the fact, with
+  //    no rollback — and a red mark on a deploy that worked trains people to ignore red
+  //    marks. Post-cutover it is a warning, which is all it can honestly be.
+  //
+  // 2. FATAL ON PROD, WARNING ELSEWHERE — the posture spec-518 dec-5 already set for a blown
+  //    budget, followed here rather than diverged from in silence. The sequence still
+  //    protects prod: int warns first, and prod's refusal lands in `plan`, BEFORE any
+  //    revision is created. The cost is that a missing declaration is discovered at prod's
+  //    plan step rather than on int, and that is the trade dec-5 already made.
   if (budget) {
-    for (const refusal of undeclaredServices(budget, {
+    const refusals = undeclaredServices(budget, {
       requireDeclarations: process.env.REQUIRE_CONNECTION_DECLARATIONS === "1",
-    })) {
-      failures.push(refusal);
+    });
+    for (const refusal of refusals) {
+      if (mode === "plan" && isProd(ENV)) failures.push(refusal);
+      else warnings.push(`${refusal}\n      (non-fatal in mode=${mode} on ${ENV})`);
     }
   }
   const warnings = [...outcome.warnings];

--- a/packages/server/scripts/verify-scaling-budget.ts
+++ b/packages/server/scripts/verify-scaling-budget.ts
@@ -372,6 +372,7 @@ async function main(): Promise<void> {
   // A read failure is "nobody checked", which is the condition this guard exists to end.
   const failures = [...outcome.failures];
 
+  const warnings = [...outcome.warnings];
   // PHASE B — OFF BY DEFAULT, and that is not timidity. Every service is undeclared the day
   // this lands, so an on-by-default refusal would abort memex-api's own deploys: the guard
   // working exactly as designed and stopping all work. Turn it on when phase A's list above
@@ -399,7 +400,6 @@ async function main(): Promise<void> {
       else warnings.push(`${refusal}\n      (non-fatal in mode=${mode} on ${ENV})`);
     }
   }
-  const warnings = [...outcome.warnings];
   for (const f of readFailures) {
     if (isProd(ENV)) failures.push(`guard could not verify: ${f}`);
     else warnings.push(`guard could not verify: ${f} — non-fatal on ${ENV}`);

--- a/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
+++ b/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
@@ -42,6 +42,7 @@ import {
   declarationWarnings,
   undeclaredServices,
   DECLARATION_VAR,
+  UNBLOCK_HINT,
   RELAY_LISTEN_PER_INSTANCE,
   CUTOVER_REVISION_FACTOR,
   FOREIGN_SERVICE_DEFAULT_POOL,
@@ -224,6 +225,15 @@ describe("spec-525 t-15 phase B: refusing the undeclared, behind a switch", () =
     // The names actually FOUND, so a near-miss is diagnosable from the failure alone rather
     // than by going and reading the revision.
     expect(message).toContain("foreign-default");
+
+    // AND ITS OWN OFF-SWITCH, in the message rather than in a standard someone has to find.
+    // This refusal can be triggered by a change nobody here made — the guard enumerates
+    // every service attached to the same Cloud SQL instance, so another team renaming their
+    // variable stops OUR deploys, including a hotfix. The remedy is one variable; a remedy
+    // that takes one word and is known to nobody costs hours at 3am.
+    expect(message).toContain(UNBLOCK_HINT);
+    expect(message).toContain("REQUIRE_CONNECTION_DECLARATIONS");
+    expect(UNBLOCK_HINT).toMatch(/unset|TO UNBLOCK/i);
   });
 
   it("closes the two-pools-one-variable under-count at ANY maxScale", () => {

--- a/packages/server/src/deploy/scaling-budget.ts
+++ b/packages/server/src/deploy/scaling-budget.ts
@@ -100,6 +100,22 @@ export const ADMIN_SESSION_RESERVE = 5;
  * prints the line it printed before declarations existed. Not a silent failure — a SUCCESS
  * SIGNAL, on the one string that IS the contract (spec-525 t-15).
  */
+/**
+ * How to UNBLOCK a deploy this guard refused — carried in the refusal message itself.
+ *
+ * Not documentation-adjacent politeness. This refusal can be triggered by a change nobody
+ * on this repo made: the guard enumerates every Cloud Run service attached to the same
+ * Cloud SQL instance (from `gcloud`, deliberately not from a list here), so a NEW service
+ * someone else deploys, or another team renaming their own variable, stops OUR deploys —
+ * including a hotfix. The remedy is one variable, and a remedy that takes one word but is
+ * known to nobody costs hours at 3am. So the message states it rather than pointing at a
+ * standard somebody has to go and find.
+ */
+export const UNBLOCK_HINT =
+  "TO UNBLOCK NOW: unset REQUIRE_CONNECTION_DECLARATIONS in the deploy workflow's " +
+  "environment and re-run. That returns the guard to over-counting undeclared services, " +
+  "which is the safe direction — then fix the declaration without a deploy blocked on it.";
+
 export const DECLARATION_VAR = "DB_CONNECTIONS_PER_INSTANCE";
 
 /**
@@ -218,9 +234,10 @@ export function serviceTerm(obs: ServiceObservation): ServiceTerm {
   // coherent relation differs per service — memex-api's total is pool + relay (5 = 4+1),
   // backstage's is 2 x pool — and the guard cannot know which form applies. A check would
   // be the guessing this removes, wearing an equals sign.
-  const perInstance = hasDeclaration
-    ? Math.floor(declared)
-    : resolvePool(obs).poolMax + RELAY_LISTEN_PER_INSTANCE;
+  const inferred = hasDeclaration ? undefined : resolvePool(obs);
+  const perInstance = inferred
+    ? inferred.poolMax + RELAY_LISTEN_PER_INSTANCE
+    : Math.floor(declared as number);
   const steady = obs.maxInstances * perInstance;
 
   const base = {
@@ -232,9 +249,9 @@ export function serviceTerm(obs: ServiceObservation): ServiceTerm {
     peak: steady * CUTOVER_REVISION_FACTOR,
   };
 
-  return hasDeclaration
-    ? { ...base, poolSource: "declared" as const, relayCounted: false }
-    : { ...base, ...resolvePool(obs), relayCounted: true };
+  return inferred
+    ? { ...base, ...inferred, relayCounted: true }
+    : { ...base, poolSource: "declared" as const, relayCounted: false };
 }
 
 /**
@@ -275,7 +292,8 @@ export function undeclaredServices(
         `${t.service} declares no ${DECLARATION_VAR} — refusing rather than inferring. ` +
         `Used ${t.poolSource} (${t.poolMax} per pool) because that is all the revision ` +
         `published. Set ${DECLARATION_VAR} to the COMPLETE per-instance total: every pool ` +
-        `the instance opens, plus any long-lived connection outside one.`,
+        `the instance opens, plus any long-lived connection outside one.` +
+        `\n      ${UNBLOCK_HINT}`,
     );
 }
 


### PR DESCRIPTION
Three corrections to **spec-525 t-15**'s phase-B refusal (shipped in #676, **off by default and still off**), all found by asking what turning the switch on would **actually do** rather than what it was for.

📋 [spec-525](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-525) · AC: ac-27

## 1. The refusal carries its own remedy

This refusal can be triggered by a change **nobody on this repo made**. The guard enumerates every Cloud Run service attached to the same Cloud SQL instance — from `gcloud`, deliberately not from a list here, so a forgotten service cannot be invisible. Which means:

| trigger | effect |
|---|---|
| a new service someone else attaches to `memex-prod` without declaring | **our** deploy aborts, hotfix included |
| the backstage team renaming or dropping their own variable | **our** deploys abort, on a variable we do not own |

The remedy is one variable. **A remedy that takes one word and is known to nobody costs hours at 3am**, so `UNBLOCK_HINT` is in the message itself rather than in a standard somebody has to go and find — and it says *why* switching off is safe (the guard returns to over-counting, which is the safe direction), so the blocked person does not hesitate.

## 2. Plan mode only

`verify-scaling-budget.ts` runs **twice** — `deploy.sh:364` (`plan`, before) and `deploy.sh:525` (`applied`, after `gcloud run deploy` at `:488`).

In `plan` a refusal **prevents** the deploy. In `applied` traffic has already moved, so it could only paint a **successful** deploy red after the fact, with no rollback — and a red mark on a deploy that worked trains people to ignore red marks. Post-cutover it is now a warning, which is all it can honestly be.

## 3. Fatal on prod, warning elsewhere — following dec-5 rather than diverging in silence

`decideOutcome` puts a blown budget into `failures` **only** when `isProd(env)`, else into `warnings` (spec-518 dec-5). **My first cut pushed refusals onto `failures` unconditionally**, so an undeclared service would have aborted **int** deploys too — against a documented decision, with nothing saying so.

The sequence still protects prod: int warns first, and prod's refusal lands in `plan` **before any revision is created**. The cost — a missing declaration surfaces at prod's plan step rather than on int — is the trade dec-5 already made.

## Also

`resolvePool(obs)` was called **twice** on the undeclared path in `serviceTerm`, once for `perInstance` and again inside the spread. Pure function, so no behaviour change, but sloppy — hoisted into `const inferred`, which also makes the branch test the value it actually depends on.

## Blast radius

**None on the running service.** The switch is read by the deploy-time guard and never reaches a Cloud Run revision — no restart, no env change on prod, nothing a user can observe.

**And nothing today.** Read off the live prod revisions this morning: memex-api declares **5** (`memex-api-00145-5tw`, from last night's deploy) and backstage declares **10** (`backstage-00054-8mn`). Recomputed with the guard's own functions, the refusal list is **empty** and phase A's warning is **quiet** — which is the evidenced condition for turning the switch on at all.

**The switch stays OFF.** No environment variable was set anywhere by this PR.

## Test plan

- [x] 9 tagged tests, one extended to assert the off-switch text is in the refusal message
- [x] **Full server suite: 6583 passed / 0 failed**; regression tier **1619 passed**
- [x] `make check` and `make typecheck` clean
- [x] Verified against live prod: `129 → 125` at cutover, i.e. **the 4 connections** t-15 was actually worth, confirmed by the running system rather than by re-reading source (`c-23` corrects an earlier claim of 26)
- [ ] Not covered: the four-line glue in `verify-scaling-budget.ts` that classifies refusals into `failures` vs `warnings`. That script has no test harness, and standing one up is out of proportion to a mode/env branch — named rather than left implied

## What is still deliberately open on t-15

Retiring the `applied` and `our-code-default` inference branches, and deleting `ServiceObservation.ownCode` with them. They go **together** — removing `applied` alone promotes `our-code-default` to being the lying branch. Their moment is when the switch is actually turned on, which is now a decision with evidence behind it rather than a remembered TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)