### PR TITLE
feat(spec-538): declare the result ceiling, and count the envelope inside the budget

### DIFF
--- a/packages/server/src/__regression__/response-budget-funnel.spec-538.regression.test.ts
+++ b/packages/server/src/__regression__/response-budget-funnel.spec-538.regression.test.ts
@@ -19,7 +19,7 @@ import { tagAc } from "@memex-ai-ac/vitest";
 import {
   formatState,
 } from "../agent/handlers/doc-state.js";
-import { RESPONSE_BODY_BUDGET_CHARS } from "../mcp/response-budget.js";
+import { RESPONSE_BUDGET_CHARS } from "../mcp/response-budget.js";
 import type { Doc, DocSection } from "../db/schema.js";
 
 const AC = (n: number) =>
@@ -85,7 +85,7 @@ describe("the budget lives at the funnel, so every caller inherits it (ac-15)", 
       tasks: [],
     } as never);
 
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
     expect(out).toContain("Response shape:");
   });
 

--- a/packages/server/src/agent/envelope-allowance-drift.spec-538.integration.test.ts
+++ b/packages/server/src/agent/envelope-allowance-drift.spec-538.integration.test.ts
@@ -1,0 +1,143 @@
+// spec-538 t-15 (ac-34) — the drift guard on ENVELOPE_SEAT_ALLOWANCE_CHARS.
+//
+// t-15 made `formatFullDocState` reserve its own envelope, computed from inputs
+// it holds: `toNudge` (pure, total) plus `nudge.fullHandoff` when the seat has
+// resolved one. Only ONE term is a reserve rather than a computation — what
+// `composeGuidanceEnvelope` adds AFTER the handler returns:
+//
+//   the FOOTER_DELIMITER · the one-line dynamic state · STEER_BY_TOOL ·
+//   spec-249's status overview · spec-521 dec-5's supersession lead line
+//
+// ENVELOPE_SEAT_ALLOWANCE_CHARS = 3,000 stands in for exactly those, and until
+// this file nothing checked it. That is the hole t-15's own checklist recorded as
+// open: "a bound anything can escape is not a bound" is the argument this Spec
+// makes about everyone else's numbers, and it applies to ours.
+//
+// WHY THE HANDOFF IS NOT AT RISK, and therefore not asserted here: the render
+// measures `nudge.fullHandoff.length` — the actual string the seat handed it — so
+// that term cannot drift from what is emitted. It is exact by construction. The
+// seat's own additions are the only estimate, so they are the only thing to pin.
+//
+// WHY AN INTEGRATION TEST: `composeGuidanceEnvelope` reads the doc, the phase and
+// the delivery claim from the database. A unit test would have to fake the thing
+// it is trying to measure.
+
+import { describe, it, expect, afterAll } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq, inArray } from "drizzle-orm";
+import {
+  BASE_SCAFFOLD,
+  toNudge,
+  toHandoffEssence,
+  type SpecPhase,
+} from "@memex/shared";
+import { db } from "../db/connection.js";
+import { memexes, documents, docSections, users } from "../db/schema.js";
+import { makeTestMemex } from "../services/test-helpers.js";
+import { createDocDraft } from "../services/documents.js";
+import { ENVELOPE_SEAT_ALLOWANCE_CHARS } from "../mcp/response-budget.js";
+import { composeGuidanceEnvelope, type ToolCtx } from "./tool-specs.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-538/acs/ac-${n}`;
+
+const cleanup = { memexes: [] as string[], docs: [] as string[], users: [] as string[] };
+
+afterAll(async () => {
+  if (cleanup.docs.length) {
+    await db.delete(docSections).where(inArray(docSections.docId, cleanup.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, cleanup.docs)).catch(() => {});
+  }
+  for (const id of cleanup.memexes) {
+    await db.delete(memexes).where(eq(memexes.id, id)).catch(() => {});
+  }
+  for (const id of cleanup.users) {
+    await db.delete(users).where(eq(users.id, id)).catch(() => {});
+  }
+});
+
+/** The verbose read path — the branch that carries the full phase footer. */
+function verboseCtx(userId: string): ToolCtx {
+  return {
+    userId,
+    verbose: true,
+    workspaceUrl: async () => "https://test.example",
+    footerSlot: {},
+  } as unknown as ToolCtx;
+}
+
+describe("the seat allowance is a bound, not a hope (ac-34)", () => {
+  it("covers what composeGuidanceEnvelope actually adds, in every phase", async () => {
+    tagAc(AC(34));
+
+    const [u] = await db
+      .insert(users)
+      .values({
+        email: `s538env-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@memex.ai`,
+      } as never)
+      .returning();
+    cleanup.users.push(u.id);
+    const memexId = await makeTestMemex("s538env");
+    cleanup.memexes.push(memexId);
+
+    const doc = await createDocDraft(
+      memexId,
+      "Envelope allowance fixture",
+      "Overview body.",
+      "spec",
+      undefined,
+      undefined,
+      u.id,
+      { actorUserId: u.id, channel: "mcp" },
+    );
+    cleanup.docs.push(doc.id);
+
+    const phases: SpecPhase[] = ["draft", "specify", "build", "verify", "done"];
+    const observed: string[] = [];
+
+    for (const phase of phases) {
+      await db
+        .update(documents)
+        .set({ status: phase })
+        .where(eq(documents.id, doc.id));
+
+      // Compose twice. The full handoff is claimed once per (user, session, spec,
+      // phase), so the second call carries the compressed essence instead — which
+      // isolates the term this test exists to bound. Taking the SMALLER of the two
+      // rather than assuming an order keeps this robust to the claim's mechanics.
+      const first = await composeGuidanceEnvelope(memexId, doc.id, verboseCtx(u.id));
+      const second = await composeGuidanceEnvelope(memexId, doc.id, verboseCtx(u.id));
+      const lengthOf = (e: { header?: string; footer?: string }) =>
+        (e.header?.length ?? 0) + (e.footer?.length ?? 0);
+      const essenceShaped = Math.min(lengthOf(first), lengthOf(second));
+
+      // What the render would compute for this phase, by the same formula, minus
+      // the allowance — i.e. the part it KNOWS.
+      const known =
+        toNudge({ dataset: BASE_SCAFFOLD, phase }).length +
+        (toHandoffEssence(BASE_SCAFFOLD, phase) ?? "").length;
+
+      const seatAdditions = essenceShaped - known;
+      observed.push(
+        `${phase}: composed ${essenceShaped}, known ${known}, seat +${seatAdditions}`,
+      );
+
+      expect(
+        seatAdditions,
+        `phase "${phase}": the seat added ${seatAdditions} chars beyond what the ` +
+          `render can compute, against an allowance of ${ENVELOPE_SEAT_ALLOWANCE_CHARS}. ` +
+          `If this is a deliberate growth, raise the allowance AND re-derive ` +
+          `RESPONSE_BUDGET_CHARS with it. Observed: ${observed.join(" | ")}`,
+      ).toBeLessThanOrEqual(ENVELOPE_SEAT_ALLOWANCE_CHARS);
+    }
+
+    // The fixture has to have actually exercised the seat, or the loop above
+    // proves nothing — the same trap as ac-4's task-less fixture (s-5 §3).
+    expect(observed).toHaveLength(phases.length);
+    expect(
+      observed.some((o) => !o.includes("composed 0,")),
+      `every phase composed an empty envelope — the fixture did not exercise the ` +
+        `seat. Observed: ${observed.join(" | ")}`,
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -7,6 +7,7 @@ import {
   allocateResponseBudget,
   effectiveBudget,
   boundRenderedList,
+  ENVELOPE_SEAT_ALLOWANCE_CHARS,
 } from "../mcp/response-budget.js";
 import type { DocSummary } from "../types/index.js";
 import type { TaskWithBlockers } from "../services/tasks.js";
@@ -156,6 +157,56 @@ function formatTagStrip(tags: Tag[] | undefined): string | null {
   return `Tags: ${tags.map(formatTag).join(", ")}`;
 }
 
+/**
+ * What this response's guidance envelope will cost, computed from the inputs the
+ * render already holds — spec-538 t-15 (dec-7's conclusion corrected).
+ *
+ * NOT exported: its only consumer is `formatFullDocState` below [per std-51 — a
+ * single-consumer symbol belongs in that consumer, and an export widened so a
+ * test can reach inside is the wrong shape]. Its behaviour is asserted through
+ * the rendered output and through the per-phase drift test.
+ *
+ * dec-7 justified `envelopeChars: 0` with "this one does not know it and must not
+ * pretend to". Half of that stands: the render cannot measure the COMPOSED
+ * envelope, because `spec-traffic.ts` attaches it after the handler returns and
+ * `target` only exists as a side effect of `ctx.resolveRef()` inside the handler.
+ *
+ * The other half was wrong. The render holds the envelope's INPUTS, and has since
+ * spec-203 dec-2 — before this Spec was written:
+ *   - `toNudge` is pure, total and stateless (`scaffold-model.ts:345`);
+ *   - `nudge` carries `tool`, `orgBlocks` and the pre-resolved `fullHandoff`;
+ *   - `doc.status` IS the phase, derived the same way at the seat.
+ * So this is a COMPUTATION over the same projection the seat will use, not a
+ * guess about it [per std-50 cl-1 — the fact from the thing].
+ *
+ * NOT dec-7 option (a): the reserve tracks THIS response, never the population
+ * maximum. Reserving MEASURED_ENVELOPE_MAX_CHARS flat would pull the majority of
+ * reads into tier 2/3 and collide with ac-26 — the objection that still holds.
+ */
+function estimateEnvelopeChars(doc: Doc, nudge?: NudgeContext): number {
+  const phase = doc.status as SpecPhase;
+  let guidance = 0;
+  let handoff = 0;
+  try {
+    guidance = toNudge({
+      dataset: BASE_SCAFFOLD,
+      tool: nudge?.tool,
+      phase,
+      orgBlocks: nudge?.orgBlocks,
+    }).length;
+    handoff =
+      nudge?.fullHandoff?.length ??
+      (toHandoffEssence(BASE_SCAFFOLD, phase) ?? "").length;
+  } catch {
+    // A doc whose status is not a Spec phase (a Standard, a plain document) has
+    // no phase guidance to project. Reserving only the seat allowance is correct
+    // there, and this must never throw inside a read path.
+    guidance = 0;
+    handoff = 0;
+  }
+  return guidance + handoff + ENVELOPE_SEAT_ALLOWANCE_CHARS;
+}
+
 export function formatFullDocState(
   // spec-371: checkoutHolder is the resolved holder name (getDoc attaches it);
   // checked_out_by/at ride along on Doc. Optional so plain-Doc callers still compile.
@@ -244,15 +295,10 @@ export function formatFullDocState(
 
   const budget = allocateResponseBudget({
     signalsChars: signalLines.join("\n").length,
-    // Zero is CORRECT here, not a stopgap (dec-7 option (d)). The body is
-    // rendered before the envelope exists — `spec-traffic.ts` attaches the
-    // envelope after the handler returns — so this number cannot be measured at
-    // this point in the call. It does not have to be: the budget constant is a
-    // BODY budget, already net of the envelope's worst case, and the headroom
-    // between it and the client cap is asserted by a test rather than claimed
-    // here. A caller that genuinely knows its envelope may pass one to tighten
-    // further; this one does not know it and must not pretend to.
-    envelopeChars: 0,
+    // t-15: computed per response, no longer 0. See estimateEnvelopeChars above
+    // for why dec-7's "the render does not know it" was half right — it cannot
+    // measure the composed envelope, but it holds its inputs.
+    envelopeChars: estimateEnvelopeChars(doc, nudge),
     proseChars,
     decisionsFullChars: decisionsFull.length,
     decisionCount: decisions.length,

--- a/packages/server/src/mcp/formatters.flag-survives.spec-538.test.ts
+++ b/packages/server/src/mcp/formatters.flag-survives.spec-538.test.ts
@@ -18,7 +18,7 @@ import {
   formatState,
 } from "../agent/handlers/doc-state.js";
 import { formatFullDocState } from "./formatters.js";
-import { RESPONSE_BODY_BUDGET_CHARS } from "./response-budget.js";
+import { RESPONSE_BUDGET_CHARS } from "./response-budget.js";
 import type { Doc, DocSection, Decision } from "../db/schema.js";
 
 const AC = (n: number) =>
@@ -96,7 +96,7 @@ describe("the signal reaches the reader on a Spec of ANY size (ac-3)", () => {
       expect(out).toContain("the person to talk to");
       // …in the response itself, which is the whole point: a payload the client
       // refuses is a payload the reader never sees.
-      expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+      expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
     });
   }
 
@@ -126,7 +126,7 @@ describe("a verbose WRITE on a flagged Spec now delivers the warning (ac-17)", (
 
     expect(out).toContain("SENSITIVE");
     expect(out).toContain("the person to talk to");
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 
   it("records what this Spec does NOT deliver: the terse-write path still says nothing", () => {

--- a/packages/server/src/mcp/formatters.response-ladder.spec-538.test.ts
+++ b/packages/server/src/mcp/formatters.response-ladder.spec-538.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { formatFullDocState } from "./formatters.js";
-import { RESPONSE_BODY_BUDGET_CHARS } from "./response-budget.js";
+import { RESPONSE_BUDGET_CHARS } from "./response-budget.js";
 import type { Doc, DocSection, Decision } from "../db/schema.js";
 
 const AC = (n: number) =>
@@ -127,7 +127,7 @@ describe("tier 1 — a Spec that fits is not reshaped (ac-11)", () => {
     // Background survives at tier 1 — only a budgeted render drops it.
     expect(out).toContain("Context: ");
     expect(out).not.toContain("shortened");
-    expect(out.length).toBeLessThan(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThan(RESPONSE_BUDGET_CHARS);
   });
 
   it("says so rather than leaving completeness to be inferred", () => {
@@ -150,7 +150,7 @@ describe("tier 2 — decisions are excerpted, and the excerpt is a door (ac-8)",
     // No decision's resolution survives whole…
     expect(out).not.toContain("R".repeat(8_000));
     // …and the whole response is inside the budget.
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 
   it("carries every decision's ref, so the shortened text has somewhere to lead", () => {
@@ -176,7 +176,7 @@ describe("tier 3 — section bodies are withheld whole, never mid-sentence (ac-1
     expect(out).toContain("body not included");
     expect(out).toContain("## 1. Overview");
     expect(out).toMatch(/Section #1 \| ref: s-1/);
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 
   it("omits the body whole — no section stops partway through as if that were its content", () => {
@@ -196,7 +196,7 @@ describe("signals survive every tier (ac-9, and the reason this Spec exists)", (
     expect(out).toContain("SENSITIVE");
     expect(out).toContain("the person who flagged it");
     // …in the response itself, not in a payload the client would spill.
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 });
 

--- a/packages/server/src/mcp/response-budget.delivery.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.delivery.spec-538.test.ts
@@ -1,0 +1,307 @@
+// spec-538 t-12 (ac-33) — budget-compliant must mean DELIVERABLE.
+//
+// issue-4: a response that satisfied EVERY asserted bound was refused by an MCP
+// client and spilled to a file. Body 37,744 (under the 40,000 budget), envelope
+// 14,815 (inside the 23,244 worst case), total 52,559 (18,235 under
+// MEASURED_CAP_BOUND_CHARS). Every mechanism this Spec built worked; delivery
+// failed anyway.
+//
+// s-1's first paragraph is the contract this file holds: "This is a DELIVERY
+// defect, not a verbosity preference." Every existing bound in this Spec asserts
+// a SIZE. Size was never the contract.
+//
+// These assertions are RED on the tree that introduced them, deliberately, and
+// they go green only once BOTH the wiring (t-12) and the constants (t-13) are
+// fixed. ac-33 is the bug's criterion and it spans both tasks — see the
+// bug -> failing-AC -> green-AC -> resolved loop on issue-4.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  RESPONSE_BUDGET_CHARS,
+  MEASURED_ENVELOPE_MAX_CHARS,
+  DECLARED_CLIENT_RESULT_CEILING_CHARS,
+  CLIENT_DEFAULT_CEILING_CHARS,
+} from "./response-budget.js";
+import { formatFullDocState } from "./formatters.js";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-538/acs/ac-${n}`;
+
+/**
+ * The client's DEFAULT refusal threshold, read from the client itself on
+ * 2026-09-04 — the fact from the thing, not from a record of it [per std-50 cl-1]:
+ *
+ *   var eG = 50000, TBe = 500000;
+ *   function h3e(name, own, ceiling = eG, skipAggregate = false) {
+ *     …
+ *     return Math.min(own, ceiling);
+ *   }
+ *
+ * Corroborated end-to-end on the founding payload: the persisted JSON measured
+ * 53,247 chars, the client reported "Output too large (52KB)" — 53,247/1024 =
+ * 52.0 — and refused it. Over by 3,247.
+ *
+ * Kept here as the number the declaration REPLACES, so the next reader can see
+ * what would apply if the `_meta` declaration were ever dropped.
+ */
+// (imported from response-budget.ts — t-12 promoted it there.)
+
+/**
+ * How much of the ceiling stays unspent — a margin, never an equality, because
+ * the ceiling is still the client's to change.
+ */
+const REQUIRED_CEILING_MARGIN = 2_000;
+
+describe("the declaration replaces the guess, and it is the operative ceiling", () => {
+  it("declares more room than the client's default, and far less than the maximum", () => {
+    tagAc(AC(33));
+    // dec-9 option (c). Both bounds matter: below the default it would be
+    // pointless, at the 500,000 maximum it would disable the client's context
+    // protection — which is the interest this Spec exists to serve.
+    expect(DECLARED_CLIENT_RESULT_CEILING_CHARS).toBeGreaterThan(
+      CLIENT_DEFAULT_CEILING_CHARS,
+    );
+    expect(DECLARED_CLIENT_RESULT_CEILING_CHARS).toBeLessThanOrEqual(100_000);
+  });
+
+  it("every MCP tool advertises it — the declaration is uniform, not per-tool", () => {
+    tagAc(AC(33));
+    // A property of the transport, not a tool classification: one number for the
+    // whole surface, which is why it is not a toolManifest field [per std-16].
+    const src = readFileSync(
+      fileURLToPath(new URL("./tools.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(src).toContain('"anthropic/maxResultSizeChars"');
+    expect(src).toContain("DECLARED_CLIENT_RESULT_CEILING_CHARS");
+  });
+});
+
+/**
+ * What the client actually weighs.
+ *
+ * From the same client source: the persisted value is
+ * `l = Array.isArray(n) ? JSON.stringify(n, null, 2) : n`, and the threshold is
+ * compared against `l.length`. So the server's rendered text is NOT the measured
+ * quantity — the JSON envelope around it is, and `formatFullDocState` cannot see
+ * that difference. On the founding payload it was 688 chars (52,559 -> 53,247),
+ * ~1.3%, and it scales with newline count because each `\n` is escaped to two
+ * characters.
+ */
+function serialisedLengthAsClientWeighsIt(text: string): number {
+  return JSON.stringify([{ type: "text", text }], null, 2).length;
+}
+
+describe("the serialisation model matches the client, before it is used to judge anything", () => {
+  it("reproduces the client's own JSON.stringify(content, null, 2) shape", () => {
+    // Assert the instrument before asserting with it: a delivery test built on a
+    // wrong model of what the client measures would be confidently useless.
+    const text = "a\nb";
+    expect(JSON.stringify([{ type: "text", text }], null, 2)).toBe(
+      '[\n  {\n    "type": "text",\n    "text": "a\\nb"\n  }\n]',
+    );
+    // And it must OVER-count the rendered text, never under-count it.
+    expect(serialisedLengthAsClientWeighsIt(text)).toBeGreaterThan(text.length);
+  });
+
+  it("the overhead grows with newlines, which is why a fixed constant would drift", () => {
+    const flat = "x".repeat(1_000);
+    const lined = "x\n".repeat(500);
+    expect(flat.length).toBe(lined.length);
+    expect(serialisedLengthAsClientWeighsIt(lined)).toBeGreaterThan(
+      serialisedLengthAsClientWeighsIt(flat),
+    );
+  });
+});
+
+describe("budget-compliant implies deliverable (ac-33)", () => {
+  it("one full budget, serialised, fits under the declared ceiling", () => {
+    tagAc(AC(33));
+    // t-15 made the budget INCLUSIVE of the envelope, so the arithmetic is no
+    // longer additive: adding MEASURED_ENVELOPE_MAX_CHARS on top would
+    // double-count what the allocator already reserved. What must arrive is one
+    // full budget, weighed the way the client weighs it.
+    const onTheWire = serialisedLengthAsClientWeighsIt(
+      "P".repeat(RESPONSE_BUDGET_CHARS),
+    );
+
+    expect(
+      onTheWire,
+      `a full ${RESPONSE_BUDGET_CHARS} budget serialises to ${onTheWire}, ` +
+        `against the declared ${DECLARED_CLIENT_RESULT_CEILING_CHARS} ` +
+        `less a ${REQUIRED_CEILING_MARGIN} margin`,
+    ).toBeLessThanOrEqual(
+      DECLARED_CLIENT_RESULT_CEILING_CHARS - REQUIRED_CEILING_MARGIN,
+    );
+
+    // The declaration must be load-bearing, not cosmetic: a full budget must NOT
+    // fit under the client's bare default, or dropping the `_meta` would cost
+    // nothing and the ceiling would be back to being inferred.
+    expect(
+      onTheWire,
+      "the declaration must be load-bearing, not cosmetic",
+    ).toBeGreaterThan(CLIENT_DEFAULT_CEILING_CHARS);
+  });
+
+  it("a real render whose body sits NEAR the budget arrives, envelope included", () => {
+    tagAc(AC(33));
+    // The existing ac-1/ac-4 checks assert `out.length <= RESPONSE_BUDGET_CHARS`
+    // and stop there — they measure the body alone, which is the half that was
+    // never in doubt. This one carries the envelope the response is actually
+    // emitted alongside, and weighs the result the way the client does.
+    //
+    // FIXTURE CHOICE, and it is the whole test. The first version of this used
+    // spec-472's 85,580 chars of prose — and PASSED, uselessly: that much prose
+    // trips tier 3, the section bodies are dropped, and the body collapses to a
+    // small map that fits alongside any envelope. The defect lives where the
+    // body is NEAR the budget and still renders in full (the founding payload's
+    // body was 37,744), so the prose is sized to stay in tier 1.
+    //
+    // This is the ac-4 flaw one level up — s-5 §3: a fixture "structurally
+    // unable to observe the largest region" of what it claims to bound. Hence
+    // the fixture-reality assertion below, before anything is concluded from it.
+    const baseDate = new Date("2026-03-25T12:00:00Z");
+    const doc = {
+      id: "d1",
+      memexId: "m1",
+      handle: "spec-1",
+      title: "Representative",
+      docType: "spec",
+      status: "build",
+      createdAt: baseDate,
+      statusChangedAt: baseDate,
+      version: 1,
+      sensitive: false,
+      sensitiveByName: null,
+      checkedOutBy: null,
+      checkedOutAt: null,
+      sections: [
+        {
+          id: "s1",
+          docId: "d1",
+          sectionType: "overview",
+          title: "Overview",
+          // Sized to land the body just under the budget in tier 1 — the shape
+          // that actually spilled. NOT spec-472's 85,580, which trips tier 3.
+          content: "P".repeat(35_000),
+          seq: 1,
+          position: 1,
+          status: "active",
+          createdAt: baseDate,
+          updatedAt: baseDate,
+        } as unknown as DocSection,
+      ],
+    } as unknown as Doc & { sections: DocSection[] };
+
+    const body = formatFullDocState(doc, [], []);
+
+    // FIXTURE REALITY, asserted before it is trusted. If a future change makes
+    // this collapse to a tier-3 map, THIS fails loudly rather than the delivery
+    // claim below passing for the wrong reason.
+    expect(
+      body.length,
+      `the fixture must exercise a near-budget body, not a collapsed map; ` +
+        `rendered ${body.length} against a ${RESPONSE_BUDGET_CHARS} budget`,
+    ).toBeGreaterThan(30_000);
+
+    const withEnvelope = body + "G".repeat(MEASURED_ENVELOPE_MAX_CHARS);
+    const onTheWire = serialisedLengthAsClientWeighsIt(withEnvelope);
+
+    expect(
+      onTheWire,
+      `body rendered ${body.length}, on the wire ${onTheWire}`,
+    ).toBeLessThanOrEqual(
+      DECLARED_CLIENT_RESULT_CEILING_CHARS - REQUIRED_CEILING_MARGIN,
+    );
+  });
+
+  it("the reserve tracks THIS response's envelope, not the population maximum (ac-34)", () => {
+    tagAc(AC(34));
+    // REPLACES a source scan that passed for the wrong reason. It looked for
+    // `envelopeChars: 0` and, once t-15 removed that string, `indexOf` returned
+    // -1, the slice widened to the whole file, and the assertion matched prose
+    // elsewhere in it. A green test measuring nothing — the exact class of defect
+    // this Spec exists to fight, committed by its own guard for the second time
+    // (see ac-4, s-5 §3).
+    //
+    // So this asserts through the RENDERED OUTPUT instead. A source read cannot
+    // distinguish a computed reserve from a hardcoded one; only behaviour can.
+    const baseDate = new Date("2026-03-25T12:00:00Z");
+    const specOfPhase = (status: string): string => {
+      const doc = {
+        id: "d1",
+        memexId: "m1",
+        handle: "spec-1",
+        title: "Representative",
+        docType: "spec",
+        status,
+        createdAt: baseDate,
+        statusChangedAt: baseDate,
+        version: 1,
+        sensitive: false,
+        sensitiveByName: null,
+        checkedOutBy: null,
+        checkedOutAt: null,
+        sections: [
+          {
+            id: "s1",
+            docId: "d1",
+            sectionType: "overview",
+            title: "Overview",
+            content: "P".repeat(20_000),
+            seq: 1,
+            position: 1,
+            status: "active",
+            createdAt: baseDate,
+            updatedAt: baseDate,
+          } as unknown as DocSection,
+        ],
+      } as unknown as Doc & { sections: DocSection[] };
+      // Enough decision weight to force tier 2, so the remainder is visible as
+      // excerpt length rather than hidden by everything fitting.
+      const decisions = Array.from({ length: 12 }, (_, i) => ({
+        id: `dec${i}`,
+        docId: "d1",
+        seq: i + 1,
+        handle: `dec-${i + 1}`,
+        title: `Decision ${i + 1}`,
+        status: "resolved",
+        resolution: "R".repeat(20_000),
+        context: null,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      })) as unknown as Parameters<typeof formatFullDocState>[1];
+      return formatFullDocState(doc, decisions, []);
+    };
+
+    // `specify` carries the largest phase guidance (13,174 + a 1,308 handoff);
+    // `done` the smallest (4,150 and no handoff). Same document, same content.
+    const specify = specOfPhase("specify");
+    const done = specOfPhase("done");
+
+    expect(
+      done.length,
+      `done rendered ${done.length}, specify ${specify.length} — the phase with ` +
+        "the smaller envelope must keep more content",
+    ).toBeGreaterThan(specify.length);
+
+    // And it must not be a flat worst-case reservation (dec-7 option (a)): the
+    // difference has to come from the phases' real guidance sizes, so the gap
+    // must be well under the population maximum it would otherwise both reserve.
+    const gap = done.length - specify.length;
+    expect(gap).toBeGreaterThan(0);
+    expect(
+      gap,
+      "a flat MEASURED_ENVELOPE_MAX_CHARS reserve would make the phases identical",
+    ).toBeLessThan(MEASURED_ENVELOPE_MAX_CHARS);
+
+    // Both still fit, which is the bound the reserve exists to hold.
+    for (const out of [specify, done]) {
+      expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
+    }
+  });
+});

--- a/packages/server/src/mcp/response-budget.lists.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.lists.spec-538.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
-import { boundRenderedList, RESPONSE_BODY_BUDGET_CHARS } from "./response-budget.js";
+import { boundRenderedList, RESPONSE_BUDGET_CHARS } from "./response-budget.js";
 import { formatDocComments } from "../formatting/formatters.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -27,11 +27,11 @@ describe("boundRenderedList — item count is a growth axis too (ac-21)", () => 
     tagAc(AC(21));
     const entries = Array.from({ length: 467 }, () => DOC_LINE);
     const unbounded = entries.join("\n").length;
-    expect(unbounded).toBeGreaterThan(RESPONSE_BODY_BUDGET_CHARS); // 87,626 — the defect
+    expect(unbounded).toBeGreaterThan(RESPONSE_BUDGET_CHARS); // 87,626 — the defect
 
     const { kept, omitted } = boundRenderedList(entries, { reservedChars: 500 });
 
-    expect(kept.join("\n").length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS - 500);
+    expect(kept.join("\n").length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS - 500);
     expect(omitted).toBeGreaterThan(0);
     expect(kept.length + omitted).toBe(467); // nothing is lost from the count
   });
@@ -61,7 +61,7 @@ describe("boundRenderedList — item count is a growth axis too (ac-21)", () => 
     const reserved = boundRenderedList(entries, { reservedChars: 10_000 });
     expect(reserved.kept.length).toBeLessThan(generous.kept.length);
     expect(reserved.kept.join("\n").length).toBeLessThanOrEqual(
-      RESPONSE_BODY_BUDGET_CHARS - 10_000,
+      RESPONSE_BUDGET_CHARS - 10_000,
     );
   });
 });
@@ -111,7 +111,7 @@ describe("list_comments — bodies are the other growth axis (ac-20)", () => {
     const many = Array.from({ length: 40 }, (_, i) => makeComment(i + 1, 4_000));
     const out = formatDocComments(commentsResult(many));
 
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
     expect(out).toContain("not shown");
     // The count is honest: the header still reports the true total.
     expect(out).toContain("# Comments (40 total)");

--- a/packages/server/src/mcp/response-budget.sizing.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.sizing.spec-538.test.ts
@@ -11,9 +11,10 @@ import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
-  RESPONSE_BODY_BUDGET_CHARS,
+  RESPONSE_BUDGET_CHARS,
   MEASURED_ENVELOPE_MAX_CHARS,
-  MEASURED_CAP_BOUND_CHARS,
+  DECLARED_CLIENT_RESULT_CEILING_CHARS,
+  CLIENT_DEFAULT_CEILING_CHARS,
   LARGEST_WORKING_BODY_CHARS,
   allocateResponseBudget,
 } from "./response-budget.js";
@@ -24,10 +25,17 @@ const AC = (n: number) =>
   `mindset-prod/memex-building-itself/specs/spec-538/acs/ac-${n}`;
 
 /**
- * How much of the cap must stay unspent. The cap bound is the smallest refusal
- * ever OBSERVED, not the cap — the real value is lower, belongs to the client,
- * and is user-configurable. Characters are also a proxy for tokens, and the
- * ratio moves with content.
+ * How much of the ceiling must stay unspent.
+ *
+ * t-12 changed what this is a margin UNDER. It used to guard
+ * MEASURED_CAP_BOUND_CHARS — the smallest refusal ever observed, which turned out
+ * to be 41.6% above the client's real default, so the margin was protecting a
+ * number that was already too generous. It now guards the ceiling this server
+ * DECLARES (dec-9), which is a value we state rather than infer.
+ *
+ * Still non-zero, and deliberately unchanged at 5,000: the declared ceiling is
+ * ours, but a client may still hold a per-tool override, and the serialised form
+ * the client weighs runs ~1.3% longer than the text we measure.
  */
 const REQUIRED_CAP_MARGIN = 5_000;
 
@@ -35,34 +43,91 @@ const REQUIRED_CAP_MARGIN = 5_000;
 const REQUIRED_FLOOR_MARGIN = 2_000;
 
 describe("the headroom is asserted, not claimed (ac-27)", () => {
-  it("body budget + worst-case envelope stays under the measured cap bound", () => {
+  it("the declared ceiling, not the client's default, is what the headroom sits under", () => {
     tagAc(AC(27));
-    const worstCaseResponse =
-      RESPONSE_BODY_BUDGET_CHARS + MEASURED_ENVELOPE_MAX_CHARS;
-
-    expect(worstCaseResponse).toBeLessThanOrEqual(
-      MEASURED_CAP_BOUND_CHARS - REQUIRED_CAP_MARGIN,
+    // t-12: the original headroom was checked against a refusal sample (70,794)
+    // that sat 41.6% above the client's real default (50,000) — so body 40,000 +
+    // envelope 23,244 = 63,244 "cleared the cap" while actually exceeding it by
+    // 13,244. The bound held by luck. It now sits under a ceiling this server
+    // states, and the default is recorded so the gap is visible.
+    expect(DECLARED_CLIENT_RESULT_CEILING_CHARS).toBeGreaterThan(
+      CLIENT_DEFAULT_CEILING_CHARS,
     );
+    expect(
+      RESPONSE_BUDGET_CHARS + MEASURED_ENVELOPE_MAX_CHARS,
+      "the worst case must NOT fit under the client's bare default — if it did, " +
+        "the declaration would be doing nothing",
+    ).toBeGreaterThan(CLIENT_DEFAULT_CEILING_CHARS);
   });
 
-  it("the envelope is accounted for by the constant, so the body render passes zero honestly (ac-18)", () => {
+  it("one full budget, serialised, stays under the declared ceiling", () => {
+    tagAc(AC(27));
+    // t-15 INVERTED this. It used to assert `budget + envelope <= cap`, because
+    // dec-7 option (d) made the budget body-only and left the envelope beyond it.
+    // The envelope is now a fixed cost INSIDE the allocation, so adding it again
+    // would double-count. What must fit is one full budget, weighed the way the
+    // client weighs it — the JSON-serialised content array, ~1.3% longer than the
+    // rendered text because newlines are escaped.
+    const onTheWire = JSON.stringify(
+      [{ type: "text", text: "P".repeat(RESPONSE_BUDGET_CHARS) }],
+      null,
+      2,
+    ).length;
+
+    expect(
+      onTheWire,
+      `a full ${RESPONSE_BUDGET_CHARS} budget serialises to ${onTheWire}`,
+    ).toBeLessThanOrEqual(
+      DECLARED_CLIENT_RESULT_CEILING_CHARS - REQUIRED_CAP_MARGIN,
+    );
+
+    // The envelope must be INSIDE the budget, not beyond it: adding the measured
+    // worst case on top must overflow, or the allocator counting it would be
+    // decorative and could quietly go back to zero.
+    expect(
+      RESPONSE_BUDGET_CHARS + MEASURED_ENVELOPE_MAX_CHARS,
+      "if budget+envelope still fitted, counting the envelope would be optional",
+    ).toBeGreaterThan(DECLARED_CLIENT_RESULT_CEILING_CHARS);
+  });
+
+  it("the envelope is counted INSIDE the budget, not added on top of it (ac-18)", () => {
     tagAc(AC(18));
-    // dec-7 option (d): the body is rendered before the envelope exists, so the
-    // render cannot measure it. It does not have to — the budget it spends is
-    // already net of the worst case, which is what the assertion above pins.
-    // What must NOT be true is that the two are simply added and hoped about.
-    const a = allocateResponseBudget({
+    // t-15 made this criterion literally true, where dec-7 option (d) had only
+    // made it true by construction. The old test asserted that the render "passes
+    // zero honestly" because the constant was already net of the worst case —
+    // a claim retired with dec-7's amendment.
+    //
+    // Now the envelope is a fixed cost the allocator subtracts before anything
+    // negotiable, so the property to assert is that it BITES: the same document
+    // gets measurably less room to spend when its envelope is larger.
+    const withSmallEnvelope = allocateResponseBudget({
       signalsChars: 0,
-      envelopeChars: 0,
-      proseChars: RESPONSE_BODY_BUDGET_CHARS - 1_000,
+      envelopeChars: 4_000,
+      proseChars: 1_000,
       decisionsFullChars: 500_000,
       decisionCount: 10,
     });
-    const bodySpend =
-      RESPONSE_BODY_BUDGET_CHARS - 1_000 + a.perDecisionChars * 10;
-    expect(bodySpend + MEASURED_ENVELOPE_MAX_CHARS).toBeLessThan(
-      MEASURED_CAP_BOUND_CHARS,
+    const withLargeEnvelope = allocateResponseBudget({
+      signalsChars: 0,
+      envelopeChars: 18_000,
+      proseChars: 1_000,
+      decisionsFullChars: 500_000,
+      decisionCount: 10,
+    });
+    expect(withLargeEnvelope.perDecisionChars).toBeLessThan(
+      withSmallEnvelope.perDecisionChars,
     );
+    expect(withLargeEnvelope.remainingAfterFixed).toBe(
+      withSmallEnvelope.remainingAfterFixed - 14_000,
+    );
+
+    // And the total a response can spend — content plus the envelope it is
+    // emitted alongside — never exceeds the budget. That is the whole point of
+    // counting it: the two are no longer "added and hoped about".
+    const envelope = 18_000;
+    const spent =
+      envelope + 1_000 + withLargeEnvelope.perDecisionChars * 10;
+    expect(spent).toBeLessThanOrEqual(withLargeEnvelope.budget);
   });
 });
 
@@ -72,7 +137,7 @@ describe("no read that works today changes shape (ac-26)", () => {
     // Measured across 18 reads that the client accepted: the largest body was
     // 33,501. At or below that, a response that works fine now would start being
     // excerpted — which is the regression ac-26 forbids.
-    expect(RESPONSE_BODY_BUDGET_CHARS).toBeGreaterThanOrEqual(
+    expect(RESPONSE_BUDGET_CHARS).toBeGreaterThanOrEqual(
       LARGEST_WORKING_BODY_CHARS + REQUIRED_FLOOR_MARGIN,
     );
   });
@@ -93,26 +158,38 @@ describe("no read that works today changes shape (ac-26)", () => {
   it("the two bounds leave a real window, not a knife edge", () => {
     tagAc(AC(26));
     const floor = LARGEST_WORKING_BODY_CHARS + REQUIRED_FLOOR_MARGIN;
-    const ceiling =
-      MEASURED_CAP_BOUND_CHARS - MEASURED_ENVELOPE_MAX_CHARS - REQUIRED_CAP_MARGIN;
+    // t-15: the budget is inclusive, so the ceiling is no longer the declared
+    // value less the envelope — the envelope is spent from inside it. What bounds
+    // it is the declared ceiling less the margin, net of the serialisation
+    // overhead the client weighs and we do not.
+    const ceiling = Math.floor(
+      (DECLARED_CLIENT_RESULT_CEILING_CHARS - REQUIRED_CAP_MARGIN) / 1.013,
+    );
     expect(ceiling).toBeGreaterThan(floor);
-    expect(RESPONSE_BODY_BUDGET_CHARS).toBeGreaterThanOrEqual(floor);
-    expect(RESPONSE_BODY_BUDGET_CHARS).toBeLessThanOrEqual(ceiling);
+    expect(RESPONSE_BUDGET_CHARS).toBeGreaterThanOrEqual(floor);
+    expect(RESPONSE_BUDGET_CHARS).toBeLessThanOrEqual(ceiling);
   });
 });
 
-describe("the name says BODY, so nobody budgets a whole response against it (ac-28)", () => {
-  it("the exported identifier cannot be mistaken for a whole-response budget", () => {
+describe("the name matches what the number covers — the WHOLE response (ac-28)", () => {
+  it("the exported identifier does not understate its scope", () => {
     tagAc(AC(28));
+    // t-15 INVERTED this criterion, deliberately.
+    //
+    // Under dec-7 option (d) the budget was body-only, so `RESPONSE_BODY_BUDGET_CHARS`
+    // was the honest name and this test forbade the shorter one. The envelope is
+    // now a fixed cost inside the allocation, so a name saying BODY would
+    // understate what the number bounds — the same trap dec-7 warned about,
+    // pointing the other way.
     const src = readFileSync(
       fileURLToPath(new URL("./response-budget.ts", import.meta.url)),
       "utf8",
     );
-    expect(src).toContain("export const RESPONSE_BODY_BUDGET_CHARS");
-    // The old name must be gone everywhere, not shadowed by an alias.
-    expect(src).not.toMatch(/export const RESPONSE_BUDGET_CHARS\b/);
-    // And the file must say, in words, which half it bounds.
-    expect(src).toMatch(/bounds the response\s*\n\/\/ BODY|budget bounds the response BODY|response\s+BODY/i);
+    expect(src).toContain("export const RESPONSE_BUDGET_CHARS");
+    // The body-only name must be gone everywhere, not shadowed by an alias.
+    expect(src).not.toMatch(/export const RESPONSE_BODY_BUDGET_CHARS\b/);
+    // And the file must say, in words, that it bounds the whole response.
+    expect(src).toMatch(/bounds the WHOLE response/);
   });
 
   it("the envelope parameter is not a field that is always zero and therefore meaningless", () => {
@@ -177,7 +254,7 @@ describe("the bound is held by a check on the real path (ac-4, ac-1)", () => {
     tagAc(AC(1));
     // spec-472: 85,580 chars of prose, larger than the entire cap on its own.
     const out = renderSpecOfProse(85_580);
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 
   it("the check bites: inflate a fixture past the budget and the bound still holds", () => {
@@ -190,7 +267,7 @@ describe("the bound is held by a check on the real path (ac-4, ac-1)", () => {
       expect(
         out.length,
         `a ${size}-char Spec rendered ${out.length} chars`,
-      ).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+      ).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
     }
   });
 });

--- a/packages/server/src/mcp/response-budget.tasks.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.tasks.spec-538.test.ts
@@ -20,7 +20,7 @@
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { formatFullDocState } from "./formatters.js";
-import { RESPONSE_BODY_BUDGET_CHARS } from "./response-budget.js";
+import { RESPONSE_BUDGET_CHARS } from "./response-budget.js";
 import type { Doc, DocSection, Decision } from "../db/schema.js";
 import type { TaskWithBlockers } from "../services/tasks.js";
 
@@ -143,7 +143,7 @@ describe("the tasks block is a measured region of the budget (ac-29)", () => {
   it("spec-538's own shape renders under the budget — the Spec that defines the bound loads itself", () => {
     tagAc(AC(29));
     const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, SPEC_538_TASKS);
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 });
 
@@ -182,8 +182,8 @@ describe("status decides what an item keeps (ac-30)", () => {
 
     expect(b.length).toBeGreaterThan(a.length);
     // …and both still fit.
-    expect(a.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
-    expect(b.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(a.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
+    expect(b.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 
   it("an OPEN decision is kept where a resolved one is excerpted — the live defect in shipped code", () => {
@@ -215,7 +215,7 @@ describe("the bound holds by construction, not by typical sizes (ac-31)", () => 
     expect(fifty).toHaveLength(50);
 
     const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, fifty);
-    expect(out.length).toBeLessThanOrEqual(RESPONSE_BODY_BUDGET_CHARS);
+    expect(out.length).toBeLessThanOrEqual(RESPONSE_BUDGET_CHARS);
   });
 
   it("no task count blows the budget", () => {
@@ -226,7 +226,7 @@ describe("the bound holds by construction, not by typical sizes (ac-31)", () => 
       );
       const out = render(SPEC_538_PROSE, SPEC_538_DECISIONS, tasks);
       expect(out.length, `${n} tasks rendered ${out.length} chars`).toBeLessThanOrEqual(
-        RESPONSE_BODY_BUDGET_CHARS,
+        RESPONSE_BUDGET_CHARS,
       );
     }
   });

--- a/packages/server/src/mcp/response-budget.test.ts
+++ b/packages/server/src/mcp/response-budget.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
-  RESPONSE_BODY_BUDGET_CHARS,
+  RESPONSE_BUDGET_CHARS,
   STRUCTURAL_RESERVE_CHARS,
   MIN_EXCERPT_CHARS,
   allocateResponseBudget,
@@ -41,8 +41,8 @@ describe("allocateResponseBudget — the total is configured, the per-decision l
     });
 
     // Both are bounded by the SAME total…
-    expect(seven.budget).toBe(RESPONSE_BODY_BUDGET_CHARS);
-    expect(thirty.budget).toBe(RESPONSE_BODY_BUDGET_CHARS);
+    expect(seven.budget).toBe(RESPONSE_BUDGET_CHARS);
+    expect(thirty.budget).toBe(RESPONSE_BUDGET_CHARS);
 
     // …and the count is absorbed by the excerpt length, not by the total.
     expect(thirty.perDecisionChars).toBeLessThan(seven.perDecisionChars);
@@ -116,7 +116,7 @@ describe("allocateResponseBudget — signals come off the top and are never rati
     // is unchanged — signals and envelope come off the top before anything
     // negotiable — but the arithmetic now has three terms, not two.
     expect(a.remainingAfterFixed).toBe(
-      RESPONSE_BODY_BUDGET_CHARS - 1_200 - SMALL.envelopeChars - STRUCTURAL_RESERVE_CHARS,
+      RESPONSE_BUDGET_CHARS - 1_200 - SMALL.envelopeChars - STRUCTURAL_RESERVE_CHARS,
     );
   });
 
@@ -137,7 +137,7 @@ describe("allocateResponseBudget — signals come off the top and are never rati
     // after the fixed costs is exactly budget − signals − envelope, whatever
     // the content does.
     expect(a.remainingAfterFixed).toBe(
-      RESPONSE_BODY_BUDGET_CHARS -
+      RESPONSE_BUDGET_CHARS -
         SMALL.signalsChars -
         SMALL.envelopeChars -
         STRUCTURAL_RESERVE_CHARS,
@@ -184,7 +184,7 @@ describe("the budget is one constant, from one place (ac-10)", () => {
       -50_000,
     ]) {
       expect(effectiveBudget(bad as number | undefined)).toBe(
-        RESPONSE_BODY_BUDGET_CHARS,
+        RESPONSE_BUDGET_CHARS,
       );
     }
   });
@@ -194,8 +194,8 @@ describe("the budget is one constant, from one place (ac-10)", () => {
     // Only the client knows its own cap, so a smaller one is honoured…
     expect(effectiveBudget(10_000)).toBe(10_000);
     // …but an override cannot be used to escape the ceiling.
-    expect(effectiveBudget(RESPONSE_BODY_BUDGET_CHARS * 10)).toBe(
-      RESPONSE_BODY_BUDGET_CHARS,
+    expect(effectiveBudget(RESPONSE_BUDGET_CHARS * 10)).toBe(
+      RESPONSE_BUDGET_CHARS,
     );
   });
 });

--- a/packages/server/src/mcp/response-budget.ts
+++ b/packages/server/src/mcp/response-budget.ts
@@ -14,12 +14,17 @@
 // ONE CONSTANT, ONE FILE — the shape spec-203 dec-3 established with
 // `footer-delimiter.ts`. Everything else in this module is derived from it.
 //
-// NAMING, and it is load-bearing (dec-7, ac-28): the budget bounds the response
-// BODY, not the whole response. The envelope is attached after the body is
-// rendered and cannot be measured from inside it, so it is accounted for by how
-// this number was chosen. A reader who budgets a whole response against it would
-// be over by up to 23k — which is exactly the class of defect ac-6 exists to
-// clean up elsewhere in this Spec.
+// NAMING, and it is load-bearing — INVERTED by t-15 (ac-28 amended). The budget
+// bounds the WHOLE response: the guidance envelope is a fixed cost inside it, not
+// a term beyond it.
+//
+// It was `RESPONSE_BODY_BUDGET_CHARS` under dec-7 option (d), which made it a
+// body-only budget and left the envelope in headroom between it and the client's
+// cap. That option's arithmetic premise was false against the client's real
+// ceiling (dec-7's amendment), and dec-9 replaced the inferred cap with a
+// DECLARED one. With the envelope now counted per response, a name saying BODY
+// would understate what the number covers — the same trap in the other
+// direction, and the class of defect ac-6 exists to clean up.
 
 /**
  * MEASURED, 2026-08-24 (t-6). Two independent bounds, and the window between
@@ -31,7 +36,13 @@
  *
  *   reads that ARRIVE INTACT   n=18   body max 33,501   p90 31,358   median 13,044
  *   envelopes observed         n=18   max 22,215        median 12,052
- *   smallest read the client REFUSED  70,794            ← upper bound on the cap
+ *   smallest read the client REFUSED  70,794            ← an upper bound on
+ *                                                       REFUSALS, never the cap
+ *                                                       itself (t-12 corrected
+ *                                                       this: the real default
+ *                                                       is 50,000, READ from the
+ *                                                       client, and the operative
+ *                                                       ceiling is now DECLARED)
  *
  * There is a clean gap: everything observed working is ≤ 47,561 in total,
  * everything observed failing is ≥ 70,794. Nothing lands between.
@@ -40,31 +51,45 @@
  * body that currently arrives is 33,501, so anything at or below that would
  * reshape a response that works fine now. 40,000 clears it by 19%.
  *
- * UPPER BOUND — ac-27, body + worst-case envelope must stay under the cap.
- * 40,000 + 23,244 = 63,244, which is 7,550 under the smallest refusal observed.
- * Both bounds are asserted in the suite, not claimed here.
+ * UPPER BOUND — ac-27. The budget is now INCLUSIVE of the envelope, so the bound
+ * is no longer additive: what must fit is one full budget, weighed the way the
+ * client weighs it. 58,000 x 1.013 (the JSON-serialisation overhead) = 58,754,
+ * which is 6,246 under the 70,000 this server DECLARES less its 5,000 margin.
  *
- * The viable window is therefore roughly 33,501 … 42,550. Move within it freely;
- * leaving it reds a test.
+ * Adding MEASURED_ENVELOPE_MAX_CHARS on top would now DOUBLE-COUNT it. The old
+ * additive form was checked against 70,794 — a refusal sample 41.6% above the
+ * client's real default — so it held by luck rather than by arithmetic.
+ *
+ * WHY 58,000 AND NOT 40,000 (t-15). Counting the envelope spends 7,150 (done) to
+ * 17,482 (specify) of the budget before any content. At 40,000 that left ~28,000
+ * of content against ~36,100 before, and it red ac-29 and both ac-30 assertions —
+ * two renders collapsed to an identical 1,469. 58,000 keeps content at or above
+ * the old figure in EVERY phase (36,618 at specify, 46,950 at done), which is
+ * what ac-26 requires. Both bounds are asserted in the suite, not claimed here.
+ *
+ * The viable window is roughly 35,501 … 64,165. Move within it freely; leaving it
+ * reds a test.
  *
  * CAVEAT ON THE SAMPLE: 18 reads, from one developer's sessions, biased toward
  * the Specs that developer worked on. The margins above are what absorb that.
  *
  * What is already known and bounds it:
- *   - The client's cap is BELOW 71,292 chars. That figure is the smallest
- *     payload observed to spill, so it is an upper bound on the cap, not the
- *     cap. The real value is lower, belongs to the client, and is
- *     user-configurable — so this must stay a margin, never an equality.
- *   - Characters are a proxy for tokens. The client counts tokens; we can only
- *     cheaply count characters, and the ratio moves with content (tables and
- *     code tokenize worse than prose). The margin absorbs that too.
+ *   - The client's DEFAULT threshold is 50,000, read from the client itself, not
+ *     inferred from a refusal (CLIENT_DEFAULT_CEILING_CHARS). This server no
+ *     longer depends on it: it DECLARES its own ceiling per dec-9.
+ *   - Characters are what the client compares, NOT tokens — corrected in t-12.
+ *     The threshold is `l.length` on the JSON-serialised content array. The
+ *     earlier "characters are a proxy for tokens" caveat was wrong about the
+ *     mechanism; what IS true is that the serialised form runs ~1.3% longer than
+ *     the rendered text (688 chars on a 52,559-char payload), because newlines
+ *     are escaped. The margin absorbs that.
  *
- * NOT an environment variable, deliberately (ac-10). The cap is a property of
+ * NOT an environment variable, deliberately (ac-10). The ceiling is a property of
  * the CLIENT, not of the deployment: one server answers clients with different
- * caps, so a per-environment value would look like tuning while being wrong for
- * half the callers. And we never read the client's cap — we do not know it.
+ * thresholds, so a per-environment value would look like tuning while being wrong
+ * for half the callers.
  */
-export const RESPONSE_BODY_BUDGET_CHARS = 40_000;
+export const RESPONSE_BUDGET_CHARS = 58_000;
 
 /**
  * The worst-case guidance envelope, measured by decomposing a real payload:
@@ -72,18 +97,104 @@ export const RESPONSE_BODY_BUDGET_CHARS = 40_000;
  * envelope observed independently in transcripts is 22,215, which corroborates
  * it from the other direction.
  *
- * This is NOT subtracted per response — dec-7 option (d): the body budget is
- * already net of it, and this constant exists so that fact is checkable rather
- * than asserted in prose.
+ * NOT the per-response reserve — t-15 computes that from the phase instead, which
+ * is why this stays a reference bound rather than a subtrahend. dec-7 option (d)
+ * rejected reserving this figure flat on every call, and that rejection still
+ * holds: at ~23,244 against a prod mean of 3,174 and p90 of 14,393, it would pull
+ * the majority of reads into tier 2/3 and collide with ac-26.
+ *
+ * Its remaining job is to bound the seat: if a real composed envelope ever exceeds
+ * it, the per-phase drift test reds.
  */
 export const MEASURED_ENVELOPE_MAX_CHARS = 23_244;
 
 /**
- * An upper bound on the MCP client's cap — the smallest response it was observed
- * to refuse. Not the cap: the real value is lower, belongs to the client, and is
- * user-configurable. Every budget here is a margin under this, never an equality.
+ * What the render CANNOT compute about its own envelope, reserved on top of what
+ * it can — t-15.
+ *
+ * `formatFullDocState` holds the inputs to the envelope's two dominant terms: the
+ * phase guidance (`toNudge` over BASE_SCAFFOLD with this call's `tool` and
+ * `orgBlocks`) and the handoff (`nudge.fullHandoff` when the seat is delivering
+ * one, else the compressed essence). Measured per phase, `toNudge` alone spans
+ * 4,150 (done) to 13,174 (specify).
+ *
+ * It does NOT hold what `composeGuidanceEnvelope` adds after the handler returns:
+ * the FOOTER_DELIMITER, the one-line dynamic state, the per-tool steer
+ * (STEER_BY_TOOL), spec-249's status overview, spec-521 dec-5's supersession lead
+ * line, and whatever the seat gains next.
+ *
+ * This constant stands in for exactly those, and [per std-50 cl-4] it errs in ONE
+ * direction — it OVER-counts, so a response reserves more than the seat will
+ * spend rather than less. The component it guesses about is named above, and the
+ * direction does not vary with the phase, the tool or the Org.
+ *
+ * A CONSTRAINT, not a measurement [per std-50 cl-8]: the seat's additions are
+ * bounded by this number, and the per-phase drift test is what enforces it.
  */
-export const MEASURED_CAP_BOUND_CHARS = 70_794;
+export const ENVELOPE_SEAT_ALLOWANCE_CHARS = 3_000;
+
+/**
+ * What this server DECLARES to its MCP clients as the largest result they should
+ * accept before spilling it to a file — spec-538 dec-9, option (c).
+ *
+ * ## Why a declaration at all
+ *
+ * The spill threshold belongs to the client, and this server cannot interrogate
+ * it. [per std-50 cl-2] a value a consumer cannot read is one its owner declares,
+ * and [per std-50 cl-3] substituting a default for an absent declaration is the
+ * behaviour that fails. The original `MEASURED_CAP_BOUND_CHARS = 70,794` (retired in t-12) was
+ * exactly that substituted default — inferred from the smallest refusal ever
+ * observed, and 41.6% above the client's real hardcoded 50,000 (issue-4).
+ * Declaring replaces a guess ABOUT the client with a statement TO it.
+ *
+ * Advertised in each tool's `_meta` as `anthropic/maxResultSizeChars`. Verified
+ * against the client (`2.1.260`): with `_meta` present the effective ceiling is
+ * `Math.min(declared, 500_000)` and the hardcoded default no longer applies.
+ *
+ * ## Why 70,000 and not 500,000
+ *
+ * The maximum the client would honour is 500,000, and declaring it would be the
+ * wrong move: the ceiling exists to protect the reading agent's CONTEXT WINDOW,
+ * which is the interest this whole Spec serves. A payload that reaches the
+ * context and floods it is not an improvement on one that reaches a file.
+ *
+ * 70,000 leaves a margin that the envelope's variance justifies. The worst case
+ * a response can present is a full body budget alongside the largest envelope
+ * ever measured — 40,000 + 23,244 = 63,244 — and 65,000 would have cleared that
+ * by only 1,756 chars. At 70,000 the same worst case clears by 6,756, which is
+ * what lets REQUIRED_CAP_MARGIN stay at 5,000 instead of being shaved to make an
+ * assertion pass. [per std-50 cl-6] the reason is written here rather than left
+ * to "it works"; [per cl-8] this is a CONSTRAINT the server states, not a
+ * measurement of anything.
+ *
+ * ## This is a bridge, not a landmark
+ *
+ * The envelope it pays for is 94% static boilerplate — 13,930 of 14,815 chars
+ * measured, re-sent on every call. When spec-510 turns that into a pointer after
+ * first sight, the reserve falls to ~4,000 and this constant should come back
+ * DOWN toward the client's own default. dec-9 sequences option (b) after this
+ * one precisely so it can. Anyone finding this number later should be asking
+ * whether spec-510 has landed, not raising it further.
+ */
+export const DECLARED_CLIENT_RESULT_CEILING_CHARS = 70_000;
+
+/**
+ * The client's DEFAULT spill threshold, READ from the client rather than inferred
+ * from its behaviour — spec-538 t-12, correcting issue-4.
+ *
+ * This constant was `MEASURED_CAP_BOUND_CHARS = 70_794`, documented as "the
+ * smallest response it was observed to refuse". That method cannot work: a
+ * refusal sample bounds refusals from ABOVE and never reaches the threshold
+ * [per std-50 cl-8 — a measurement of the present can falsify a reserve but
+ * never confirm it]. The real value, read from the client (`2.1.260`), is
+ * `eG = 50_000`, and 70,794 was 41.6% too high. A response of 53,247 chars was
+ * refused while every bound derived from 70,794 said it would arrive.
+ *
+ * It is kept — under a name that describes what it IS — because it is what
+ * applies if the `_meta` declaration below is ever dropped. It is NOT the
+ * operative ceiling: DECLARED_CLIENT_RESULT_CEILING_CHARS is.
+ */
+export const CLIENT_DEFAULT_CEILING_CHARS = 50_000;
 
 /**
  * The largest response BODY observed to arrive intact. The floor ac-26 puts
@@ -187,9 +298,9 @@ export interface BudgetAllocation {
  * unusable override cannot widen or disable the bound.
  */
 export function effectiveBudget(maxChars?: number): number {
-  if (typeof maxChars !== "number") return RESPONSE_BODY_BUDGET_CHARS;
-  if (!Number.isFinite(maxChars) || maxChars <= 0) return RESPONSE_BODY_BUDGET_CHARS;
-  return Math.min(maxChars, RESPONSE_BODY_BUDGET_CHARS);
+  if (typeof maxChars !== "number") return RESPONSE_BUDGET_CHARS;
+  if (!Number.isFinite(maxChars) || maxChars <= 0) return RESPONSE_BUDGET_CHARS;
+  return Math.min(maxChars, RESPONSE_BUDGET_CHARS);
 }
 
 /**

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -20,6 +20,7 @@ import { listMemberships } from "../services/users.js";
 import { ArchivedDocError, NotFoundError, ValidationError } from "../types/errors.js";
 import { formatArchivedDocStub } from "../services/archived-docs.js";
 import { formatMemexList } from "./formatters.js";
+import { DECLARED_CLIENT_RESULT_CEILING_CHARS } from "./response-budget.js";
 import { listTopics } from "../services/guidance.js";
 import {
   McpAuthError,
@@ -554,6 +555,15 @@ export function createMcpServer(
         description: spec.description,
         inputSchema: z.looseObject(spec.schema as z.ZodRawShape),
         annotations: spec.annotations,
+        // spec-538 dec-9 option (c): declare the result ceiling instead of
+        // guessing at the client's. Uniform across every tool — this is a
+        // property of the transport, not a per-tool classification, which is why
+        // it is NOT a `toolManifest` field [per std-16: the manifest is the one
+        // source of the tool CONTRACT; `readOnlyHint` lives there because the
+        // mutate-coverage gate derives behaviour from it, and nothing here does].
+        _meta: {
+          "anthropic/maxResultSizeChars": DECLARED_CLIENT_RESULT_CEILING_CHARS,
+        },
       },
       handler,
     );


### PR DESCRIPTION
## The bound held by luck

`MEASURED_CAP_BOUND_CHARS = 70_794` was documented as *"the smallest response the client was observed to refuse"*. That method bounds refusals from **above** — it can never reach the threshold. The client's real default, read from the client itself, is **50,000**.

So a 53,247-char response was refused with **every asserted bound satisfied**, and `ac-27`'s headroom arithmetic (`40,000 + 23,244 = 63,244`) exceeded the true ceiling by 13,244. Filed as **issue-4**; the Spec went back from `verify` to `build`.

This was found by reading spec-538 through an MCP client — the read spilled to a file, on the Spec whose subject is reads that spill to files.

## What this PR does

**Declares the ceiling instead of inferring it** (dec-9 option c, t-12)

- `DECLARED_CLIENT_RESULT_CEILING_CHARS = 70_000`, advertised in every tool's `_meta` as `anthropic/maxResultSizeChars`
- `MEASURED_CAP_BOUND_CHARS` retired → `CLIENT_DEFAULT_CEILING_CHARS = 50_000`, named for what it is and corrected to the **read** value
- Uniform, and deliberately **not** a `toolManifest` field: `readOnlyHint` lives there because the mutate-coverage gate derives behaviour from it, and nothing derives from a transport size hint `[per std-16]`
- Not 500,000 — the ceiling protects the reading agent's context window, which is this Spec's whole interest. Not 65,000 — the worst case cleared it by only 1,756, which would have forced the margin to be shaved to pass

**Counts the envelope inside the budget** (t-15)

- `envelopeChars` was `0`. dec-7 called that *"correct, not a stopgap"* because the render *"does not know"* its envelope. Half right: it cannot measure the **composed** envelope, but it has held the **inputs** since spec-203 dec-2 — `toNudge` is pure and total, and `nudge` carries the tool, the Org blocks and the pre-resolved full handoff
- Computed **per response**, never a flat reservation. dec-7 rejected reserving the population maximum and that rejection still holds: 23,244 against a prod mean of 3,174 would pull the majority of reads into tier 2/3 and collide with `ac-26`
- `RESPONSE_BODY_BUDGET_CHARS` → `RESPONSE_BUDGET_CHARS`, **40,000 → 58,000**. It now bounds the whole response, so `ac-28`'s naming criterion is **inverted** and amended deliberately. 58,000 keeps the content allowance at or above its old figure in every phase (36,618 specify … 46,950 done), which is what `ac-26` requires

## Red before green, proven not claimed

The delivery test was red on pre-fix code — worst case **63,290** vs 48,000; a real near-budget render **58,560** vs 48,000; `envelopeChars: 0` present.

Where new pure code had no observable red phase, the implementation was mutated instead:

| mutation | result |
|---|---|
| flat 23,244 envelope reserve | `ac-34` reds — `done 32,188` vs `specify 32,194`, phases collapse 6 chars apart |
| allowance → 1 | drift guard reds with the real figure: `draft: composed 11,858, known 11,494, seat +364` |

## Two of this Spec's own guards were passing for the wrong reason

- The delivery test's first fixture used spec-472's 85,580 chars of prose and **passed uselessly** — that much prose trips tier 3, bodies drop, and the body collapses to a map that fits alongside any envelope. That is `ac-4`'s flaw (s-5 §3) reproduced in the test written to fix it.
- A source scan looked for `envelopeChars: 0`; once t-15 removed that string, `indexOf` returned −1, the slice widened to the whole file, and the assertion matched prose elsewhere.

Both replaced by behavioural assertions with fixture-reality guards.

## Scope

No UI, route, auth, tenancy, RLS or schema change. No migration, no flags — every constant is in source (`ac-10`: the ceiling belongs to the client, not the deployment).

## Test plan

- [x] `make check` clean
- [x] `tsc` clean
- [x] full server suite — **714 files / 6,607 tests / 0 failures**
- [x] `test:unit` — 229 files / 2,109 tests green
- [x] `ac-33` and `ac-34` verified on the board; two orphaned identifiers from renames retired `[per std-48 cl-7]`
- [x] `ac-26`, `ac-27`, `ac-28`, `ac-29`, `ac-30` green — no read that works today changed shape
- [ ] **t-14 — live verification, needs this deployed.** dec-9 asserts a state of production and `[per std-50 cl-7]` an unverified resolution is not resolved: a `tools/list` against int must show the `_meta` on the wire, then the founding call re-run on int and prod with the read proven to arrive in context rather than as a spill path
- [ ] no Playwright journey — this alters no user-facing flow (`std-28`); `make e2e-cold` is locally blocked by a pg14/pgvector split, so CI's per-PR run is the gate

## Reviewer notes

- **The declaration only takes effect for clients that reconnect** and re-read `tools/list`. An already-connected session keeps the ceiling it was given.
- **Do not revert the `_meta` without also reverting the 58,000 budget** — without the declaration the additive worst case exceeds the client default again.
- **`70,000` is a bridge, not a landmark.** The envelope it pays for is 94% static boilerplate (13,930 of 14,815 measured), re-sent every call. When spec-510 makes that a pointer, the reserve falls to ~4,000 and this number should come **down**.
- **One claim recorded as indicated, not verified:** `h3e` consults a per-tool client-settings lookup *before* the declared value, which would mean a user's explicit override still beats ours. The identifier is minified and could not be confirmed, so it is on dec-9 as unverified and deliberately absent from source comments.

Full session record: **qa_report-3** on spec-538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
