### PR TITLE
test(spec-538): assert the ceiling declaration over the tool list, not the source text

### DIFF
--- a/packages/server/src/mcp/response-budget.delivery.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.delivery.spec-538.test.ts
@@ -26,7 +26,10 @@ import {
   CLIENT_DEFAULT_CEILING_CHARS,
 } from "./response-budget.js";
 import { formatFullDocState } from "./formatters.js";
+import { createMcpServer } from "./tools.js";
 import type { Doc, DocSection } from "../db/schema.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-00000000beef";
 
 const AC = (n: number) =>
   `mindset-prod/memex-building-itself/specs/spec-538/acs/ac-${n}`;
@@ -56,6 +59,30 @@ const AC = (n: number) =>
  */
 const REQUIRED_CEILING_MARGIN = 2_000;
 
+/**
+ * Tools that do NOT carry the `_meta` declaration on the wire — issue-5.
+ *
+ * `list_memexes` is registered through the positional
+ * `server.tool(name, description, shape, annotations, handler)` overload
+ * (`tools.ts`, "MCP-only: Memex discovery"), which has no `_meta` parameter at
+ * all. The other 70 tools go through the `registerTool` loop that attaches it.
+ * So the declaration is NOT uniform, whatever the comment at the registration
+ * site says, and this list is the honest name for that.
+ *
+ * Consequence today: nothing. `list_memexes` returns a short membership list
+ * plus the guidance topic index, nowhere near the client's 50,000 default. It
+ * is pinned rather than fixed because the fix is a separate call (issue-5) —
+ * NOT because an exemption is the right shape.
+ *
+ * This is debt with an expiry, not a category. When issue-5 lands, this array
+ * empties and the assertion below reds until the entry is deleted.
+ *
+ * Found by t-14's wire read against prod, 2026-09-05: 71 tools in
+ * `tools/list`, 70 carrying `anthropic/maxResultSizeChars: 70000`. The
+ * source-text check above was green throughout — a grep cannot see a wire.
+ */
+const KNOWN_UNDECLARED_TOOLS: readonly string[] = ["list_memexes"];
+
 describe("the declaration replaces the guess, and it is the operative ceiling", () => {
   it("declares more room than the client's default, and far less than the maximum", () => {
     tagAc(AC(33));
@@ -68,16 +95,58 @@ describe("the declaration replaces the guess, and it is the operative ceiling", 
     expect(DECLARED_CLIENT_RESULT_CEILING_CHARS).toBeLessThanOrEqual(100_000);
   });
 
-  it("every MCP tool advertises it — the declaration is uniform, not per-tool", () => {
+  it("the declaration is written against the constant, not inlined", () => {
     tagAc(AC(33));
-    // A property of the transport, not a tool classification: one number for the
-    // whole surface, which is why it is not a toolManifest field [per std-16].
+    // Narrow by design: this reads SOURCE TEXT, so it can only speak about how
+    // the value is spelled — never about what any tool actually carries. It used
+    // to be titled "every MCP tool advertises it", which is a claim about the
+    // WIRE that a grep cannot make; the test below makes that one. Kept because
+    // it still guards something real: the ceiling must reference the owned
+    // constant so [per std-50 cl-6] the reason stays attached to the number.
     const src = readFileSync(
       fileURLToPath(new URL("./tools.ts", import.meta.url)),
       "utf8",
     );
     expect(src).toContain('"anthropic/maxResultSizeChars"');
     expect(src).toContain("DECLARED_CLIENT_RESULT_CEILING_CHARS");
+  });
+
+  it("every registered tool carries the declaration — asserted over the tool list, not the source", () => {
+    tagAc(AC(33));
+    const server = createMcpServer(TEST_USER_ID);
+    const registered = (
+      server as unknown as {
+        _registeredTools: Record<string, { _meta?: Record<string, unknown> }>;
+      }
+    )._registeredTools;
+
+    // Sanity on the instrument before asserting with it: if the SDK ever stops
+    // exposing `_meta` here, EVERY tool looks undeclared and the failure would
+    // read as a catastrophic regression instead of a harness break. Assert the
+    // harness can see a declaration at all before trusting the ones it can't.
+    expect(Object.keys(registered).length).toBeGreaterThan(1);
+    expect(
+      Object.values(registered).filter(
+        (t) =>
+          t._meta?.["anthropic/maxResultSizeChars"] ===
+          DECLARED_CLIENT_RESULT_CEILING_CHARS,
+      ).length,
+    ).toBeGreaterThan(1);
+
+    const undeclared = Object.entries(registered)
+      .filter(
+        ([, tool]) =>
+          tool._meta?.["anthropic/maxResultSizeChars"] !==
+          DECLARED_CLIENT_RESULT_CEILING_CHARS,
+      )
+      .map(([name]) => name)
+      .sort();
+
+    // Exact equality in BOTH directions, deliberately. A new tool that misses
+    // the declaration reds this; so does fixing `list_memexes` without deleting
+    // the line below. A known gap that can silently become permanent is how the
+    // gap got here.
+    expect(undeclared).toEqual(KNOWN_UNDECLARED_TOOLS);
   });
 });
 


### PR DESCRIPTION
## Why

spec-538 dec-9 has the server **declare** its result ceiling to the MCP client via `anthropic/maxResultSizeChars` in each tool's `_meta`. The guard that was supposed to protect that declaration was titled:

> `every MCP tool advertises it — the declaration is uniform, not per-tool`

and it did this:

```ts
const src = readFileSync(new URL("./tools.ts", import.meta.url), "utf8");
expect(src).toContain('"anthropic/maxResultSizeChars"');
expect(src).toContain("DECLARED_CLIENT_RESULT_CEILING_CHARS");
```

It reads **source text**. It stays green if `_meta` is stripped from *every* tool, so long as either string survives anywhere in the file — in a comment, for instance. It could never fail on the claim in its own title. It is tagged **ac-33**, so ac-33 has been green on a check that cannot see its subject.

Verifying spec-538 t-14 against prod found it green while the claim was false: `tools/list` on `https://memex.ai/mcp` returns **71 tools, 70 carrying the declaration**. `list_memexes` is registered through the positional `server.tool(name, description, shape, annotations, handler)` overload, which has no `_meta` parameter at all, so it never got one. Filed as **spec-538 issue-5**.

## What changed

One test file. No production code.

- **New assertion over the registered tool list**, using the harness `__regression__/tools-coverage.regression.test.ts` already uses (`createMcpServer(...)` → `_registeredTools`). Offline, no network, no DB dependency of its own.
- **The known gap is pinned**, not hidden: `KNOWN_UNDECLARED_TOOLS: readonly string[] = ["list_memexes"]`, with the cause, the (nil) impact and the issue ref written beside it.
- **Exact equality in both directions.** A new tool that misses the declaration reds this; so does *fixing* `list_memexes` without deleting the entry. The pin cannot ossify into a permanent exemption.
- **Instrument check before the assertion.** If the SDK ever stops exposing `_meta` there, every tool would look undeclared — that would read as a catastrophic regression rather than a broken harness. The test asserts it can see at least one declaration before trusting the set it cannot.
- **The old grep is kept, retitled** to what it can actually prove: the ceiling is spelled as the owned constant rather than inlined [per std-50 cl-6].

`list_memexes` itself is deliberately **not** fixed here — that is issue-5, scoped separately.

## The loop, in the order std-52 asks for

1. **RED, before the pin** — `AssertionError: expected [ 'list_memexes' ] to deeply equal []`. That single run proves three things at once: the SDK does expose `_meta` on `_registeredTools` (the other 70 passed), the test reads the tool list and not the source, and `list_memexes` is the only gap.
2. **GREEN with the gap pinned** — 8/8.
3. **RED in the other direction**, proven by temporarily listing a declared tool as exempt — `expected [ 'list_memexes' ] to deeply equal [ 'get_doc', 'list_memexes' ]`.

## Test plan

- [x] `vitest run src/mcp/response-budget.delivery.spec-538.test.ts` — 8/8
- [x] `vitest run src/mcp src/__regression__` — 2103 passed. One failure: `spec-129-ci-emission-key.regression.test.ts`, which asserts `MEMEX_EMIT_KEY` is set. Unset on the dev machine; different directory; nothing imports the changed file. Environmental and pre-existing.
- [x] `tsc --noEmit` clean
- [x] `make check` (offline guard battery) passed
- [x] `.husky/pre-push` green — 229 files, 2110 passed, 5 skipped
- [ ] **CI re-emits ac-33.** Local runs had emission enabled but keyless (401, silently swallowed), so the new assertion has never emitted. ac-33 is currently green *on the old source-scan*. This PR's CI run is what makes it green on a check that can actually fail.
- [ ] N/A — no e2e journey [per std-28]: test-only, no user-facing flow altered.

## Licence

Fair-code (no `.ee.` marker) — a test beside the code it guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)