### PR TITLE
release: spec-525 — the denominator, the refusal's off-switch, and two CI guard-rails made proportionate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,7 +343,21 @@ jobs:
   # composite action) which speeds the already-sharded server + e2e tiers.
   ui:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20, not 10, and the asymmetry it corrects is the point: `server` runs across THREE
+    # shards at 15 minutes each, `e2e` across three — and `ui` is a SINGLE job running the
+    # whole UI suite plus the coverage gate, on the tightest budget in the file. It had the
+    # least parallelism and the smallest allowance.
+    #
+    # Measured 2026-09-04, same workflow, same runner image: 6m41s, 10m16s, 10m19s, and one
+    # more over 10 — four crossings in a day against a norm of ~5 minutes the day before,
+    # including 5m08s and 8m14s on the SAME commit. So the variance is the runner's, not the
+    # suite's, and a limit set at the observed maximum is a coin flip.
+    #
+    # Not one of those crossings caught a defect: the job was killed mid-run every time, and
+    # passed on rerun with no code change. What it did instead was turn `test` into
+    # `cancelled` with 12 of 13 jobs green, which fails the deploy gate closed — so a runner
+    # hiccup presented as a red DEPLOY, four times, inviting a search for a deployment bug.
+    timeout-minutes: 20
     env:
       # UI unit tests tag ACs too (std-35 Recipe A — "representative unit tests at
       # the track() sites"); emit them like the server / e2e / ac-emit jobs do.

--- a/packages/server/scripts/verify-scaling-budget.ts
+++ b/packages/server/scripts/verify-scaling-budget.ts
@@ -372,18 +372,34 @@ async function main(): Promise<void> {
   // A read failure is "nobody checked", which is the condition this guard exists to end.
   const failures = [...outcome.failures];
 
+  const warnings = [...outcome.warnings];
   // PHASE B — OFF BY DEFAULT, and that is not timidity. Every service is undeclared the day
   // this lands, so an on-by-default refusal would abort memex-api's own deploys: the guard
   // working exactly as designed and stopping all work. Turn it on when phase A's list above
   // is empty.
+  //
+  // TWO CONDITIONS on the refusal, both learned by asking what it would actually do:
+  //
+  // 1. `plan` MODE ONLY. This script runs twice — before the deploy (`plan`) and after the
+  //    cutover (`applied`). In `plan` a refusal PREVENTS the deploy. In `applied` traffic
+  //    has already moved, so it can only paint a successful deploy red after the fact, with
+  //    no rollback — and a red mark on a deploy that worked trains people to ignore red
+  //    marks. Post-cutover it is a warning, which is all it can honestly be.
+  //
+  // 2. FATAL ON PROD, WARNING ELSEWHERE — the posture spec-518 dec-5 already set for a blown
+  //    budget, followed here rather than diverged from in silence. The sequence still
+  //    protects prod: int warns first, and prod's refusal lands in `plan`, BEFORE any
+  //    revision is created. The cost is that a missing declaration is discovered at prod's
+  //    plan step rather than on int, and that is the trade dec-5 already made.
   if (budget) {
-    for (const refusal of undeclaredServices(budget, {
+    const refusals = undeclaredServices(budget, {
       requireDeclarations: process.env.REQUIRE_CONNECTION_DECLARATIONS === "1",
-    })) {
-      failures.push(refusal);
+    });
+    for (const refusal of refusals) {
+      if (mode === "plan" && isProd(ENV)) failures.push(refusal);
+      else warnings.push(`${refusal}\n      (non-fatal in mode=${mode} on ${ENV})`);
     }
   }
-  const warnings = [...outcome.warnings];
   for (const f of readFailures) {
     if (isProd(ENV)) failures.push(`guard could not verify: ${f}`);
     else warnings.push(`guard could not verify: ${f} — non-fatal on ${ENV}`);

--- a/packages/server/src/__regression__/deploy-gate.regression.test.ts
+++ b/packages/server/src/__regression__/deploy-gate.regression.test.ts
@@ -364,3 +364,74 @@ describe("spec-395 deploy gate — runGate end-to-end (fail-closed semantics, de
     expect(code).toBe(0);
   });
 });
+
+// ── The invariant nobody had written down (spec-395 dec-1, c-2) ───────────────
+//
+// dec-1 required "a bounded timeout that fails closed". `pollTimeoutS: 900` met that TO
+// THE LETTER and was never large enough, because the requirement never put the bound in a
+// relationship with the thing it bounds. The gate waits on `test.yml`'s conclusion, and
+// `test.yml`'s own `server` shards are each allowed `timeout-minutes: 15` — exactly 900s.
+// The gate's entire patience equalled ONE job's allowance, before queueing and before the
+// twelve other jobs.
+//
+// Observed 2026-09-04 on develop@4c11e88d: the gate abandoned at 15m11s with
+// `verdict is 'pending'`, and `test` concluded SUCCESS 84 seconds later. The deploy was
+// skipped for a run that passed.
+//
+// A COMMENT IS NOT A GUARD-RAIL, which is why this exists: nothing otherwise stops someone
+// raising a `server` shard to `timeout-minutes: 30` without touching the gate, and
+// recreating this exactly — where it would again arrive as a red DEPLOY on a SHA that
+// looks unverified.
+//
+// Deliberately UNTAGGED. This is a repository invariant, not a Spec's acceptance
+// criterion: spec-395 is `done` with all six of its ACs verified, and minting one there —
+// or hanging it off a Spec that does not own the gate — would misfile it. It still gates
+// every PR, because it runs in the `server` shards like every other regression test.
+
+describe("deploy gate — its patience must exceed the test workflow's worst-case budget", () => {
+  const testYml = readFileSync(resolve(repoRoot, ".github/workflows/test.yml"), "utf8");
+  const gateSrc = readFileSync(resolve(repoRoot, "scripts/ci/deploy-gate.mjs"), "utf8");
+
+  const budgetsMin = [...testYml.matchAll(/^\s*timeout-minutes:\s*(\d+)\s*$/gm)].map((m) =>
+    Number(m[1]),
+  );
+  const pollTimeoutS = Number(/pollTimeoutS:\s*(\d+)/.exec(gateSrc)?.[1]);
+
+  it("parsed both sides — a pattern that silently matches nothing reports success", () => {
+    // THE GUARD ON THE GUARD, and it is today's other lesson: a count can be
+    // syntactically right and semantically empty. Twice on 2026-09-04 a grep of mine
+    // returned 0 on a tree that had dozens of hits, and both times the only thing that
+    // caught it was printing the detail beside the count. A regex that stops matching
+    // here would make this whole invariant pass vacuously, forever.
+    expect(budgetsMin.length).toBeGreaterThanOrEqual(8); // test.yml has ~12 timeout-minutes
+    expect(Math.max(...budgetsMin)).toBeGreaterThanOrEqual(10);
+    expect(Number.isFinite(pollTimeoutS)).toBe(true);
+    expect(pollTimeoutS).toBeGreaterThan(0);
+  });
+
+  it("the gate outlasts the slowest job test.yml is allowed to run", () => {
+    const worstCaseS = Math.max(...budgetsMin) * 60;
+
+    // Strictly greater, not >=: at equality the gate can abandon the very run it is
+    // waiting for, which is precisely what happened. The message names both numbers
+    // because the fix depends on WHICH side moved — a job's allowance was raised, or the
+    // gate's patience was lowered.
+    expect(
+      pollTimeoutS,
+      `deploy-gate pollTimeoutS=${pollTimeoutS}s must exceed test.yml's worst-case job ` +
+        `budget of ${worstCaseS}s (max timeout-minutes = ${Math.max(...budgetsMin)}). ` +
+        `The gate waits on that workflow's CONCLUSION, so a patience at or below a single ` +
+        `job's allowance can abandon a run that was going to pass — it did, on ` +
+        `develop@4c11e88d, 84 seconds early. Raise pollTimeoutS in scripts/ci/deploy-gate.mjs, ` +
+        `or lower the job budget in .github/workflows/test.yml.`,
+    ).toBeGreaterThan(worstCaseS);
+  });
+
+  it("leaves real headroom, not a single second of it", () => {
+    // The whole workflow is a GRAPH, not one job: queueing, checkout, install and the
+    // other twelve jobs all sit between the push and the conclusion this gate reads. A
+    // bound that merely clears the slowest single job still has no room for the rest.
+    const worstCaseS = Math.max(...budgetsMin) * 60;
+    expect(pollTimeoutS).toBeGreaterThanOrEqual(worstCaseS * 1.5);
+  });
+});

--- a/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
+++ b/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
@@ -42,6 +42,7 @@ import {
   declarationWarnings,
   undeclaredServices,
   DECLARATION_VAR,
+  UNBLOCK_HINT,
   RELAY_LISTEN_PER_INSTANCE,
   CUTOVER_REVISION_FACTOR,
   FOREIGN_SERVICE_DEFAULT_POOL,
@@ -224,6 +225,15 @@ describe("spec-525 t-15 phase B: refusing the undeclared, behind a switch", () =
     // The names actually FOUND, so a near-miss is diagnosable from the failure alone rather
     // than by going and reading the revision.
     expect(message).toContain("foreign-default");
+
+    // AND ITS OWN OFF-SWITCH, in the message rather than in a standard someone has to find.
+    // This refusal can be triggered by a change nobody here made — the guard enumerates
+    // every service attached to the same Cloud SQL instance, so another team renaming their
+    // variable stops OUR deploys, including a hotfix. The remedy is one variable; a remedy
+    // that takes one word and is known to nobody costs hours at 3am.
+    expect(message).toContain(UNBLOCK_HINT);
+    expect(message).toContain("REQUIRE_CONNECTION_DECLARATIONS");
+    expect(UNBLOCK_HINT).toMatch(/unset|TO UNBLOCK/i);
   });
 
   it("closes the two-pools-one-variable under-count at ANY maxScale", () => {

--- a/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
+++ b/packages/server/src/__regression__/spec-525-t15-declared-footprint.regression.test.ts
@@ -39,6 +39,7 @@ import {
   computeBudget,
   formatBudgetReport,
   parseRevisionScaling,
+  decideOutcome,
   declarationWarnings,
   undeclaredServices,
   DECLARATION_VAR,
@@ -266,5 +267,46 @@ describe("spec-525 t-15 phase B: refusing the undeclared, behind a switch", () =
       expect(refused.length).toBe(1);
       expect(refused[0]).toContain(DECLARATION_VAR);
     }
+  });
+});
+
+describe("spec-525 t-15: no message ever prints `undefined` for a declared service", () => {
+  it("survives an over-budget report where every term is declared", () => {
+    tagAc(AC_DECLARED);
+
+    // THE DEFECT THIS PINS, found in a live int deploy log rather than in review:
+    //
+    //   ⚠ connection budget exceeded: peak 41 > 22 usable
+    //     (memex-api 2×3×(undefined+1)=36 + admin 5)
+    //
+    // `decideOutcome`'s detail string read `t.poolMax` and hardcoded `+1` for EVERY term.
+    // Making `poolMax` optional (a declared service has no per-pool figure) fixed
+    // `formatBudgetReport`, which branches on `relayCounted` — and missed this second
+    // formatter, which does not. `tsc` cannot help: interpolating `number | undefined`
+    // into a template literal is perfectly legal.
+    //
+    // Asserted as a PROPERTY over every message this module produces, not at the one site.
+    // Naming the site would pin the bug I already know about; the property catches the next
+    // reader of an optional field — which is how this one got in.
+    const usable = 22; // int's db-f1-micro default (25) minus superuser_reserved (3)
+    const services = [
+      { service: "memex-api", revision: "rev-1", maxInstances: 3, declaredPerInstance: 6, ownCode: true },
+      { service: "other", revision: "rev-2", maxInstances: 2, declaredPerInstance: 10 },
+    ];
+    const budget = computeBudget({ services, usable });
+    expect(budget.withinBudget).toBe(false); // the fixture must actually blow the budget
+
+    const outcome = decideOutcome({ env: "int", budget, comparison: undefined, revision: undefined });
+    const everything = [
+      ...formatBudgetReport(budget),
+      ...declarationWarnings(budget),
+      ...undeclaredServices(budget, { requireDeclarations: true }),
+      ...outcome.failures,
+      ...outcome.warnings,
+    ].join("\n");
+
+    expect(everything.length).toBeGreaterThan(0);
+    expect(everything).not.toContain("undefined");
+    expect(everything).not.toContain("NaN");
   });
 });

--- a/packages/server/src/deploy/scaling-budget.ts
+++ b/packages/server/src/deploy/scaling-budget.ts
@@ -100,6 +100,22 @@ export const ADMIN_SESSION_RESERVE = 5;
  * prints the line it printed before declarations existed. Not a silent failure — a SUCCESS
  * SIGNAL, on the one string that IS the contract (spec-525 t-15).
  */
+/**
+ * How to UNBLOCK a deploy this guard refused — carried in the refusal message itself.
+ *
+ * Not documentation-adjacent politeness. This refusal can be triggered by a change nobody
+ * on this repo made: the guard enumerates every Cloud Run service attached to the same
+ * Cloud SQL instance (from `gcloud`, deliberately not from a list here), so a NEW service
+ * someone else deploys, or another team renaming their own variable, stops OUR deploys —
+ * including a hotfix. The remedy is one variable, and a remedy that takes one word but is
+ * known to nobody costs hours at 3am. So the message states it rather than pointing at a
+ * standard somebody has to go and find.
+ */
+export const UNBLOCK_HINT =
+  "TO UNBLOCK NOW: unset REQUIRE_CONNECTION_DECLARATIONS in the deploy workflow's " +
+  "environment and re-run. That returns the guard to over-counting undeclared services, " +
+  "which is the safe direction — then fix the declaration without a deploy blocked on it.";
+
 export const DECLARATION_VAR = "DB_CONNECTIONS_PER_INSTANCE";
 
 /**
@@ -218,9 +234,10 @@ export function serviceTerm(obs: ServiceObservation): ServiceTerm {
   // coherent relation differs per service — memex-api's total is pool + relay (5 = 4+1),
   // backstage's is 2 x pool — and the guard cannot know which form applies. A check would
   // be the guessing this removes, wearing an equals sign.
-  const perInstance = hasDeclaration
-    ? Math.floor(declared)
-    : resolvePool(obs).poolMax + RELAY_LISTEN_PER_INSTANCE;
+  const inferred = hasDeclaration ? undefined : resolvePool(obs);
+  const perInstance = inferred
+    ? inferred.poolMax + RELAY_LISTEN_PER_INSTANCE
+    : Math.floor(declared as number);
   const steady = obs.maxInstances * perInstance;
 
   const base = {
@@ -232,9 +249,9 @@ export function serviceTerm(obs: ServiceObservation): ServiceTerm {
     peak: steady * CUTOVER_REVISION_FACTOR,
   };
 
-  return hasDeclaration
-    ? { ...base, poolSource: "declared" as const, relayCounted: false }
-    : { ...base, ...resolvePool(obs), relayCounted: true };
+  return inferred
+    ? { ...base, ...inferred, relayCounted: true }
+    : { ...base, poolSource: "declared" as const, relayCounted: false };
 }
 
 /**
@@ -275,7 +292,8 @@ export function undeclaredServices(
         `${t.service} declares no ${DECLARATION_VAR} — refusing rather than inferring. ` +
         `Used ${t.poolSource} (${t.poolMax} per pool) because that is all the revision ` +
         `published. Set ${DECLARATION_VAR} to the COMPLETE per-instance total: every pool ` +
-        `the instance opens, plus any long-lived connection outside one.`,
+        `the instance opens, plus any long-lived connection outside one.` +
+        `\n      ${UNBLOCK_HINT}`,
     );
 }
 

--- a/packages/server/src/deploy/scaling-budget.ts
+++ b/packages/server/src/deploy/scaling-budget.ts
@@ -477,7 +477,15 @@ export function decideOutcome({
     const detail =
       `connection budget exceeded: peak ${budget.peakTotal} > ${budget.usable} usable ` +
       `(${budget.terms
-        .map((t) => `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×(${t.poolMax}+1)=${t.peak}`)
+        // Branches on `relayCounted` for the same reason `formatBudgetReport` does: a
+        // declared service has no per-pool figure and no relay added, so `(poolMax+1)`
+        // would print `(undefined+1)` — which it did, in a live int deploy log, until this
+        // was the second reader of an optional field to be fixed rather than the first.
+        .map((t) =>
+          t.relayCounted
+            ? `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×(${t.poolMax}+1)=${t.peak}`
+            : `${t.service} ${CUTOVER_REVISION_FACTOR}×${t.maxInstances}×${t.perInstance}=${t.peak}`,
+        )
         .join(" + ")} + admin ${budget.adminReserve})`;
     if (isProd(env)) failures.push(detail);
     else warnings.push(`${detail} — non-fatal on ${env} per spec-518 dec-5`);

--- a/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
+++ b/packages/server/src/observability/emission-gate-heartbeat.spec-525.test.ts
@@ -65,6 +65,9 @@ function fakeGate(over: Partial<GateSnapshotSource> = {}): GateSnapshotSource {
     // from a guess (ac-22).
     inFlightEvents: 0,
     eventBudget: DEFAULT_EVENT_BUDGET,
+    // The denominator (ac-28). A shed COUNT without it is what left t-13's window
+    // unusable for ac-2, so the heartbeat carries both axes.
+    arrivals: { events: 0, requests: 0 },
     trackedKeys: 0,
     wouldShed: {
       events: 0,

--- a/packages/server/src/observability/emission-shed-log.ts
+++ b/packages/server/src/observability/emission-shed-log.ts
@@ -32,6 +32,7 @@
 // Re-judge if the window is extended or if enforcing mode runs indefinitely.
 
 import type {
+  ArrivalCount,
   GateMode,
   ShedCause,
   WouldShedCount,
@@ -115,6 +116,12 @@ export interface GateSnapshotSource {
   readonly eventBudget: number;
   readonly trackedKeys: number;
   readonly wouldShed: WouldShedCount;
+  /**
+   * TOTAL ARRIVALS — the denominator t-13's window did not have (spec-525 t-14, ac-28).
+   * Published on BOTH axes because a rate needs its denominator on the same axis as its
+   * numerator, and `wouldShed` is already split for that reason.
+   */
+  readonly arrivals: ArrivalCount;
 }
 
 export const GATE_WINDOW_EVENT = "emission_gate_window";
@@ -159,7 +166,13 @@ export function startEmissionGateHeartbeat(opts: {
   type DeltaState = Pick<
     WouldShedCount,
     "events" | "requests" | "eventsByCause" | "requestsByCause"
-  >;
+  > & {
+    // Arrivals are delta'd with the sheds, never reported only as a cumulative: a RATE
+    // divides a window's refusals by THAT window's arrivals. Two cumulative totals from
+    // different instances, or across a recycle, do not divide (spec-525 t-14, ac-28).
+    arrivalEvents: number;
+    arrivalRequests: number;
+  };
   let previous: DeltaState | null = null;
 
   heartbeat = setInterval(() => {
@@ -172,12 +185,16 @@ export function startEmissionGateHeartbeat(opts: {
           requests: 0,
           eventsByCause: zeroByCause(),
           requestsByCause: zeroByCause(),
+          arrivalEvents: 0,
+          arrivalRequests: 0,
         };
       previous = {
         events: now.events,
         requests: now.requests,
         eventsByCause: { ...now.eventsByCause },
         requestsByCause: { ...now.requestsByCause },
+        arrivalEvents: g.arrivals.events,
+        arrivalRequests: g.arrivals.requests,
       };
 
       console.log(
@@ -211,6 +228,16 @@ export function startEmissionGateHeartbeat(opts: {
           wouldShedRequestsByCause: deltaByCause(now.requestsByCause, before.requestsByCause),
           wouldShedEventsTotal: now.events,
           wouldShedRequestsTotal: now.requests,
+          // THE DENOMINATOR (spec-525 t-14, ac-28). t-13's window had 35 547 refused
+          // requests carrying 135 801 emissions and nothing to divide them by, and the
+          // quantity is unrecoverable retroactively — so it is counted going forward.
+          // Per-window deltas so `wouldShedRequests / arrivalRequests` is a rate within
+          // ONE window, plus cumulative totals because the counter is per-instance and
+          // dies on recycle (32 distinct instances in 12 h of prod).
+          arrivalEvents: g.arrivals.events - before.arrivalEvents,
+          arrivalRequests: g.arrivals.requests - before.arrivalRequests,
+          arrivalEventsTotal: g.arrivals.events,
+          arrivalRequestsTotal: g.arrivals.requests,
           // t-13 — the ceiling-alone counterfactual, an UPPER BOUND (see WouldShedCount).
           // Cumulative rather than a delta: this one is read once, at dec-6, not tracked
           // window by window, and a running total is what a single query wants.

--- a/packages/server/src/services/admission/emission-arrivals.spec-525.test.ts
+++ b/packages/server/src/services/admission/emission-arrivals.spec-525.test.ts
@@ -1,0 +1,197 @@
+// spec-525 t-14 / ac-28 — the DENOMINATOR. Total arrivals, on both axes.
+//
+// WHY THIS EXISTS. t-13's shadow window measured 35 547 would-be refused requests carrying
+// 135 801 emissions over 7 days. That is an absolute count with NOTHING to divide it by,
+// and ac-2 asks for a RATE. What fraction of traffic that represents decides whether
+// enforcing is viable at all: 0.5% and a ceiling of 3 may be fine; 30% and no tuning here
+// is close.
+//
+// AND IT IS UNRECOVERABLE RETROACTIVELY, verified rather than assumed (dec-6, t-14):
+//   - the gate held no total counter, and the heartbeat published 16 fields, none a total
+//   - Cloud Run's `request_count` metric carries no URL-path label
+//   - request logs are sampled
+//   - `test_events` is trimmed INSIDE the emission transaction to 10 rows per
+//     (subject_ref, test_identifier) pair, so a row count measures what SURVIVED, not what
+//     arrived — and the ingest route states there is no second trace: "test_event is NOT
+//     persisted to activity_log (it's the firehose)"
+//
+// So it can only be counted going forward, which is what this is.
+//
+// BOTH AXES, not the single integer t-14 asked for. The shed counters are already split
+// events/requests because neither can be inferred from the other — t-12 measured ~8.1
+// emissions per refused request, batches to 261 — and a rate needs its denominator on the
+// SAME axis as its numerator. One arrivals integer would leave the EVENTS-axis rate
+// uncomputable, and that is the axis ac-13 states the counter's unit is.
+//
+// COUNTED AT ARRIVAL, before any bound is evaluated and regardless of mode. In shadow every
+// caller is admitted, so counting admissions would make the denominator the numerator's
+// complement and the rate meaningless.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { EmissionGate } from "./emission-gate.js";
+import {
+  startEmissionGateHeartbeat,
+  _resetEmissionGateHeartbeat,
+  GATE_WINDOW_EVENT,
+} from "../../observability/emission-shed-log.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-525/acs";
+const AC_ARRIVALS = `${SPEC}/ac-28`;
+
+describe("spec-525 ac-28: total arrivals, on both axes", () => {
+  it("counts every arrival on both axes, admitted or refused", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // poolMax 4 -> ceiling 2, per-key allowance 1. Enforcing, so some of these really are
+    // refused — which is the point: an arrival is an arrival either way.
+    const gate = new EmissionGate({ poolMax: 4, mode: "enforcing", waitMs: 0 });
+    expect(gate.arrivals.requests).toBe(0);
+    expect(gate.arrivals.events).toBe(0);
+
+    const held = [gate.tryAcquire("a", 10), gate.tryAcquire("b", 20)]; // admitted: 2 req / 30 ev
+    const refused = [gate.tryAcquire("c", 5), gate.tryAcquire("d", 7)]; // refused:  2 req / 12 ev
+    expect(held.every((h) => h.ok)).toBe(true);
+    expect(refused.every((r) => !r.ok)).toBe(true);
+
+    // 4 arrivals carrying 42 emissions — regardless of what the bounds decided.
+    expect(gate.arrivals.requests).toBe(4);
+    expect(gate.arrivals.events).toBe(10 + 20 + 5 + 7);
+
+    held.forEach((h) => h.ok && h.release());
+  });
+
+  it("counts arrivals in SHADOW, where nothing is refused", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // THE CASE THAT MATTERS, because shadow is the mode the measurement runs in. Every
+    // caller is admitted here, so a counter that incremented on admission would produce a
+    // denominator that cannot disagree with the numerator — and a rate of exactly zero
+    // forever, which reads as good news.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 5 });
+    const results = await Promise.all([
+      gate.acquire("a", 3),
+      gate.acquire("b", 3),
+      gate.acquire("loud", 500),
+      gate.acquire("loud", 500),
+      gate.acquire("loud", 500),
+    ]);
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(results.every((r) => r.ok)).toBe(true); // shadow refuses nothing
+    expect(gate.arrivals.requests).toBe(5);
+    expect(gate.arrivals.events).toBe(3 + 3 + 500 + 500 + 500);
+
+    // And the simulation DID count would-be sheds against those arrivals, so a rate is
+    // now computable on each axis from one instrument.
+    expect(gate.wouldShed.requests).toBeGreaterThan(0);
+    expect(gate.wouldShed.requests).toBeLessThanOrEqual(gate.arrivals.requests);
+    expect(gate.wouldShed.events).toBeLessThanOrEqual(gate.arrivals.events);
+
+    results.forEach((r) => r.ok && r.release());
+  });
+
+  it("the two axes are not each other — which is why there are two", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // A single arrivals integer would have made the events-axis rate uncomputable. On the
+    // live window t-12 measured ~8.1 emissions per refused request (batches to 261), so
+    // the axes diverge by an order of magnitude in practice.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    await gate.acquire("a", 500);
+    expect(gate.arrivals.requests).toBe(1);
+    expect(gate.arrivals.events).toBe(500);
+    expect(gate.arrivals.events).not.toBe(gate.arrivals.requests);
+  });
+
+  it("a release does not decrement an arrival — it is a flow, not an occupancy", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // The distinction from `inFlight` / `inFlightEvents`, which DO go down. Arrivals are
+    // cumulative-forever per instance, because a rate divides a window's sheds by that
+    // window's arrivals; a counter that fell back would make the ratio unreadable.
+    const gate = new EmissionGate({ poolMax: 4, mode: "enforcing", waitMs: 0 });
+    const a = gate.tryAcquire("a", 9);
+    expect(gate.arrivals.requests).toBe(1);
+    if (a.ok) a.release();
+    expect(gate.arrivals.requests).toBe(1);
+    expect(gate.arrivals.events).toBe(9);
+    expect(gate.inFlight).toBe(0); // occupancy went back, arrivals did not
+  });
+
+  it("a rate is computable from one instrument, and it is bounded by construction", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // What ac-2 actually needs. Not asserted against a magic number — asserted as the
+    // PROPERTY that makes the number meaningful: the ratio exists, and it lies in [0, 1]
+    // on each axis, which is exactly what an absolute count could never promise.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 5 });
+    await Promise.all(
+      Array.from({ length: 12 }, (_, i) => gate.acquire(i % 3 === 0 ? "loud" : `k${i}`, 8)),
+    );
+    await new Promise((r) => setTimeout(r, 60));
+
+    for (const axis of ["requests", "events"] as const) {
+      const rate = gate.wouldShed[axis] / gate.arrivals[axis];
+      expect(Number.isFinite(rate)).toBe(true);
+      expect(rate).toBeGreaterThanOrEqual(0);
+      expect(rate).toBeLessThanOrEqual(1);
+    }
+    expect(gate.arrivals.requests).toBe(12);
+    expect(gate.arrivals.events).toBe(96);
+  });
+});
+
+describe("spec-525 ac-28: the denominator reaches the heartbeat, or t-10 cannot read it", () => {
+  afterEach(() => {
+    _resetEmissionGateHeartbeat();
+    vi.restoreAllMocks();
+  });
+
+  it("publishes both axes as a WINDOW DELTA and a cumulative total", async () => {
+    tagAc(AC_ARRIVALS);
+
+    // The half that matters operationally. An in-process getter is invisible from outside:
+    // t-11 established that `EmissionGate.wouldShed` is exposed by no route and dies with
+    // the instance, which is why the shadow window "counted into a void". A denominator
+    // that only exists in memory repeats that exactly.
+    const gate = new EmissionGate({ poolMax: 4, mode: "shadow", waitMs: 0 });
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((l: unknown) => {
+      if (typeof l === "string" && l.includes(GATE_WINDOW_EVENT)) lines.push(l);
+    });
+
+    startEmissionGateHeartbeat({ gate: () => gate, intervalMs: 10 });
+    await new Promise((r) => setTimeout(r, 30)); // a first, quiet window
+
+    const held = await Promise.all([gate.acquire("a", 7), gate.acquire("b", 11)]);
+    await new Promise((r) => setTimeout(r, 40)); // a window WITH arrivals in it
+
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const last = JSON.parse(lines[lines.length - 1]);
+
+    // The four fields, mirroring the shed axes exactly.
+    for (const k of [
+      "arrivalEvents",
+      "arrivalRequests",
+      "arrivalEventsTotal",
+      "arrivalRequestsTotal",
+    ]) {
+      expect(last, `heartbeat must publish ${k}`).toHaveProperty(k);
+      expect(Number.isFinite(last[k])).toBe(true);
+    }
+
+    // Cumulative caught everything presented; the delta is bounded by it. Asserted as a
+    // relationship rather than an exact delta, because which 10 ms window a call lands in
+    // is a timing race and pinning it would make this flaky rather than strict.
+    expect(last.arrivalRequestsTotal).toBe(2);
+    expect(last.arrivalEventsTotal).toBe(18);
+    expect(last.arrivalRequests).toBeLessThanOrEqual(last.arrivalRequestsTotal);
+    expect(last.arrivalEvents).toBeLessThanOrEqual(last.arrivalEventsTotal);
+
+    // AND THE POINT OF ALL OF IT: a rate is now readable from one line of one instrument.
+    expect(last.wouldShedRequestsTotal / last.arrivalRequestsTotal).toBeLessThanOrEqual(1);
+
+    held.forEach((h) => h.ok && h.release());
+  });
+});

--- a/packages/server/src/services/admission/emission-gate.ts
+++ b/packages/server/src/services/admission/emission-gate.ts
@@ -151,6 +151,36 @@ export function resolveGateMode(env: Record<string, string | undefined> = proces
  * 500 shed single POSTs are identical on the event axis and completely different
  * situations. Neither axis can be inferred from the other; keep both.
  */
+/**
+ * TOTAL ARRIVALS — the denominator (spec-525 t-14, ac-28).
+ *
+ * t-13's window measured 35 547 would-be refused requests carrying 135 801 emissions and
+ * had NOTHING to divide them by. ac-2 asks for a rate, and what fraction of traffic those
+ * refusals represent decides whether enforcing is viable at all.
+ *
+ * **It is unrecoverable retroactively**, verified rather than assumed (dec-6): the gate held
+ * no total, the heartbeat published 16 fields and none was one, Cloud Run's `request_count`
+ * carries no URL-path label, request logs are sampled, and `test_events` is trimmed INSIDE
+ * the emission transaction — so a row count measures what survived, not what arrived, and
+ * the ingest route keeps no second trace ("test_event is NOT persisted to activity_log").
+ * It can only be counted going forward.
+ *
+ * **BOTH AXES, not the one integer t-14 asked for.** A rate needs its denominator on the
+ * SAME axis as its numerator, and {@link WouldShedCount} is already split for the reason
+ * t-12 paid to learn: neither axis can be inferred from the other (~8.1 emissions per
+ * refused request on the live window, batches to 261). A single integer would leave the
+ * EVENTS-axis rate uncomputable — and events is the axis ac-13 states the unit is.
+ *
+ * A FLOW, not an occupancy: unlike {@link EmissionGate.inFlight} these never decrease, so
+ * a window's sheds divide by that window's arrivals.
+ */
+export interface ArrivalCount {
+  /** EMISSIONS presented — the sum of every arriving batch's weight. */
+  readonly events: number;
+  /** REQUESTS presented — one per call, whatever it weighed. */
+  readonly requests: number;
+}
+
 export interface WouldShedCount {
   /** EMISSIONS that would have been lost — the batch's weight. ac-13's unit. */
   readonly events: number;
@@ -498,6 +528,18 @@ export class EmissionGate {
 
   readonly #onShed?: (weight: number, cause: ShedCause, waited: boolean) => void;
 
+  /**
+   * ONE place increments, called first by both entry points.
+   *
+   * Two call sites duplicating `+= 1` / `+= weight` is how the axes drift apart — which is
+   * exactly the defect t-12 found in the shed counters, where one axis was incremented by
+   * 1 under a comment promising the other.
+   */
+  #countArrival(weight: number): void {
+    this.#arrivalRequests += 1;
+    this.#arrivalEvents += weight;
+  }
+
   /** Report a shed without letting a caller's throw escape into the request path. */
   #reportShed(weight: number, cause: ShedCause, waited: boolean): void {
     if (!this.#onShed) return;
@@ -507,6 +549,21 @@ export class EmissionGate {
       // Telemetry must never break admission. A counter that throws would turn every
       // shed into a 500 — the load-protection mechanism becoming the outage.
     }
+  }
+
+  #arrivalEvents = 0;
+  #arrivalRequests = 0;
+
+  /**
+   * Everything that reached the gate — see {@link ArrivalCount}.
+   *
+   * Counted at ARRIVAL, before any bound is evaluated and independent of mode. That last
+   * part is load-bearing: in shadow every caller is admitted, so counting admissions would
+   * make the denominator the numerator's complement and yield a rate of zero forever,
+   * which reads as good news.
+   */
+  get arrivals(): ArrivalCount {
+    return { events: this.#arrivalEvents, requests: this.#arrivalRequests };
   }
 
   #wouldShedEvents = 0;
@@ -562,6 +619,7 @@ export class EmissionGate {
    * saturation would send someone to resize the wrong thing.
    */
   tryAcquire(presentedToken: string, weight = 1): Acquisition {
+    this.#countArrival(weight);
     const taken = this.#take(keyOf(presentedToken), weight);
     if (taken.ok) return { ok: true, release: taken.release, waited: false };
     this.#reportShed(weight, taken.cause, false);
@@ -583,6 +641,7 @@ export class EmissionGate {
    * outcome rather than a conservative version of "wait".
    */
   acquire(presentedToken: string, weight = 1): Promise<Acquisition> {
+    this.#countArrival(weight);
     const key = keyOf(presentedToken);
     return this.mode === "shadow"
       ? this.#admitAndSimulate(key, weight)

--- a/scripts/ci/deploy-gate.mjs
+++ b/scripts/ci/deploy-gate.mjs
@@ -54,12 +54,29 @@ import { appendFileSync } from "node:fs";
 const DEFAULTS = {
   testWorkflowFile: "test.yml",
   deployWorkflowFile: "deploy.yml",
-  pollTimeoutS: 900,
+  // THE INVARIANT NOBODY HAD WRITTEN DOWN: this gate's patience must EXCEED the test
+  // workflow's own worst-case budget, because it waits on that workflow's conclusion.
+  //
+  // At 900s it did not, and never had. `test.yml`'s `server` shards are allowed
+  // `timeout-minutes: 15` — 900s — each. So the gate's entire patience equalled ONE job's
+  // allowance, before queueing and before the twelve other jobs. A `server` shard
+  // legitimately taking 14 minutes has always been able to blow this, independently of how
+  // fast the runners happen to be.
+  //
+  // Today's slowness only revealed it: on develop@4c11e88d the gate abandoned at 15m11s
+  // and the test workflow concluded SUCCESS 84 seconds later. The deploy was skipped for a
+  // run that passed.
+  //
+  // 2400s (40 min) is chosen against the budget rather than against an observation: the
+  // longest single job allowance is 15 min, and this leaves room for queueing plus the rest
+  // of the graph. Raising it costs wall-clock on a genuinely stuck run and nothing else —
+  // the gate still fails CLOSED at the end, so a hung test suite never becomes a deploy.
+  pollTimeoutS: 2400,
   pollIntervalS: 15,
   intSmokeEnforce: "warn",
 };
 
-// ── Pure helpers (unit-tested by scripts/ci/deploy-gate.test.mjs) ──────────────
+// ── Pure helpers (unit-tested by packages/server/src/__regression__/deploy-gate.regression.test.ts) ──
 
 /**
  * Classify a list of workflow runs for a SHA into a gate verdict.


### PR DESCRIPTION
**Promotion `develop` → `main`.** Five commits, none of which changes what a user can see.

⚠️ **Merge as a MERGE COMMIT, not a squash** [per std-21 cl-50]. The content invariant is `git log develop..main --no-merges` being empty; a squash would create a commit on `main` that is not in `develop` and break it. GitHub's PR surface cannot fast-forward, which is why releases land as merge commits here.

## What it carries

| commit | what | effect in prod |
|---|---|---|
| `c7993c39` **#683** | total-arrivals counter (t-14, ac-28) | **starts collecting the denominator** |
| `292b5580` #682 | the deploy gate's patience, as a check | CI only |
| `a6b20f0f` #681 | `ui` timeout 10→20, `pollTimeoutS` 900→2400 | CI only |
| `e46f61d3` #680 | the `(undefined+1)` in the budget warning | a readable log line |
| `4c11e88d` #679 | phase B's refusal: off-switch in the message, `plan` mode only, dec-5's posture | inert (switch is OFF) |

**No migration. No route. No UI. No client-contract change** — `201` still means persisted. The emission gate stays in `shadow`, so it refuses nothing.

## ⭐ Why this is time-sensitive rather than housekeeping

**#683's counter only counts forward.** Verified rather than assumed (dec-6, t-14): `test_events` is trimmed inside the emission transaction so a row count measures what *survived*; Cloud Run's `request_count` carries no URL-path label; request logs are sampled; and test events are deliberately kept out of `activity_log`.

So **every day it is not in prod is a day of denominator not collected** — and t-14's whole remaining sequence waits on it accumulating. t-13's window measured 35 547 would-be refusals with nothing to divide them by; ac-2 asks for a rate. This starts the clock on the only measurement that can close it.

## Blast radius

**A prod deploy is a revision cutover, which is the 2026-08-11 failure mode** — so pick a quiet window, not a CI peak (t-10 and t-14 both say so).

The context has changed since August, and the numbers are read rather than recalled: the connection budget now sits at **125 of 197 with 72 spare** (memex-api declares 5 × 8 instances doubled = 80, backstage declares 10 × 2 doubled = 40, admin 5), against a `max_connections` raised from 50 to 200 on 2026-08-12. Recomputed with the guard's own functions against the live serving revisions.

## Verification

Every commit was merged on green CI, and the two that touch runtime behaviour were verified on int after deploy:

- **#679/#680** — int deploy green; the budget line now reads `(memex-api 2×3×6=36 + admin 5)` where it read `(undefined+1)`, confirmed in the deploy log that had revealed the bug
- **#681/#682** — the first `develop` deploy since they landed went green **with no manual rerun**, after three that each needed two
- **#683** — full server suite 6598 passed / 0 failed; 23 CI checks green
- Guard report on int: `6 per instance [declared]` and `✓ every service declares DB_CONNECTIONS_PER_INSTANCE`

## Post-deploy checks

- [ ] Prod serving revision still reports `MEMEX_EMISSION_GATE_MODE=shadow` (std-17 smoke)
- [ ] `arrivalEvents` / `arrivalRequests` / `arrivalEventsTotal` / `arrivalRequestsTotal` appear in prod `emission_gate_window` heartbeats — **this is the check that matters**, since it is what t-14 will read
- [ ] The prod budget report names `declared` for both memex-api and backstage — prod is the only environment where the two coexist on one Cloud SQL instance, so it is the only place phase A's read of *backstage's* declaration is exercised

## Still open on spec-525 after this

**No code.** ac-2 needs the rate read under enforcement (t-14, on a calendar); ac-4 needs an alerting surface, since t-11 established there is no OTLP endpoint in either environment; and dec-6's effect in production waits on `DB_POOL_MAX` rising, which is `spec-332` dec-3's call — recorded there as `c-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)