### PR TITLE
fix(spec-525): the over-budget message printed `(undefined+1)` for a declared service

### DIFF
--- a/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
+++ b/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
@@ -39,6 +39,7 @@ import {
   computeBudget,
   formatBudgetReport,
   parseRevisionScaling,
+  decideOutcome,
   declarationWarnings,
   undeclaredServices,
   DECLARATION_VAR,
@@ -266,5 +267,46 @@ describe("spec-525 t-15 phase B: refusing the undeclared, behind a switch", () =
       expect(refused.length).toBe(1);
       expect(refused[0]).toContain(DECLARATION_VAR);
     }
+  });
+});
+
+describe("spec-525 t-15: no message ever prints `undefined` for a declared service", () => {
+  it("survives an over-budget report where every term is declared", () => {
+    tagAc(AC_DECLARED);
+
+    // THE DEFECT THIS PINS, found in a live int deploy log rather than in review:
+    //
+    //   ⚠ connection budget exceeded: peak 41 > 22 usable
+    //     (memex-api 2×3×(undefined+1)=36 + admin 5)
+    //
+    // `decideOutcome`'s detail string read `t.poolMax` and hardcoded `+1` for EVERY term.
+    // Making `poolMax` optional (a declared service has no per-pool figure) fixed
+    // `formatBudgetReport`, which branches on `relayCounted` — and missed this second
+    // formatter, which does not. `tsc` cannot help: interpolating `number | undefined`
+    // into a template literal is perfectly legal.
+    //
+    // Asserted as a PROPERTY over every message this module produces, not at the one site.
+    // Naming the site would pin the bug I already know about; the property catches the next
+    // reader of an optional field — which is how this one got in.
+    const usable = 22; // int's db-f1-micro default (25) minus superuser_reserved (3)
+    const services = [
+      { service: "memex-api", revision: "rev-1", maxInstances: 3, declaredPerInstance: 6, ownCode: true },
+      { service: "other", revision: "rev-2", maxInstances: 2, declaredPerInstance: 10 },
+    ];
+    const budget = computeBudget({ services, usable });
+    expect(budget.withinBudget).toBe(false); // the fixture must actually blow the budget
+
+    const outcome = decideOutcome({ env: "int", budget, comparison: undefined, revision: undefined });
+    const everything = [
+      ...formatBudgetReport(budget),
+      ...declarationWarnings(budget),
+      ...undeclaredServices(budget, { requireDeclarations: true }),
+      ...outcome.failures,
+      ...outcome.warnings,
+    ].join("\n");
+
+    expect(everything.length).toBeGreaterThan(0);
+    expect(everything).not.toContain("undefined");
+    expect(everything).not.toContain("NaN");
   });
 });

--- a/packages/server/src/deploy/scaling-budget.ts
+++ b/packages/server/src/deploy/scaling-budget.ts
@@ -477,7 +477,15 @@ export function decideOutcome({
     const detail =
       `connection budget exceeded: peak ${budget.peakTotal} > ${budget.usable} usable ` +
       `(${budget.terms
-        .map((t) => `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×(${t.poolMax}+1)=${t.peak}`)
+        // Branches on `relayCounted` for the same reason `formatBudgetReport` does: a
+        // declared service has no per-pool figure and no relay added, so `(poolMax+1)`
+        // would print `(undefined+1)` — which it did, in a live int deploy log, until this
+        // was the second reader of an optional field to be fixed rather than the first.
+        .map((t) =>
+          t.relayCounted
+            ? `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×(${t.poolMax}+1)=${t.peak}`
+            : `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×${t.perInstance}=${t.peak}`,
+        )
         .join(" + ")} + admin ${budget.adminReserve})`;
     if (isProd(env)) failures.push(detail);
     else warnings.push(`${detail} — non-fatal on ${env} per spec-518 dec-5`);


### PR DESCRIPTION
Found in a **live int deploy log**, not in review:

```
⚠ connection budget exceeded: peak 41 > 22 usable
  (memex-api 2×3×(undefined+1)=36 + admin 5)
                  ↑
```

📋 [spec-525](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-525) · AC: ac-27

## The cause is mine, one file from the change that introduced it

t-15 (#676) made `ServiceTerm.poolMax` **optional** — a declared service has no per-pool figure, and holding a whole-instance total in a field named `poolMax` would have been the counted-vs-real confusion under a new name.

I then fixed **one** reader — `formatBudgetReport`, which branches on `relayCounted` — and missed the second: `decideOutcome`'s over-budget detail string, which maps over **every** term and hardcodes `(poolMax+1)`.

**Why no gate caught it:**

- `tsc` cannot — interpolating `number | undefined` into a template literal is perfectly legal.
- No test covered it — the message only appears when the budget is **blown**, which on int is the permanent state (peak 41 against 22 usable, filed as `spec-332/c-6`) and on prod never is.

So it took a real deploy log. That makes three defects today found by something other than my own tests: the type-checker, a review bot, and now production.

## The test is a property, not a site

It builds an over-budget budget in which **every term is declared**, then asserts that **nothing this module emits** contains `undefined` or `NaN` — `formatBudgetReport`, `declarationWarnings`, `undeclaredServices`, and both `decideOutcome` channels.

Pinning the site would pin the bug I already know about. **The property catches the next reader of an optional field**, which is exactly how this one got in. Same shape as ac-26's total-agnostic cause sums, and for the same reason.

## Effect

**Cosmetic** — the arithmetic was right, only its explanation was broken. `peak 41`, `36`, `admin 5` were all correct; only the middle term's derivation printed wrong.

But a budget warning that reads `(undefined+1)` is one a reader discounts, and this warning is the only thing standing between int's permanent over-budget state and its normalisation into background noise. That state is itself worth someone's attention (`spec-332/c-6`): int runs a `db-f1-micro` on the tier default of 25 connections while prod was raised to 200, so a cutover on int demands 36 against 25 — the exact `FATAL 53300` spec-518 exists to prevent, on the environment used to prove prod won't.

## Test plan

- [x] **Red on the exact message before the fix** — `expected '… maxInstances 3…' not to contain 'undefined'`
- [x] **Full server suite: 6589 passed / 0 failed**; regression tier **1620 passed**
- [x] `make check` and `make typecheck` clean
- [ ] Post-merge: the next int deploy log shows the same warning with real arithmetic in place of `(undefined+1)`

## Note on today's CI

Runs are taking ~3× yesterday's time (17 min vs 5), which has already tripped two guard-rails calibrated on yesterday: `timeout-minutes: 10` on the `ui` job (cancelled #679's first run) and `pollTimeoutS: 900` in `deploy-gate.mjs` (aborted develop's deploy 84 seconds before the test verdict landed). If a check here is cancelled around the 10-minute mark, that is the timeout rather than a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)