### PR TITLE
ci(test): make the ui timeout and the deploy gate's patience proportionate to the budget

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,7 +343,21 @@ jobs:
   # composite action) which speeds the already-sharded server + e2e tiers.
   ui:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20, not 10, and the asymmetry it corrects is the point: `server` runs across THREE
+    # shards at 15 minutes each, `e2e` across three — and `ui` is a SINGLE job running the
+    # whole UI suite plus the coverage gate, on the tightest budget in the file. It had the
+    # least parallelism and the smallest allowance.
+    #
+    # Measured 2026-09-04, same workflow, same runner image: 6m41s, 10m16s, 10m19s, and one
+    # more over 10 — four crossings in a day against a norm of ~5 minutes the day before,
+    # including 5m08s and 8m14s on the SAME commit. So the variance is the runner's, not the
+    # suite's, and a limit set at the observed maximum is a coin flip.
+    #
+    # Not one of those crossings caught a defect: the job was killed mid-run every time, and
+    # passed on rerun with no code change. What it did instead was turn `test` into
+    # `cancelled` with 12 of 13 jobs green, which fails the deploy gate closed — so a runner
+    # hiccup presented as a red DEPLOY, four times, inviting a search for a deployment bug.
+    timeout-minutes: 20
     env:
       # UI unit tests tag ACs too (std-35 Recipe A — "representative unit tests at
       # the track() sites"); emit them like the server / e2e / ac-emit jobs do.

--- a/scripts/ci/deploy-gate.mjs
+++ b/scripts/ci/deploy-gate.mjs
@@ -54,12 +54,29 @@ import { appendFileSync } from "node:fs";
 const DEFAULTS = {
   testWorkflowFile: "test.yml",
   deployWorkflowFile: "deploy.yml",
-  pollTimeoutS: 900,
+  // THE INVARIANT NOBODY HAD WRITTEN DOWN: this gate's patience must EXCEED the test
+  // workflow's own worst-case budget, because it waits on that workflow's conclusion.
+  //
+  // At 900s it did not, and never had. `test.yml`'s `server` shards are allowed
+  // `timeout-minutes: 15` — 900s — each. So the gate's entire patience equalled ONE job's
+  // allowance, before queueing and before the twelve other jobs. A `server` shard
+  // legitimately taking 14 minutes has always been able to blow this, independently of how
+  // fast the runners happen to be.
+  //
+  // Today's slowness only revealed it: on develop@4c11e88d the gate abandoned at 15m11s
+  // and the test workflow concluded SUCCESS 84 seconds later. The deploy was skipped for a
+  // run that passed.
+  //
+  // 2400s (40 min) is chosen against the budget rather than against an observation: the
+  // longest single job allowance is 15 min, and this leaves room for queueing plus the rest
+  // of the graph. Raising it costs wall-clock on a genuinely stuck run and nothing else —
+  // the gate still fails CLOSED at the end, so a hung test suite never becomes a deploy.
+  pollTimeoutS: 2400,
   pollIntervalS: 15,
   intSmokeEnforce: "warn",
 };
 
-// ── Pure helpers (unit-tested by scripts/ci/deploy-gate.test.mjs) ──────────────
+// ── Pure helpers (unit-tested by packages/server/src/__regression__/deploy-gate.regression.test.ts) ──
 
 /**
  * Classify a list of workflow runs for a SHA into a gate verdict.


### PR DESCRIPTION
**Four times on 2026-09-04 a runner hiccup presented as a RED DEPLOY**, and none of them was a defect.

## The chain

```
ui crosses its 10-minute limit, killed mid-run
  → the whole `test` run concludes `cancelled`  (12 of 13 jobs GREEN)
    → the deploy gate needs `success`, finds `cancelled` → FAIL CLOSED
      → `deploy` skipped
```

The gate is **right** to refuse an unverified SHA. What failed was the verification, for a reason that has nothing to do with the code — and the failure surfaces as a red *deploy*, which invites a search for a deployment bug.

## 1. `ui`: `timeout-minutes` 10 → 20

The asymmetry this corrects is the point:

| job | shards | allowance each |
|---|---|---|
| `server` | **3** | 15 min |
| `e2e` | **3** | 15 min |
| **`ui`** | **1** | **10 min** |

`ui` is a single job running the whole UI suite **plus** the coverage gate — the least parallelism in the file and the smallest allowance.

Measured today, same workflow, same runner image: **6m41s, 10m16s, 10m19s** and one more crossing — against **~5 minutes yesterday**, including **5m08s and 8m14s on the same commit**. The variance is the runner's, not the suite's, and a limit set at the observed maximum is a coin flip.

**Not one crossing caught anything.** Each passed on rerun with no code change.

## 2. `deploy-gate.mjs`: `pollTimeoutS` 900 → 2400 — and this one was never right

**The invariant nobody had written down: the gate's patience must EXCEED the test workflow's own worst-case budget**, because it waits on that workflow's conclusion.

At 900s it equalled **one job's allowance** — `test.yml`'s `server` shards are each allowed `timeout-minutes: 15`, i.e. exactly 900s — before queueing and before the twelve other jobs. **A shard legitimately taking 14 minutes has always been able to blow this**, independently of runner speed.

Today only revealed it: on `develop@4c11e88d` the gate abandoned at **15m11s** and `test` concluded **SUCCESS 84 seconds later**. The deploy was skipped for a run that passed.

2400s is chosen **against the budget**, not against an observation. Raising it costs wall-clock on a genuinely stuck run and nothing else — the gate still fails **CLOSED** at the end, so a hung suite never becomes a deploy.

## Neither change masks a failure

Neither limit has ever caught a defect; both have killed verifications that were going to pass. Loosening them restores the signal — a red deploy should mean a deploy problem.

## Also

The file's own comment claimed its pure helpers were *"unit-tested by `scripts/ci/deploy-gate.test.mjs`"* — **a file that does not exist**. Corrected to the real one, `packages/server/src/__regression__/deploy-gate.regression.test.ts`, whose **19 tests pass** against the new value.

## What this PR does NOT do, and why a Spec now holds it

This takes the **cheapest of three remedies** without anyone having weighed the other two:

1. loosen the limits ← this PR
2. **shard the `ui` job** like `server` and `e2e` — less wall-clock, but merging coverage across shards is fiddly
3. **find out why CI is ~3× slower than yesterday** — unknown cost, possibly GitHub-side

And the invariant in §2 is currently a **comment**. A comment is not a guard-rail: nothing stops someone raising a `server` shard to 30 minutes without touching the gate, recreating this exact defect. Making it checkable is the durable half, and this repo's habit is to give an invariant a clause and a check.

Both questions are carried by a Spec rather than lost in this PR's description.

## Test plan

- [x] `make check` (offline guard battery) clean
- [x] `deploy-gate.regression.test.ts` — **19 tests pass** against `pollTimeoutS: 2400`
- [x] Workflow YAML parses (the run this PR triggers is itself the proof)
- [ ] Post-merge: the next `develop` push deploys int without a rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)