### PR TITLE
ci(test): the deploy gate's patience is now checked against the budget, not commented

### DIFF
--- a/packages/server/src/__regression__/deploy-gate.regression.test.ts
+++ b/packages/server/src/__regression__/deploy-gate.regression.test.ts
@@ -364,3 +364,74 @@ describe("spec-395 deploy gate — runGate end-to-end (fail-closed semantics, de
     expect(code).toBe(0);
   });
 });
+
+// ── The invariant nobody had written down (spec-395 dec-1, c-2) ───────────────
+//
+// dec-1 required "a bounded timeout that fails closed". `pollTimeoutS: 900` met that TO
+// THE LETTER and was never large enough, because the requirement never put the bound in a
+// relationship with the thing it bounds. The gate waits on `test.yml`'s conclusion, and
+// `test.yml`'s own `server` shards are each allowed `timeout-minutes: 15` — exactly 900s.
+// The gate's entire patience equalled ONE job's allowance, before queueing and before the
+// twelve other jobs.
+//
+// Observed 2026-09-04 on develop@4c11e88d: the gate abandoned at 15m11s with
+// `verdict is 'pending'`, and `test` concluded SUCCESS 84 seconds later. The deploy was
+// skipped for a run that passed.
+//
+// A COMMENT IS NOT A GUARD-RAIL, which is why this exists: nothing otherwise stops someone
+// raising a `server` shard to `timeout-minutes: 30` without touching the gate, and
+// recreating this exactly — where it would again arrive as a red DEPLOY on a SHA that
+// looks unverified.
+//
+// Deliberately UNTAGGED. This is a repository invariant, not a Spec's acceptance
+// criterion: spec-395 is `done` with all six of its ACs verified, and minting one there —
+// or hanging it off a Spec that does not own the gate — would misfile it. It still gates
+// every PR, because it runs in the `server` shards like every other regression test.
+
+describe("deploy gate — its patience must exceed the test workflow's worst-case budget", () => {
+  const testYml = readFileSync(resolve(repoRoot, ".github/workflows/test.yml"), "utf8");
+  const gateSrc = readFileSync(resolve(repoRoot, "scripts/ci/deploy-gate.mjs"), "utf8");
+
+  const budgetsMin = [...testYml.matchAll(/^\s*timeout-minutes:\s*(\d+)\s*$/gm)].map((m) =>
+    Number(m[1]),
+  );
+  const pollTimeoutS = Number(/pollTimeoutS:\s*(\d+)/.exec(gateSrc)?.[1]);
+
+  it("parsed both sides — a pattern that silently matches nothing reports success", () => {
+    // THE GUARD ON THE GUARD, and it is today's other lesson: a count can be
+    // syntactically right and semantically empty. Twice on 2026-09-04 a grep of mine
+    // returned 0 on a tree that had dozens of hits, and both times the only thing that
+    // caught it was printing the detail beside the count. A regex that stops matching
+    // here would make this whole invariant pass vacuously, forever.
+    expect(budgetsMin.length).toBeGreaterThanOrEqual(8); // test.yml has ~12 timeout-minutes
+    expect(Math.max(...budgetsMin)).toBeGreaterThanOrEqual(10);
+    expect(Number.isFinite(pollTimeoutS)).toBe(true);
+    expect(pollTimeoutS).toBeGreaterThan(0);
+  });
+
+  it("the gate outlasts the slowest job test.yml is allowed to run", () => {
+    const worstCaseS = Math.max(...budgetsMin) * 60;
+
+    // Strictly greater, not >=: at equality the gate can abandon the very run it is
+    // waiting for, which is precisely what happened. The message names both numbers
+    // because the fix depends on WHICH side moved — a job's allowance was raised, or the
+    // gate's patience was lowered.
+    expect(
+      pollTimeoutS,
+      `deploy-gate pollTimeoutS=${pollTimeoutS}s must exceed test.yml's worst-case job ` +
+        `budget of ${worstCaseS}s (max timeout-minutes = ${Math.max(...budgetsMin)}). ` +
+        `The gate waits on that workflow's CONCLUSION, so a patience at or below a single ` +
+        `job's allowance can abandon a run that was going to pass — it did, on ` +
+        `develop@4c11e88d, 84 seconds early. Raise pollTimeoutS in scripts/ci/deploy-gate.mjs, ` +
+        `or lower the job budget in .github/workflows/test.yml.`,
+    ).toBeGreaterThan(worstCaseS);
+  });
+
+  it("leaves real headroom, not a single second of it", () => {
+    // The whole workflow is a GRAPH, not one job: queueing, checkout, install and the
+    // other twelve jobs all sit between the push and the conclusion this gate reads. A
+    // bound that merely clears the slowest single job still has no room for the rest.
+    const worstCaseS = Math.max(...budgetsMin) * 60;
+    expect(pollTimeoutS).toBeGreaterThanOrEqual(worstCaseS * 1.5);
+  });
+});


### PR DESCRIPTION
**Stacked on #681** (base is `ci/proportionate-timeouts`, not `develop`). #681 raises the two values; this adds the thing #681 cannot — a check, so the invariant survives the next person to edit either side.

## The invariant

> **The deploy gate's patience must exceed the test workflow's own worst-case job budget**, because it waits on that workflow's conclusion.

`spec-395` dec-1 required *"a bounded timeout that fails closed"*. `pollTimeoutS: 900` met that **to the letter** and was never large enough — the requirement never put the bound in a relationship with the thing it bounds.

At 900s the gate's entire patience equalled **one job's allowance** (`test.yml`'s `server` shards are each `timeout-minutes: 15` = 900s), before queueing and before the twelve other jobs. Observed on `develop@4c11e88d`: the gate abandoned at **15m11s** with `verdict is 'pending'`, and `test` concluded **SUCCESS 84 seconds later**. A deploy skipped for a run that passed.

Recorded as `spec-395/c-2`.

## Why a check and not a comment

#681 writes the invariant into the file. **Nothing whatsoever stops someone raising a `server` shard to `timeout-minutes: 30` without touching the gate** — recreating this exactly, where it arrives as a **red DEPLOY** on a SHA that looks unverified. Three of today's deploy failures had that shape and none was a defect.

## Three assertions, and the first is the one I would have skipped a week ago

1. **Both sides parsed.** A regex that stops matching makes the whole invariant pass **vacuously, forever**. Twice on 2026-09-04 a grep of mine returned 0 on a tree with dozens of hits — once nearly keeping a broken `tsconfig`, once reporting 15 CI failures that did not exist — and both times what caught it was printing the detail beside the count. So the count is asserted before it is used.
2. **`pollTimeoutS > max(timeout-minutes) × 60`**, strictly greater. At equality the gate can abandon the very run it waits for, which is what happened.
3. **×1.5 headroom**, because the workflow is a *graph*: queueing, checkout, install and twelve other jobs sit between the push and the conclusion. A bound that merely clears the slowest single job has no room for the rest.

The failure message names **both numbers and both files**, because the fix depends on which side moved:

```
deploy-gate pollTimeoutS=900s must exceed test.yml's worst-case job budget
of 1200s (max timeout-minutes = 20). … Raise pollTimeoutS in
scripts/ci/deploy-gate.mjs, or lower the job budget in .github/workflows/test.yml.
```

## Deliberately untagged

This is a **repository invariant, not a Spec's acceptance criterion**. `spec-395` is `done` with all six of its ACs verified; minting one there — or hanging it off a Spec that does not own the gate — would misfile it. It gates every PR regardless, running in the `server` shards like every other regression test.

## Test plan

- [x] **Red-capability proven, not asserted** [per std-52]: with `pollTimeoutS` put back to develop's 900, two of the three assertions fail with the message above. Restored → 22 pass
- [x] **Full server suite: 6592 passed / 0 failed**
- [x] `make check` and `make typecheck` clean
- [x] No export widened to let the test reach inside [per std-51] — both values are read from source text, which is already this file's idiom for `deploy.yml`

## Merge order

Merge **#681 first**. This PR's base is `ci/proportionate-timeouts`, so GitHub will retarget it to `develop` automatically once #681 lands. Merged in the other order, the check would go red on `develop` — which is correct behaviour, and not a state to leave `develop` in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)