### PR TITLE
feat(spec-525): count total arrivals — the denominator t-13's window did not have

### DIFF
--- a/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
+++ b/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
@@ -65,6 +65,9 @@ function fakeGate(over: Partial<GateSnapshotSource> = {}): GateSnapshotSource {
     // from a guess (ac-22).
     inFlightEvents: 0,
     eventBudget: DEFAULT_EVENT_BUDGET,
+    // The denominator (ac-28). A shed COUNT without it is what left t-13's window
+    // unusable for ac-2, so the heartbeat carries both axes.
+    arrivals: { events: 0, requests: 0 },
     trackedKeys: 0,
     wouldShed: {
       events: 0,

--- a/packages/server/src/observability/emission-shed-log.ts
+++ b/packages/server/src/observability/emission-shed-log.ts
@@ -32,6 +32,7 @@
 // Re-judge if the window is extended or if enforcing mode runs indefinitely.
 
 import type {
+  ArrivalCount,
   GateMode,
   ShedCause,
   WouldShedCount,
@@ -115,6 +116,12 @@ export interface GateSnapshotSource {
   readonly eventBudget: number;
   readonly trackedKeys: number;
   readonly wouldShed: WouldShedCount;
+  /**
+   * TOTAL ARRIVALS — the denominator t-13's window did not have (spec-525 t-14, ac-28).
+   * Published on BOTH axes because a rate needs its denominator on the same axis as its
+   * numerator, and `wouldShed` is already split for that reason.
+   */
+  readonly arrivals: ArrivalCount;
 }
 
 export const GATE_WINDOW_EVENT = "emission_gate_window";
@@ -159,7 +166,13 @@ export function startEmissionGateHeartbeat(opts: {
   type DeltaState = Pick<
     WouldShedCount,
     "events" | "requests" | "eventsByCause" | "requestsByCause"
-  >;
+  > & {
+    // Arrivals are delta'd with the sheds, never reported only as a cumulative: a RATE
+    // divides a window's refusals by THAT window's arrivals. Two cumulative totals from
+    // different instances, or across a recycle, do not divide (spec-525 t-14, ac-28).
+    arrivalEvents: number;
+    arrivalRequests: number;
+  };
   let previous: DeltaState | null = null;
 
   heartbeat = setInterval(() => {
@@ -172,12 +185,16 @@ export function startEmissionGateHeartbeat(opts: {
           requests: 0,
           eventsByCause: zeroByCause(),
           requestsByCause: zeroByCause(),
+          arrivalEvents: 0,
+          arrivalRequests: 0,
         };
       previous = {
         events: now.events,
         requests: now.requests,
         eventsByCause: { ...now.eventsByCause },
         requestsByCause: { ...now.requestsByCause },
+        arrivalEvents: g.arrivals.events,
+        arrivalRequests: g.arrivals.requests,
       };
 
       console.log(
@@ -211,6 +228,16 @@ export function startEmissionGateHeartbeat(opts: {
           wouldShedRequestsByCause: deltaByCause(now.requestsByCause, before.requestsByCause),
           wouldShedEventsTotal: now.events,
           wouldShedRequestsTotal: now.requests,
+          // THE DENOMINATOR (spec-525 t-14, ac-28). t-13's window had 35 547 refused
+          // requests carrying 135 801 emissions and nothing to divide them by, and the
+          // quantity is unrecoverable retroactively — so it is counted going forward.
+          // Per-window deltas so `wouldShedRequests / arrivalRequests` is a rate within
+          // ONE window, plus cumulative totals because the counter is per-instance and
+          // dies on recycle (32 distinct instances in 12 h of prod).
+          arrivalEvents: g.arrivals.events - before.arrivalEvents,
+          arrivalRequests: g.arrivals.requests - before.arrivalRequests,
+          arrivalEventsTotal: g.arrivals.events,
+          arrivalRequestsTotal: g.arrivals.requests,
           // t-13 — the ceiling-alone counterfactual, an UPPER BOUND (see WouldShedCount).
           // Cumulative rather than a delta: this one is read once, at dec-6, not tracked
           // window by window, and a running total is what a single query wants.

--- a/packages/server/src/services/admission/emission-arrivals.spec-525.test.ts
+++ b/packages/server/src/services/admission/emission-arrivals.spec-525.test.ts
@@ -1,0 +1,197 @@
+// spec-525 t-14 / ac-28 — the DENOMINATOR. Total arrivals, on both axes.
+//
+// WHY THIS EXISTS. t-13's shadow window measured 35 547 would-be refused requests carrying
+// 135 801 emissions over 7 days. That is an absolute count with NOTHING to divide it by,
+// and ac-2 asks for a RATE. What fraction of traffic that represents decides whether
+// enforcing is viable at all: 0.5% and a ceiling of 3 may be fine; 30% and no tuning here
+// is close.
+//
+// AND IT IS UNRECOVERABLE RETROACTIVELY, verified rather than assumed (dec-6, t-14):
+//   - the gate held no total counter, and the heartbeat published 16 fields, none a total
+//   - Cloud Run's `request_count` metric carries no URL-path label
+//   - request logs are sampled
+//   - `test_events` is trimmed INSIDE the emission transaction to 10 rows per
+//     (subject_ref, test_identifier) pair, so a row count measures what SURVIVED, not what
+//     arrived — and the ingest route states there is no second trace: "test_event is NOT
+//     persisted to activity_log (it's the firehose)"
+//
+// So it can only be counted going forward, which is what this is.
+//
+// BOTH AXES, not the single integer t-14 asked for. The shed counters are already split
+// events/requests because neither can be inferred from the other — t-12 measured ~8.1
+// emissions per refused request, batches to 261 — and a rate needs its denominator on the
+// SAME axis as its numerator. One arrivals integer would leave the EVENTS-axis rate
+// uncomputable, and that is the axis ac-13 states the counter's unit is.
+//
+// COUNTED AT ARRIVAL, before any bound is evaluated and regardless of mode. In shadow every
+// caller is admitted, so counting admissions would make the denominator the numerator's
+// complement and the rate meaningless.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { EmissionGate } from "./emission-gate.js";
+import {
+  startEmissionGateHeartbeat,
+  _resetEmissionGateHeartbeat,
+  GATE_WINDOW_EVENT,
+} from "../../observability/emission-shed-log.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-525/acs";
+const AC_ARRIVALS = `${SPEC}/ac-28`;
+
+describe("spec-525 ac-28: total arrivals, on both axes", () => {
+  it("counts every arrival on both axes, admitted or refused", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // poolMax 4 -> ceiling 2, per-key allowance 1. Enforcing, so some of these really are
+    // refused — which is the point: an arrival is an arrival either way.
+    const gate = new EmissionGate({ poolMax: 4, mode: "enforcing", waitMs: 0 });
+    expect(gate.arrivals.requests).toBe(0);
+    expect(gate.arrivals.events).toBe(0);
+
+    const held = [gate.tryAcquire("a", 10), gate.tryAcquire("b", 20)]; // admitted: 2 req / 30 ev
+    const refused = [gate.tryAcquire("c", 5), gate.tryAcquire("d", 7)]; // refused:  2 req / 12 ev
+    expect(held.every((h) => h.ok)).toBe(true);
+    expect(refused.every((r) => !r.ok)).toBe(true);
+
+    // 4 arrivals carrying 42 emissions — regardless of what the bounds decided.
+    expect(gate.arrivals.requests).toBe(4);
+    expect(gate.arrivals.events).toBe(10 + 20 + 5 + 7);
+
+    held.forEach((h) => h.ok && h.release());
+  });
+
+  it("counts arrivals in SHADOW, where nothing is refused", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // THE CASE THAT MATTERS, because shadow is the mode the measurement runs in. Every
+    // caller is admitted here, so a counter that incremented on admission would produce a
+    // denominator that cannot disagree with the numerator — and a rate of exactly zero
+    // forever, which reads as good news.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 5 });
+    const results = await Promise.all([
+      gate.acquire("a", 3),
+      gate.acquire("b", 3),
+      gate.acquire("loud", 500),
+      gate.acquire("loud", 500),
+      gate.acquire("loud", 500),
+    ]);
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(results.every((r) => r.ok)).toBe(true); // shadow refuses nothing
+    expect(gate.arrivals.requests).toBe(5);
+    expect(gate.arrivals.events).toBe(3 + 3 + 500 + 500 + 500);
+
+    // And the simulation DID count would-be sheds against those arrivals, so a rate is
+    // now computable on each axis from one instrument.
+    expect(gate.wouldShed.requests).toBeGreaterThan(0);
+    expect(gate.wouldShed.requests).toBeLessThanOrEqual(gate.arrivals.requests);
+    expect(gate.wouldShed.events).toBeLessThanOrEqual(gate.arrivals.events);
+
+    results.forEach((r) => r.ok && r.release());
+  });
+
+  it("the two axes are not each other — which is why there are two", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // A single arrivals integer would have made the events-axis rate uncomputable. On the
+    // live window t-12 measured ~8.1 emissions per refused request (batches to 261), so
+    // the axes diverge by an order of magnitude in practice.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    await gate.acquire("a", 500);
+    expect(gate.arrivals.requests).toBe(1);
+    expect(gate.arrivals.events).toBe(500);
+    expect(gate.arrivals.events).not.toBe(gate.arrivals.requests);
+  });
+
+  it("a release does not decrement an arrival — it is a flow, not an occupancy", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // The distinction from `inFlight` / `inFlightEvents`, which DO go down. Arrivals are
+    // cumulative-forever per instance, because a rate divides a window's sheds by that
+    // window's arrivals; a counter that fell back would make the ratio unreadable.
+    const gate = new EmissionGate({ poolMax: 4, mode: "enforcing", waitMs: 0 });
+    const a = gate.tryAcquire("a", 9);
+    expect(gate.arrivals.requests).toBe(1);
+    if (a.ok) a.release();
+    expect(gate.arrivals.requests).toBe(1);
+    expect(gate.arrivals.events).toBe(9);
+    expect(gate.inFlight).toBe(0); // occupancy went back, arrivals did not
+  });
+
+  it("a rate is computable from one instrument, and it is bounded by construction", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // What ac-2 actually needs. Not asserted against a magic number — asserted as the
+    // PROPERTY that makes the number meaningful: the ratio exists, and it lies in [0, 1]
+    // on each axis, which is exactly what an absolute count could never promise.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 5 });
+    await Promise.all(
+      Array.from({ length: 12 }, (_, i) => gate.acquire(i % 3 === 0 ? "loud" : `k${i}`, 8)),
+    );
+    await new Promise((r) => setTimeout(r, 60));
+
+    for (const axis of ["requests", "events"] as const) {
+      const rate = gate.wouldShed[axis] / gate.arrivals[axis];
+      expect(Number.isFinite(rate)).toBe(true);
+      expect(rate).toBeGreaterThanOrEqual(0);
+      expect(rate).toBeLessThanOrEqual(1);
+    }
+    expect(gate.arrivals.requests).toBe(12);
+    expect(gate.arrivals.events).toBe(96);
+  });
+});
+
+describe("spec-525 ac-28: the denominator reaches the heartbeat, or t-10 cannot read it", () => {
+  afterEach(() => {
+    _resetEmissionGateHeartbeat();
+    vi.restoreAllMocks();
+  });
+
+  it("publishes both axes as a WINDOW DELTA and a cumulative total", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // The half that matters operationally. An in-process getter is invisible from outside:
+    // t-11 established that `EmissionGate.wouldShed` is exposed by no route and dies with
+    // the instance, which is why the shadow window "counted into a void". A denominator
+    // that only exists in memory repeats that exactly.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((l: unknown) => {
+      if (typeof l === "string" && l.includes(GATE_WINDOW_EVENT)) lines.push(l);
+    });
+
+    startEmissionGateHeartbeat({ gate: () => gate, intervalMs: 10 });
+    await new Promise((r) => setTimeout(r, 30)); // a first, quiet window
+
+    const held = await Promise.all([gate.acquire("a", 7), gate.acquire("b", 11)]);
+    await new Promise((r) => setTimeout(r, 40)); // a window WITH arrivals in it
+
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const last = JSON.parse(lines[lines.length - 1]);
+
+    // The four fields, mirroring the shed axes exactly.
+    for (const k of [
+      "arrivalEvents",
+      "arrivalRequests",
+      "arrivalEventsTotal",
+      "arrivalRequestsTotal",
+    ]) {
+      expect(last, `heartbeat must publish ${k}`).toHaveProperty(k);
+      expect(Number.isFinite(last[k])).toBe(true);
+    }
+
+    // Cumulative caught everything presented; the delta is bounded by it. Asserted as a
+    // relationship rather than an exact delta, because which 10 ms window a call lands in
+    // is a timing race and pinning it would make this flaky rather than strict.
+    expect(last.arrivalRequestsTotal).toBe(2);
+    expect(last.arrivalEventsTotal).toBe(18);
+    expect(last.arrivalRequests).toBeLessThanOrEqual(last.arrivalRequestsTotal);
+    expect(last.arrivalEvents).toBeLessThanOrEqual(last.arrivalEventsTotal);
+
+    // AND THE POINT OF ALL OF IT: a rate is now readable from one line of one instrument.
+    expect(last.wouldShedRequestsTotal / last.arrivalRequestsTotal).toBeLessThanOrEqual(1);
+
+    held.forEach((h) => h.ok && h.release());
+  });
+});

--- a/packages/server/src/services/admission/emission-gate.ts
+++ b/packages/server/src/services/admission/emission-gate.ts
@@ -151,6 +151,36 @@ export function resolveGateMode(env: Record<string, string | undefined> = proces
  * 500 shed single POSTs are identical on the event axis and completely different
  * situations. Neither axis can be inferred from the other; keep both.
  */
+/**
+ * TOTAL ARRIVALS — the denominator (spec-525 t-14, ac-28).
+ *
+ * t-13's window measured 35 547 would-be refused requests carrying 135 801 emissions and
+ * had NOTHING to divide them by. ac-2 asks for a rate, and what fraction of traffic those
+ * refusals represent decides whether enforcing is viable at all.
+ *
+ * **It is unrecoverable retroactively**, verified rather than assumed (dec-6): the gate held
+ * no total, the heartbeat published 16 fields and none was one, Cloud Run's `request_count`
+ * carries no URL-path label, request logs are sampled, and `test_events` is trimmed INSIDE
+ * the emission transaction — so a row count measures what survived, not what arrived, and
+ * the ingest route keeps no second trace ("test_event is NOT persisted to activity_log").
+ * It can only be counted going forward.
+ *
+ * **BOTH AXES, not the one integer t-14 asked for.** A rate needs its denominator on the
+ * SAME axis as its numerator, and {@link WouldShedCount} is already split for the reason
+ * t-12 paid to learn: neither axis can be inferred from the other (~8.1 emissions per
+ * refused request on the live window, batches to 261). A single integer would leave the
+ * EVENTS-axis rate uncomputable — and events is the axis ac-13 states the unit is.
+ *
+ * A FLOW, not an occupancy: unlike {@link EmissionGate.inFlight} these never decrease, so
+ * a window's sheds divide by that window's arrivals.
+ */
+export interface ArrivalCount {
+  /** EMISSIONS presented — the sum of every arriving batch's weight. */
+  readonly events: number;
+  /** REQUESTS presented — one per call, whatever it weighed. */
+  readonly requests: number;
+}
+
 export interface WouldShedCount {
   /** EMISSIONS that would have been lost — the batch's weight. ac-13's unit. */
   readonly events: number;
@@ -498,6 +528,18 @@ export class EmissionGate {
 
   readonly #onShed?: (weight: number, cause: ShedCause, waited: boolean) => void;
 
+  /**
+   * ONE place increments, called first by both entry points.
+   *
+   * Two call sites duplicating `+= 1` / `+= weight` is how the axes drift apart — which is
+   * exactly the defect t-12 found in the shed counters, where one axis was incremented by
+   * 1 under a comment promising the other.
+   */
+  #countArrival(weight: number): void {
+    this.#arrivalRequests += 1;
+    this.#arrivalEvents += weight;
+  }
+
   /** Report a shed without letting a caller's throw escape into the request path. */
   #reportShed(weight: number, cause: ShedCause, waited: boolean): void {
     if (!this.#onShed) return;
@@ -507,6 +549,21 @@ export class EmissionGate {
       // Telemetry must never break admission. A counter that throws would turn every
       // shed into a 500 — the load-protection mechanism becoming the outage.
     }
+  }
+
+  #arrivalEvents = 0;
+  #arrivalRequests = 0;
+
+  /**
+   * Everything that reached the gate — see {@link ArrivalCount}.
+   *
+   * Counted at ARRIVAL, before any bound is evaluated and independent of mode. That last
+   * part is load-bearing: in shadow every caller is admitted, so counting admissions would
+   * make the denominator the numerator's complement and yield a rate of zero forever,
+   * which reads as good news.
+   */
+  get arrivals(): ArrivalCount {
+    return { events: this.#arrivalEvents, requests: this.#arrivalRequests };
   }
 
   #wouldShedEvents = 0;
@@ -562,6 +619,7 @@ export class EmissionGate {
    * saturation would send someone to resize the wrong thing.
    */
   tryAcquire(presentedToken: string, weight = 1): Acquisition {
+    this.#countArrival(weight);
     const taken = this.#take(keyOf(presentedToken), weight);
     if (taken.ok) return { ok: true, release: taken.release, waited: false };
     this.#reportShed(weight, taken.cause, false);
@@ -583,6 +641,7 @@ export class EmissionGate {
    * outcome rather than a conservative version of "wait".
    */
   acquire(presentedToken: string, weight = 1): Promise<Acquisition> {
+    this.#countArrival(weight);
     const key = keyOf(presentedToken);
     return this.mode === "shadow"
       ? this.#admitAndSimulate(key, weight)


### PR DESCRIPTION
**t-14's first acceptance criterion**, and the thing **ac-2 cannot close without**.

📋 [spec-525](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-525) · AC: ac-28

## What was missing

t-13 measured **35 547 would-be refused requests carrying 135 801 emissions** over 7 days of prod. That is an absolute count with **nothing to divide it by**, and ac-2 asks for a **rate**.

What fraction of traffic those refusals represent decides whether enforcing is viable at all: **0.5 % and a ceiling of 3 may be fine; 30 % and no tuning in this Spec is close.**

## And it is unrecoverable retroactively

Each leg verified rather than assumed (dec-6, t-14):

- the gate held **no total counter**, and the heartbeat published 16 fields — none a total
- Cloud Run's `request_count` metric carries **no URL-path label**
- request logs are **sampled**
- `test_events` is trimmed **inside the emission transaction** to 10 rows per `(subject_ref, test_identifier)` pair, so a row count measures what **survived**, not what arrived
- and there is no second trace: the ingest route deliberately keeps test events out of `activity_log` — *"it's the firehose"*

**It can only be counted going forward.** That is this PR.

## Both axes, not the single integer t-14 asked for

`WouldShedCount` is already split events/requests for the reason **t-12 paid to learn**: neither axis can be inferred from the other — **~8.1 emissions per refused request** on the live window, batches to 261.

A rate needs its denominator on the **same axis** as its numerator. One arrivals integer would have left the **events-axis rate uncomputable** — and events is the axis ac-13 states the unit is.

```
wouldShedRequests / arrivalRequests     ← the request-axis rate
wouldShedEvents   / arrivalEvents       ← the events-axis rate
```

## Counted at arrival, and that is load-bearing

Before any bound is evaluated, independent of mode. **In shadow every caller is admitted**, so counting *admissions* would make the denominator the numerator's complement and yield a rate of **zero forever** — which reads as good news.

One private `#countArrival` is called first by both entry points, because two sites each doing `+= 1` / `+= weight` is precisely how the axes drifted apart in the defect t-12 fixed.

## And it reaches the heartbeat — the half that matters operationally

t-11 established that `EmissionGate.wouldShed` is exposed by **no route** and dies with the instance, which is why the shadow window *"counted into a void"*. A denominator living only in memory would repeat that exactly.

Published as a **window delta plus a cumulative total** on each axis, mirroring the shed axes: the delta because a rate divides a window's refusals by **that window's** arrivals; the cumulative because the counter is per-instance and dies on recycle — **32 distinct instances in 12 h of prod**.

```
arrivalEvents          arrivalRequests          ← this window
arrivalEventsTotal     arrivalRequestsTotal     ← cumulative, survives nothing else
```

## Test plan

- [x] **Red before the change** — all five assertions failed on `arrivals` being undefined
- [x] Six tagged tests: both axes counted admitted **and** refused; counted in **shadow** where nothing is refused; the axes proven not to be each other; a release does **not** decrement an arrival (a flow, not an occupancy); the rate bounded in [0,1] on each axis by construction; and the four fields **present in a real heartbeat line**
- [x] **Full server suite: 6598 passed / 0 failed**
- [x] `make check` and `make typecheck` clean — and `tsc` **earned its keep** on the widened `GateSnapshotSource`: the heartbeat test's fake gate went red immediately for the missing field, the kind of omission it *can* catch, unlike yesterday's `(undefined+1)` inside a template literal
- [ ] Post-deploy: `arrivalRequests` / `arrivalEvents` appear in `emission_gate_window` heartbeats on int

## What this does NOT do

**It does not close ac-2.** ac-2 wants the rate **read under enforcement**, and that is t-14's remaining sequence: let this accumulate, read the rate with t-10's values in force and the mode still `shadow`, then enable enforcement in a deliberately quiet window and record the real rate against the budget.

It also does not make the rate *good*. It makes it **knowable** — which is the difference between a criterion a reviewer can check and one nobody can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)