### PR TITLE
fix(spec-538): register list_memexes through registerTool so the ceiling declaration is uniform on the wire

### DIFF
--- a/packages/server/src/mcp/response-budget.delivery.spec-538.test.ts
+++ b/packages/server/src/mcp/response-budget.delivery.spec-538.test.ts
@@ -81,7 +81,21 @@ const REQUIRED_CEILING_MARGIN = 2_000;
  * `tools/list`, 70 carrying `anthropic/maxResultSizeChars: 70000`. The
  * source-text check above was green throughout — a grep cannot see a wire.
  */
-const KNOWN_UNDECLARED_TOOLS: readonly string[] = ["list_memexes"];
+/**
+ * Tools that legitimately ship no ceiling declaration. EMPTY, and it should stay
+ * that way — spec-538 issue-5 closed the one entry it ever held.
+ *
+ * `list_memexes` was registered through the positional
+ * `server.tool(name, description, shape, annotations, handler)` overload, which
+ * has no `_meta` parameter, so it shipped `_meta: null` while the other 70 tools
+ * carried the declaration. It is on `registerTool` now.
+ *
+ * Kept as a named empty list rather than deleted: the assertion below is an exact
+ * equality, so a tool added through the positional overload reds this test and
+ * whoever hits it needs somewhere to record a deliberate exemption — with its
+ * reason [per std-50 cl-6] — rather than weakening the assertion to a subset check.
+ */
+const KNOWN_UNDECLARED_TOOLS: readonly string[] = [];
 
 describe("the declaration replaces the guess, and it is the operative ceiling", () => {
   it("declares more room than the client's default, and far less than the maximum", () => {

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -306,11 +306,29 @@ export function createMcpServer(
   };
 
   // ── MCP-only: Memex discovery ──────────────────────────────
-  server.tool(
+  //
+  // spec-538 issue-5: this was the POSITIONAL `server.tool(name, description,
+  // shape, annotations, handler)` overload, which has no `_meta` parameter — so
+  // it shipped `_meta: null` while the other 70 tools carried the declared
+  // ceiling, and the comment at the catalogue's registration site claiming the
+  // declaration was uniform was false on the wire. Registered through
+  // `registerTool` now, carrying the same `_meta` as every other tool.
+  //
+  // A tool added through the positional overload silently inherits the client's
+  // own default ceiling. The guard in `response-budget.delivery.spec-538.test.ts`
+  // asserts over the server's registered tool list (not the source text) with an
+  // exact equality, so the next one reds the suite instead of going unnoticed.
+  server.registerTool(
     "list_memexes",
-    "List the Memexes this user is a member of, grouped by namespace. Identifiers come back in `<namespace>/<memex>` form (e.g. `mindset/website-rewrite`) — the same string scoped tools expect as their `memex` argument. Each entry carries `kind` (personal or team). Call this at the START of any session and present the list to the user as a chooser before any scoped mutation — do not auto-pick the only / personal one.",
-    {},
-    { title: "List Memexes", readOnlyHint: true, destructiveHint: false },
+    {
+      description:
+        "List the Memexes this user is a member of, grouped by namespace. Identifiers come back in `<namespace>/<memex>` form (e.g. `mindset/website-rewrite`) — the same string scoped tools expect as their `memex` argument. Each entry carries `kind` (personal or team). Call this at the START of any session and present the list to the user as a chooser before any scoped mutation — do not auto-pick the only / personal one.",
+      inputSchema: {},
+      annotations: { title: "List Memexes", readOnlyHint: true, destructiveHint: false },
+      _meta: {
+        "anthropic/maxResultSizeChars": DECLARED_CLIENT_RESULT_CEILING_CHARS,
+      },
+    },
     withTelemetry("list_memexes", async () => {
       const memberships = await listMemberships(userId);
       const filtered = filterMembershipsForOrgScope(memberships, orgFilter);
@@ -556,11 +574,18 @@ export function createMcpServer(
         inputSchema: z.looseObject(spec.schema as z.ZodRawShape),
         annotations: spec.annotations,
         // spec-538 dec-9 option (c): declare the result ceiling instead of
-        // guessing at the client's. Uniform across every tool — this is a
-        // property of the transport, not a per-tool classification, which is why
-        // it is NOT a `toolManifest` field [per std-16: the manifest is the one
-        // source of the tool CONTRACT; `readOnlyHint` lives there because the
-        // mutate-coverage gate derives behaviour from it, and nothing here does].
+        // guessing at the client's. A property of the transport, not a per-tool
+        // classification, which is why it is NOT a `toolManifest` field [per
+        // std-16: the manifest is the one source of the tool CONTRACT;
+        // `readOnlyHint` lives there because the mutate-coverage gate derives
+        // behaviour from it, and nothing here does].
+        //
+        // This comment used to claim the declaration was "uniform across every
+        // tool". It was not: `list_memexes` is registered outside this loop and
+        // shipped `_meta: null` for a day (issue-5) while the claim sat here
+        // unchallenged, because the guard that was supposed to check it read
+        // source text instead of the tool list. Uniformity is now asserted over
+        // the server's registered tools, so it is a fact rather than a comment.
         _meta: {
           "anthropic/maxResultSizeChars": DECLARED_CLIENT_RESULT_CEILING_CHARS,
         },


### PR DESCRIPTION
Closes the open half of **issue-5**. PR #687 fixed the *guard*; this fixes the *tool*.

## The gap

`tools/list` on prod: **71 tools, 70 declared, `list_memexes` shipping `_meta: null`** — while the comment at the catalogue registration site claimed the declaration was "uniform across every tool".

`list_memexes` is registered outside the shared-catalogue loop, through the positional `server.tool(name, description, shape, annotations, handler)` overload, **which has no `_meta` parameter**. Moved onto `registerTool` with the same `_meta` as every other tool.

## Why the original guard missed it — worth reading, it was mine

It read `tools.ts` as **source text** and asserted two strings appeared somewhere in the file. It would have stayed green with `_meta` stripped from every tool, as long as either string survived in a comment. It was tagged `ac-33`, so **ac-33 was green on a check that could not see its subject** — a claim about the runtime answered with a source read (`std-52`).

#687 replaced it with an assertion over the server's registered tool list and pinned the gap. This PR empties the pin.

## The pin cannot ossify, and that is the point

The assertion is an **exact equality**, so fixing the tool without removing the pin reds the suite. Observed before removing it:

```
AssertionError: expected [] to deeply equal [ 'list_memexes' ]
```

`KNOWN_UNDECLARED_TOOLS` is kept as a **named empty array** rather than deleted: the next tool registered through the positional overload reds this test, and whoever hits it needs somewhere to record a deliberate exemption with its reason `[per std-50 cl-6]` — rather than reaching for a subset check and quietly widening the hole.

## Test plan

- [x] RED observed with the fix in and the pin still present (above)
- [x] GREEN after emptying the pin — 8/8 on the delivery file
- [x] `make check` clean, `tsc` clean
- [x] full server suite **713 files / 0 failures**
- [x] ac-33 emissions confirmed landing (a first run was silently rejected on an expired key — re-run on a fresh one, zero rejections)

## Scope

Two files. No behaviour change for callers: same tool name, same description, same annotations, same handler, same empty input shape. No UI, auth, tenancy or schema change.

Impact was nil in practice — `list_memexes` returns a short membership list plus the topic index, nowhere near any ceiling. The reason to fix it is that the next tool added through that overload silently inherits the client's own default, and now the guard says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
