### PR TITLE
fix(spec-550): the standards readout declares which ranker scored it, and stops calling a rank a relevance

### DIFF
--- a/packages/server/src/__regression__/spec-550-fair-code.static-scan.regression.test.ts
+++ b/packages/server/src/__regression__/spec-550-fair-code.static-scan.regression.test.ts
@@ -1,0 +1,41 @@
+// spec-550 dec-5 (ac-9) — this Spec is fair-code (Sustainable Use License), NOT
+// Enterprise Edition. The licence marker in this repo IS the file path, so the guard is
+// a scan of the paths this Spec touched. Mirrors spec-500 / spec-545 and shares their
+// predicate (./licence-marker.ts) rather than restating it — two definitions that drift
+// would disagree about something with legal consequences [per std-51].
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { eeMarkedAmong } from "./licence-marker.js";
+
+const AC_9 = "mindset-prod/memex-building-itself/specs/spec-550/acs/ac-9";
+
+const REPO_ROOT = join(__dirname, "../../../..");
+
+// Every file spec-550 introduces or edits, repo-relative. All must be fair-code.
+const SPEC_550_FILES = [
+  "packages/server/src/services/facet-routing.ts",
+  "packages/server/src/services/facet-routing.integration.test.ts",
+  "packages/server/src/services/facet-routing-readout.spec-550.test.ts",
+  "packages/server/src/services/facet-rerank.ts",
+  "packages/server/src/__regression__/spec-550-fair-code.static-scan.regression.test.ts",
+  "packages/server/src/__regression__/spec-550-readout-single-author.regression.test.ts",
+];
+
+describe("spec-550 is fair-code — no EE markers (ac-9)", () => {
+  it("every spec-550 file exists and carries no .ee. / .ee marker", () => {
+    tagAc(AC_9);
+
+    // Existence first: this is what catches a later MOVE across the licence line.
+    const missing = SPEC_550_FILES.filter((f) => !existsSync(join(REPO_ROOT, f)));
+    expect(missing, `spec-550 files not found (moved or renamed?): ${missing.join(", ")}`).toEqual([]);
+
+    const eeMarked = eeMarkedAmong(SPEC_550_FILES);
+    expect(
+      eeMarked,
+      `spec-550 is fair-code (dec-5), but these paths are EE-marked: ${eeMarked.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/server/src/__regression__/spec-550-readout-single-author.regression.test.ts
+++ b/packages/server/src/__regression__/spec-550-readout-single-author.regression.test.ts
@@ -1,0 +1,103 @@
+// spec-550 dec-3 (ac-8) — the routed-standards readout has exactly ONE author.
+//
+// dec-3 kept the ranker declaration inline in `formatRoutedStandards` rather than moving
+// one sentence into scaffold-data.ts, so a single rendered string keeps a single author.
+// That property is only worth having if something holds it: a later tidy-up that lifts
+// half the readout into the Scaffold would produce exactly the split dec-3 rejected, and
+// nothing in the tree today would notice.
+//
+// SCOPE — read this before widening it. This guard protects spec-550's own property. It
+// is NOT the fix for the pre-existing std-15 question (cl-68 confines tool-response
+// footer prose to `composeGuidanceEnvelope`, and this readout is authored in a service,
+// which predates that carve-out). That is flagged as drift c-4 on std-15 §8 and belongs
+// to the standard's owner. If they rule the readout must move into the seat, this guard
+// moves with it.
+//
+// WHAT IT COVERS, stated plainly because a guard that cannot tell "clean" from "I did
+// not look" is not a check [per std-52]: it scans the two canonical prompt-prose homes
+// (packages/shared/src/scaffold-data.ts and packages/server/src/agent/phases/**.md) plus
+// the footer-prose seat (packages/server/src/agent/handlers/*.ts) for fragments of this
+// readout. It does NOT scan the rest of the repo, and it does not police prose that is
+// not the routed-standards readout.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const AC_8 = "mindset-prod/memex-building-itself/specs/spec-550/acs/ac-8";
+
+const REPO_ROOT = join(__dirname, "../../../..");
+const OWNER = join(REPO_ROOT, "packages/server/src/services/facet-routing.ts");
+
+// Distinctive fragments of the readout — long enough that an incidental match elsewhere
+// is not plausible, and spread across the heading, the dec-1 declaration, and an entry.
+const READOUT_FRAGMENTS = [
+  "govern this work",
+  "The implicated sections are inlined below",
+  "your facet ballot chose these candidates",
+];
+
+// The homes this prose must NOT reach. Each entry is [label, absolute path].
+function forbiddenSources(): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+
+  const scaffold = join(REPO_ROOT, "packages/shared/src/scaffold-data.ts");
+  out.push(["scaffold-data.ts", scaffold]);
+
+  const phasesDir = join(REPO_ROOT, "packages/server/src/agent/phases");
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith(".md")) out.push([`phases/${entry.name}`, p]);
+    }
+  };
+  if (existsSync(phasesDir)) walk(phasesDir);
+
+  const handlersDir = join(REPO_ROOT, "packages/server/src/agent/handlers");
+  for (const name of readdirSync(handlersDir).filter((n) => n.endsWith(".ts"))) {
+    out.push([`handlers/${name}`, join(handlersDir, name)]);
+  }
+
+  return out;
+}
+
+describe("spec-550 dec-3 — the routed-standards readout has one author (ac-8)", () => {
+  it("every fragment is composed in facet-routing.ts", () => {
+    tagAc(AC_8);
+    const owner = readFileSync(OWNER, "utf-8");
+    for (const fragment of READOUT_FRAGMENTS) {
+      expect(owner, `readout fragment missing from its owner: "${fragment}"`).toContain(fragment);
+    }
+  });
+
+  it("no fragment appears in scaffold-data.ts, a phases/*.md, or a footer handler", () => {
+    tagAc(AC_8);
+    const offenders: string[] = [];
+    for (const [label, path] of forbiddenSources()) {
+      const src = readFileSync(path, "utf-8");
+      for (const fragment of READOUT_FRAGMENTS) {
+        if (src.includes(fragment)) offenders.push(`${label}: "${fragment}"`);
+      }
+    }
+    expect(
+      offenders,
+      `readout prose found outside facet-routing.ts — dec-3 requires one author:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("the scan actually reads its corpus (guards the guard)", () => {
+    tagAc(AC_8);
+    // Without this, a wrong path or an empty read would make the assertion above
+    // vacuously green forever — clean and "I did not look" would be indistinguishable.
+    const sources = forbiddenSources();
+    expect(sources.length).toBeGreaterThan(5);
+    for (const [label, path] of sources) {
+      expect(readFileSync(path, "utf-8").length, `${label} read as empty`).toBeGreaterThan(0);
+    }
+    // And the fragments must be the kind of string that CAN be found by this scan —
+    // proven by finding them in the owner, which the same reader reaches.
+    expect(readFileSync(OWNER, "utf-8")).toContain(READOUT_FRAGMENTS[0]);
+  });
+});

--- a/packages/server/src/services/facet-rerank.ts
+++ b/packages/server/src/services/facet-rerank.ts
@@ -64,9 +64,17 @@ export class CohereReranker implements Reranker {
 }
 
 // The active reranker, or null when no credential is present (keyless baseline).
-// Reads COHERE_API_KEY — wired from the `cohere-api-key` Secret Manager secret on
-// Cloud Run (present on int; absent on prod until provisioned, and on self-host /
-// BYOK / free tier). Absence is a normal degraded state, never an error.
+// Reads COHERE_API_KEY — wired from the `cohere-api-key` Secret Manager secret wherever
+// the environment provides one. Absence (self-host, BYOK, free tier, or an environment
+// that has not provisioned the secret) is a normal degraded state, never an error: the
+// caller falls back to the keyless density baseline and the work is never blocked.
+//
+// This deliberately states no per-environment provisioning status. The previous version
+// claimed the secret was "absent on prod until provisioned" — false since 2026-06-27,
+// four days before this code shipped, and it cost spec-550 a live-config check to
+// disprove after it was read as evidence that the re-ranker never runs in prod. A
+// comment asserting deployment state is a claim about production that nothing verifies
+// [per std-50]; the environment is the authority on that, not this file.
 export function getReranker(): Reranker | null {
   const key = process.env.COHERE_API_KEY;
   if (!key) return null;

--- a/packages/server/src/services/facet-routing-readout.spec-550.test.ts
+++ b/packages/server/src/services/facet-routing-readout.spec-550.test.ts
@@ -1,0 +1,133 @@
+// spec-550 t-1 (dec-1) — the readout declares, PER CALL, which ranker actually scored it.
+//
+// Pure: `formatRoutedStandards` is a renderer over a `RoutingResult`, so these drive it
+// with hand-built results and need no DB. The degrade path itself (a re-ranker that
+// throws -> rankerModel falls back to KEYLESS_MODEL) is exercised against the real
+// `routeFacets` in facet-routing.integration.test.ts; here we assert what the caller is
+// TOLD for each of the two ranker states.
+
+import { describe, it, expect } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatRoutedStandards, KEYLESS_MODEL, type RoutingResult } from "./facet-routing.js";
+
+const SPEC = "mindset-prod/memex-building-itself/specs/spec-550";
+const AC = (n: number) => `${SPEC}/acs/ac-${n}`;
+
+const RERANKER = "cohere:rerank-v3.5";
+
+// One surfaced standard is enough — the declaration rides the heading, not the entries.
+function resultWith(rankerModel: string): RoutingResult {
+  const std = {
+    handle: "std-50",
+    title: "A value one component depends on and another owns is declared, never defaulted",
+    facetKeys: ["api-design"],
+    score: 1,
+    surfaced: true,
+    sections: [],
+  };
+  return { surfaced: [std], all: [std], k: 10, rankerModel };
+}
+
+// A realistic shape: a wide candidate field, only the top K surfaced. Scores descend
+// from the normalised 1.00 leader, exactly as routeFacets produces them.
+function wideResult(surfacedCount = 3, totalCount = 24): RoutingResult {
+  const mk = (i: number, surfaced: boolean) => ({
+    handle: `std-${i + 1}`,
+    title: `Standard number ${i + 1}`,
+    facetKeys: ["api-design"],
+    score: 1 - i / totalCount,
+    surfaced,
+    sections: [],
+  });
+  const all = Array.from({ length: totalCount }, (_, i) => mk(i, i < surfacedCount));
+  return { surfaced: all.slice(0, surfacedCount), all, k: 10, rankerModel: RERANKER };
+}
+
+describe("spec-550 dec-1 — the readout names the ranker that actually scored this call", () => {
+  it("names the ranker's model id (ac-4)", () => {
+    tagAc(AC(4));
+    expect(formatRoutedStandards(resultWith(RERANKER))).toContain(RERANKER);
+    expect(formatRoutedStandards(resultWith(KEYLESS_MODEL))).toContain(KEYLESS_MODEL);
+  });
+
+  it("states the ballot did NOT order the list when a re-ranker scored it (ac-5, ac-1)", () => {
+    tagAc(AC(5));
+    tagAc(AC(1));
+    const readout = formatRoutedStandards(resultWith(RERANKER));
+    // The caller must be able to learn the ballot's ranking contribution was dropped —
+    // naming the model alone (option A, rejected) would not carry this.
+    expect(readout).toMatch(/did not order/i);
+    expect(readout).toMatch(/ballot/i);
+  });
+
+  it("states the ballot DID order the list when the keyless baseline scored it (ac-5, ac-1)", () => {
+    tagAc(AC(5));
+    tagAc(AC(1));
+    const readout = formatRoutedStandards(resultWith(KEYLESS_MODEL));
+    expect(readout).toMatch(/ordered them/i);
+    expect(readout).not.toMatch(/did not order/i);
+  });
+
+  it("is computed per call, not per deployment (ac-1)", () => {
+    tagAc(AC(1));
+    // The whole point of dec-1: the ranker can differ between two consecutive calls in
+    // one process (the silent `catch` degrade — measured at 1 of 23 in a single prod
+    // session). Two renders back-to-back in THIS process must disagree, which no
+    // env-read or module-level constant could produce.
+    const reranked = formatRoutedStandards(resultWith(RERANKER));
+    const keyless = formatRoutedStandards(resultWith(KEYLESS_MODEL));
+    expect(reranked).not.toEqual(keyless);
+    expect(reranked).toContain(RERANKER);
+    expect(keyless).toContain(KEYLESS_MODEL);
+    expect(keyless).not.toContain(RERANKER);
+  });
+
+  it("says nothing when nothing is surfaced (ac-4)", () => {
+    tagAc(AC(4));
+    // An empty routing emits no readout at all; the declaration must not resurrect one.
+    expect(formatRoutedStandards({ surfaced: [], all: [], k: 10, rankerModel: RERANKER })).toBe("");
+  });
+});
+
+describe("spec-550 dec-2 — a rank the caller can act on, not a score that is 1.00 by construction", () => {
+  it("prints no `relevance` token and no normalised score (ac-6, ac-2)", () => {
+    tagAc(AC(6));
+    tagAc(AC(2));
+    const readout = formatRoutedStandards(wideResult());
+    expect(readout).not.toMatch(/relevance/i);
+    // No bare 0..1 decimal anywhere an entry header could carry one.
+    expect(readout).not.toMatch(/\b[01]\.\d{2}\b/);
+  });
+
+  it("carries each standard's rank and the FULL candidate count, not k (ac-6, ac-2)", () => {
+    tagAc(AC(6));
+    tagAc(AC(2));
+    // 3 surfaced, k=10, 24 candidates — so k, surfaced.length and all.length all differ
+    // and only the right one can satisfy this.
+    const readout = formatRoutedStandards(wideResult(3, 24));
+    expect(readout).toMatch(/rank 1 of 24/);
+    expect(readout).toMatch(/rank 2 of 24/);
+    expect(readout).toMatch(/rank 3 of 24/);
+    expect(readout).not.toMatch(/of 10\b/); // not k
+    expect(readout).not.toMatch(/of 3\b/); // not surfaced.length
+  });
+
+  it("leaves the surfaced order and membership exactly as given (ac-7, ac-3)", () => {
+    tagAc(AC(7));
+    tagAc(AC(3));
+    const r = wideResult(3, 24);
+    const readout = formatRoutedStandards(r);
+    const rendered = [...readout.matchAll(/▸ (std-\d+)/g)].map((m) => m[1]);
+    expect(rendered).toEqual(r.surfaced.map((s) => s.handle));
+  });
+
+  it("keeps the score on the result object — only the READOUT drops it (ac-7)", () => {
+    tagAc(AC(7));
+    // dec-2 changes a rendered token, not the data model: `logRouting` still persists
+    // every candidate's score, and re-tuning K offline still depends on it.
+    const r = wideResult();
+    formatRoutedStandards(r);
+    expect(r.all.every((s) => typeof s.score === "number")).toBe(true);
+    expect(r.all[0].score).toBe(1);
+  });
+});

--- a/packages/server/src/services/facet-routing.integration.test.ts
+++ b/packages/server/src/services/facet-routing.integration.test.ts
@@ -107,7 +107,7 @@ describe("recall-first routing (spec-423 t-3, dec-1)", () => {
   });
 });
 
-describe("surfacing cut — top-K, no relevance floor, scores shown (spec-423 t-3, dec-2)", () => {
+describe("surfacing cut — top-K, no relevance floor, scores on the result (spec-423 t-3, dec-2; readout rendering superseded by spec-550 dec-2)", () => {
   it("caps at top-K (attention cut) with scores shown, nothing pruned from the full set (ac-10)", async () => {
     tagAc(AC(10));
     process.env.MEMEX_FACET_TOPK = "2";
@@ -139,12 +139,24 @@ describe("surfacing cut — top-K, no relevance floor, scores shown (spec-423 t-
     expect(catchall!.score).toBeLessThan(1.0); // low score, surfaced regardless
   });
 
-  it("formats the surfaced readout with visible scores (ac-10)", async () => {
-    tagAc(AC(10));
+  // SUPERSEDED BY spec-550 dec-2, deliberately. This test used to assert
+  // /relevance 1\.00/ and was tagged spec-423 ac-10 ("every surfaced standard carries
+  // its score in the output"). The score is normalised against the call's maximum, so
+  // the leader reads 1.00 on EVERY call by construction — measured on 23 of 23 prod
+  // rows — which cannot support the self-triage ac-10 wanted from it. The readout now
+  // carries a rank over the full candidate field instead.
+  //
+  // The ac-10 TAG is dropped from THIS test only: its other two clauses (top-K cut, no
+  // relevance floor) and the score living on the result object are still proven by the
+  // two tests above, which keep their ac-10 tags. ac-10 is not stranded.
+  it("formats the surfaced readout with a rank over the full candidate field (spec-550 ac-2, ac-6)", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-550/acs/ac-2");
+    tagAc("mindset-prod/memex-building-itself/specs/spec-550/acs/ac-6");
     const r = await routeFacets(memexId, ["zb-security"], "auth", null);
     const readout = formatRoutedStandards(r);
     expect(readout).toContain("std-zb-focused");
-    expect(readout).toMatch(/relevance 1\.00/); // score shown, now stamped "relevance N.NN"
+    expect(readout).not.toMatch(/relevance/i);
+    expect(readout).toMatch(new RegExp(`rank 1 of ${r.all.length}\\b`));
   });
 });
 
@@ -182,6 +194,25 @@ describe("ranking backend — keyless baseline + re-ranker degrade (spec-423 t-3
     const r = await routeFacets(memexId, ["zb-security"], "auth", boom);
     expect(r.rankerModel).toBe(KEYLESS_MODEL); // degraded, non-blocking
     expect(r.all.length).toBe(3); // still recall-first
+  });
+
+  // spec-550 ac-5: the degrade is SILENT (the catch logs nothing), so the only thing
+  // that can tell the caller is the readout. Rendering a hand-built keyless result
+  // proves the wording; only driving the real catch proves the wording is reached.
+  it("renders the KEYLESS declaration after a re-ranker throws — never the configured model (spec-550 ac-5)", async () => {
+    tagAc("mindset-prod/memex-building-itself/specs/spec-550/acs/ac-5");
+    const boom: Reranker = {
+      model: "mock:boom",
+      rerank: async () => {
+        throw new Error("provider outage");
+      },
+    };
+    const r = await routeFacets(memexId, ["zb-security"], "auth", boom);
+    const readout = formatRoutedStandards(r);
+    expect(readout).toContain(KEYLESS_MODEL);
+    expect(readout).not.toContain("mock:boom"); // the configured model did NOT score it
+    expect(readout).toMatch(/ordered them/i);
+    expect(readout).not.toMatch(/did not order/i);
   });
 });
 

--- a/packages/server/src/services/facet-routing.ts
+++ b/packages/server/src/services/facet-routing.ts
@@ -509,11 +509,28 @@ export function formatRoutedStandards(result: RoutingResult, occasion: ReadoutOc
       : occasion === "in_progress"
         ? `You're starting this task now — ${govern} govern it. The implicated sections are inlined below, each marked with its exact standard + clause refs. Follow them, and cite them by ref:`
         : `${govern} govern this work. The implicated sections are inlined below, each marked with its exact standard + clause refs so you can follow and cite them precisely:`;
-  const lines = ["", heading];
-  let used = heading.length;
+  // spec-550 dec-1: declare, PER CALL, which ranker actually scored this list, and what
+  // that means for the ballot the caller was forced to cast. Read from THIS call's
+  // `rankerModel` — never from process config — because `rerank()` degrades through a
+  // silent catch above, so two consecutive calls in one process can be scored
+  // differently (measured: 1 of 23 in a single prod session). A static claim about the
+  // deployment would therefore be false on the next call. std-50: a value one component
+  // depends on and another owns is declared, never defaulted in silence.
+  const rankerNote =
+    result.rankerModel === KEYLESS_MODEL
+      ? `Ranked by ${result.rankerModel}: your facet ballot chose these candidates and ordered them.`
+      : `Ranked by ${result.rankerModel} over the work text: your facet ballot chose these candidates but did not order them.`;
+  const lines = ["", heading, rankerNote];
+  let used = heading.length + rankerNote.length;
   result.surfaced.forEach((s, i) => {
     const facetTag = s.facetKeys.length ? `; facets: ${s.facetKeys.join(", ")}` : "";
-    const header = `\n▸ ${s.handle} — "${s.title}" (relevance ${s.score.toFixed(2)}${facetTag})`;
+    // spec-550 dec-2: a RANK over the full candidate field, not a score. The score is
+    // normalised against this call's maximum (below), so the leader reads 1.00 on every
+    // call by construction — a relative position printed in the grammar of an absolute
+    // judgement. The total is `all.length`, not `k`: it tells the reader how deep the
+    // field was that this standard was drawn from. The score itself is untouched on the
+    // result object and still persisted by logRouting — only the rendering changes.
+    const header = `\n▸ ${s.handle} — "${s.title}" (rank ${i + 1} of ${result.all.length}${facetTag})`;
     const sections = s.sections ?? [];
     const docRef = sections[0]?.docRef ?? `…/standards/${s.handle}`;
     // Beyond the inline cap, nothing to inline, or budget spent → a get_doc pointer.


### PR DESCRIPTION
## What and why

`create_decision` / `create_task` **fail** without a complete facet ballot — a true/false verdict over all 16 facets. But when a re-ranker credential is present, `routeFacets` replaces the fused score with query-text relevance over the whole union, so the ballot decides only what is a **candidate** and contributes nothing to **rank**. Nothing in the response said so.

That is std-50 verbatim: *a value one component depends on and another owns is read, declared, or refused — never defaulted in silence.*

It is the normal path, not an edge case. From prod `facet_routing_log` (read 2026-09-07): `cohere:rerank-v3.5` scored **18884** calls against `keyless-density`'s **110**.

## The change — two lines of production code

```diff
+ Ranked by cohere:rerank-v3.5 over the work text: your facet ballot chose
+ these candidates but did not order them.

- ▸ std-9 — "Infrastructure: int + prod GCP projects" (relevance 1.00; facets: …)
+ ▸ std-9 — "Infrastructure: int + prod GCP projects" (rank 1 of 24; facets: …)
```

**dec-1 — declared per call, not per deployment.** The `catch` around `rerank()` degrades silently, so two consecutive calls in one process can be scored differently (measured: 1 of 23 in a single prod session). Any static claim — a docs line, a startup log — would be false on the next call. The declaration is computed from that call's `rankerModel`, which already existed on `RoutingResult` and already reached `logRouting`; only the formatter was never told to say it. On the keyless path the wording states the ballot **did** order the list, because it did.

**dec-2 — `rank N of M` replaces `relevance <score>`.** The score is normalised against the call's maximum, so the leader reads `1.00` on **every** call by construction (`top1_score` was 1.000 on 23 of 23 prod rows): a relative position printed in the grammar of an absolute judgement. The rank also carries what the score never did — how deep the field was.

⚠️ **This supersedes half of spec-423 dec-2**, which resolved *"order by score, SHOW the scores (the agent triages weak matches itself), cap at K, never floor."* That decision showed scores **for a purpose** a 1.00-by-construction leader cannot serve. A rank is not a score, so this is a supersession with cause, not a compatible reading. Recorded in spec-550 dec-2 rather than retro-edited into the closed Spec. **The floorless top-K it also resolved is untouched.**

**Retrieval and ordering do not change** (ac-3). `routeFacets`, the normalisation, `rrfFuse`, `keylessDensity` and the top-K cut are untouched; the score stays on the result object and is still persisted, so offline K-tuning keeps its input. Only the rendering changes.

**dec-3 — one string, one author.** The new prose sits beside the readout prose already in this service. std-15 cl-68 confines tool-response footer prose to `composeGuidanceEnvelope`, and this function predates that carve-out; whether it should move is raised as drift on std-15 §8 for that standard's owner rather than decided here. Both of std-15's enforcement arms are structurally blind to it — the static guard's corpus is `agent/handlers/*` + `agent/tool-specs.ts`, and the behavioural guard is a five-entry regex denylist — which is part of the flag.

**dec-5** — fair-code. No `.ee.` marker added.

## Test plan

- [x] TDD, red first: t-1 4 red → implement → 15 green; t-2 2 red → implement → green
- [x] `tsc -p tsconfig.build.json --noEmit` — exit 0
- [x] `src/__regression__` — **127 files green**
- [x] **`make e2e-cold` — 158 passed, 0 failed** (std-28)
- [x] All **9/9 ACs verified** via tagged emissions, confirmed with `list_acs` rather than inferred from a green suite
- [x] The ac-8 guard proven **red-capable**: planting readout prose in `scaffold-data.ts` fails it; removing it returns green

**A false green removed.** After the first pass `ac-5` read verified, but its degrade clause was proven by nothing — a hand-built keyless result, not a real degrade. Added a test that drives `routeFacets` with a throwing re-ranker and asserts the readout carries `keyless-density`, not the configured model.

**The 14 e2e failures were not this change.** A three-pass A/B, one variable at a time: branch/main-worktree → 144 passed, 14 failed; develop/fresh → 158/0; **branch/fresh → 158/0**. Passes 2 and 3 share the environment and differ only in code. One failing journey (`decision-reactive-via-mcp`) genuinely sat on the changed call path, which is why "no plausible mechanism" was not accepted as an answer.

## Follow-ups (filed, not fixed here)

- `issue-1` — `facet-routing.ts:416` names the re-ranker on the zero-candidate early return, where nothing was ranked. Telemetry only, but future lift measurements must filter `jsonb_array_length(candidates) > 0`.
- `issue-2` — `logRouting` drops per-candidate `facetKeys`, so "how often does the top hit share zero voted facets?" is unanswerable at scale. Not reconstructable by join: `standard_clause_facets` is mutable.
- Drift `c-4` on std-15 §8.

Spec: https://memex.ai/mindset-prod/memex-building-itself/specs/spec-550 · full QA report in its `qa_report` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)