### PR TITLE
feat(spec-552): the cost panel — a gated aggregate, the ninth Insights card, and its journey

### DIFF
--- a/packages/server/src/__smoke__/cost-panel.smoke.test.ts
+++ b/packages/server/src/__smoke__/cost-panel.smoke.test.ts
@@ -1,0 +1,153 @@
+// Cost-panel smoke (spec-552 t-6) [per std-17].
+//
+// THE FAILURE THIS EXISTS FOR IS SILENT. `result_text_length` is written with
+// no gate and read by nothing else, so a regression — an inverted condition, a
+// dropped insert field, a migration that did not run on this env — produces a
+// column full of NULLs, no error anywhere, and a cost card that is simply
+// blank. Every local test can stay green through all of it. Only a live row
+// settles it.
+//
+// Three probes, in the order they can lie to you:
+//
+//   1. The column POPULATES on the deployed host. Drive a real MCP call, then
+//      read the row it wrote. Not "the endpoint answered 200" — the row.
+//   2. result_text_length >= footer_text_length holds on real rows. The card
+//      derives the answer half by subtracting; if the inequality ever breaks,
+//      that subtraction silently goes negative. Arithmetic, not string
+//      matching for a truncation marker.
+//   3. The ROLLOUT GATE reached the running revision. Requesting the cost
+//      aggregate and getting `available: true` is a BEHAVIOURAL read-back of
+//      COST_PANEL_MEMEXES: if the value had been stranded anywhere along its
+//      four deploy links (GitHub Environment variable → deploy.yml →
+//      deploy-config.sh's set-vs-unset export → deploy.sh's Cloud Run wiring),
+//      the gate would be closed and this would read `false`. That is a
+//      stronger check than reading the config back, and it needs no gcloud.
+//
+// ⚠ WHICH DIRECTION IS VERIFIABLE WHERE. int runs with COST_PANEL_MEMEXES="*"
+// (dec-8), so on int only the OPEN direction exists — every Memex is admitted
+// and the closed states are unreachable. The CLOSED direction is verifiable on
+// PROD, where the value names the dogfood Memex alone: any other Memex is then
+// closed. Do not read a green int smoke as proof the gate can refuse.
+//
+// Skips cleanly without SMOKE_MCP_TOKEN / SMOKE_DATABASE_URL (cloud-sql-proxy
+// is not always up); `make smoke-int-with-db` / `smoke-prod-with-db` start it.
+// ⚠ A skipped tier looks identical to a passing one. If this file matters to
+// you, confirm from the printed row counts below that it actually ran.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { tagAc } from "@memex-ai-ac/vitest";
+import {
+  SMOKE_BASE_URL,
+  SMOKE_CANONICAL_REF,
+  SMOKE_DATABASE_URL,
+  SMOKE_MCP_TOKEN,
+  SMOKE_NAMESPACE,
+  SMOKE_SESSION_TOKEN,
+  callMcpTool,
+} from "./smoke-env.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-552/acs/ac-${n}`;
+
+const DB_ENABLED = !!SMOKE_MCP_TOKEN && !!SMOKE_DATABASE_URL;
+
+describe.skipIf(!DB_ENABLED)(
+  `cost-panel telemetry smoke @ ${SMOKE_BASE_URL}`,
+  () => {
+    let sql: ReturnType<typeof postgres>;
+    // Filter to rows from THIS run, with slack for clock drift between this
+    // machine and the database.
+    const startedAt = new Date(Date.now() - 2_000);
+
+    beforeAll(async () => {
+      sql = postgres(SMOKE_DATABASE_URL, { max: 2 });
+      // Real traffic on the live host, so there is a row to read.
+      await callMcpTool("get_information", { topic: "phases" });
+    });
+
+    afterAll(async () => {
+      await sql?.end?.({ timeout: 5 });
+    });
+
+    it("populates result_text_length on the deployed host", async () => {
+      tagAc(AC(6));
+      const rows = await sql<{ n: number; with_len: number; max_len: number }[]>`
+        SELECT count(*)::int                     AS n,
+               count(result_text_length)::int    AS with_len,
+               coalesce(max(result_text_length), 0)::int AS max_len
+        FROM mcp_tool_calls
+        WHERE created_at >= ${startedAt}
+      `;
+      const [row] = rows;
+      // Printed so a reader can tell a PASS from a SKIP — the whole point of
+      // this file is that silence is indistinguishable from success.
+      console.log(
+        `[cost-panel smoke] rows since start: ${row.n}, with a length: ${row.with_len}, max length: ${row.max_len}`
+      );
+
+      expect(row.n).toBeGreaterThan(0);
+      // The load-bearing assertion: EVERY row written since this run started
+      // carries a length. A partial count means something is gating the write.
+      expect(row.with_len).toBe(row.n);
+      expect(row.max_len).toBeGreaterThan(0);
+    });
+
+    it("keeps result_text_length >= footer_text_length on real rows", async () => {
+      tagAc(AC(7));
+      const rows = await sql<{ violations: number; checked: number }[]>`
+        SELECT count(*) FILTER (
+                 WHERE result_text_length < footer_text_length
+               )::int AS violations,
+               count(*)::int AS checked
+        FROM mcp_tool_calls
+        WHERE created_at >= ${startedAt}
+          AND result_text_length IS NOT NULL
+          AND footer_text_length IS NOT NULL
+      `;
+      const [row] = rows;
+      console.log(
+        `[cost-panel smoke] rows with both lengths: ${row.checked}, inequality violations: ${row.violations}`
+      );
+      // The card derives the ANSWER half as result − footer. If this ever
+      // inverts, that subtraction goes negative and the card reports nonsense
+      // with nothing failing.
+      expect(row.violations).toBe(0);
+    });
+  }
+);
+
+// The gate's behavioural read-back needs a session (the aggregate requires
+// MEMBERSHIP, dec-9), not an MCP token — so it gates on a different variable
+// and lives in its own tier.
+describe.skipIf(!SMOKE_SESSION_TOKEN)(
+  `cost-panel rollout gate @ ${SMOKE_BASE_URL}`,
+  () => {
+    it("serves the aggregate, proving COST_PANEL_MEMEXES reached the revision", async () => {
+      tagAc(AC(20));
+      const res = await fetch(
+        `${SMOKE_BASE_URL}/api/${SMOKE_NAMESPACE}/analytics/cost-panel`,
+        { headers: { Cookie: `session=${SMOKE_SESSION_TOKEN}` } }
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { available: boolean };
+      console.log(
+        `[cost-panel smoke] gate for ${SMOKE_NAMESPACE} (ref ${SMOKE_CANONICAL_REF}): available=${body.available}`
+      );
+
+      // On int this MUST be true: the env runs "*" (dec-8), so a false here
+      // means the value never reached the running revision — the exact silent
+      // failure ac-20's four-link guard exists to prevent, caught at the one
+      // moment the source scan cannot see.
+      //
+      // On PROD this is expected FALSE for the throwaway smoke namespace,
+      // because the value names only the dogfood Memex. That asymmetry is the
+      // point: the closed direction is verifiable there and not here.
+      if (process.env.SMOKE_ENV === "prod") {
+        expect(body.available).toBe(false);
+      } else {
+        expect(body.available).toBe(true);
+      }
+    });
+  }
+);

--- a/packages/server/src/routes/analytics-cost-panel.anonymous.integration.test.ts
+++ b/packages/server/src/routes/analytics-cost-panel.anonymous.integration.test.ts
@@ -1,0 +1,235 @@
+// spec-552 t-3 — the cost aggregate seen by a TRULY anonymous caller (ac-11),
+// and the route-surface promise it keeps (ac-16).
+//
+// This file deliberately does NOT set GOOGLE_CLIENT_ID="" (the pattern borrowed
+// from activity.anonymous-projection.integration.test.ts). A non-empty stub
+// makes isDevMode() false, so a request with no Authorization header is really
+// anonymous — currentUserId null — rather than auto-logged-in as dev@memex.ai.
+//
+// The sibling file (analytics-cost-panel.integration.test.ts) covers the
+// member and non-member cases under dev auth. That file CANNOT test anonymity:
+// dev-mode auth supplies a user on every request. Splitting the file is the
+// only way to reach this branch, which is why it exists.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "stub-non-empty-for-spec552-anon-test";
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import {
+  mcpSessions,
+  mcpToolCalls,
+  memexes,
+  namespaces,
+  orgs,
+  users,
+} from "../db/schema.js";
+import { app } from "../app.js";
+import { isDevMode } from "../middleware/session.js";
+import { RESERVED_SLUGS, validateSlugFormat } from "../services/shared/slug.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-552/acs/ac-${n}`;
+
+const VAR = "COST_PANEL_MEMEXES";
+
+let seq = 0;
+function unique(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${Date.now().toString(36)}-${seq}`.toLowerCase();
+}
+
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+const createdUserIds: string[] = [];
+const createdSessionIds: string[] = [];
+const createdMemexIds: string[] = [];
+const createdNamespaceIds: string[] = [];
+let savedFlag: string | undefined;
+
+let publicSlug: string;
+let publicMemexId: string;
+let privateSlug: string;
+
+async function makeMemex(
+  visibility: "public" | "private"
+): Promise<{ memexId: string; slug: string }> {
+  const slug = unique("cp-anon");
+  return db.transaction(async (tx) => {
+    const [ns] = await tx
+      .insert(namespaces)
+      .values({ slug, kind: "org" })
+      .returning();
+    const [org] = await tx
+      .insert(orgs)
+      .values({ namespaceId: ns.id, name: `Anon ${slug}` })
+      .returning();
+    await tx
+      .update(namespaces)
+      .set({ ownerOrgId: org.id })
+      .where(eq(namespaces.id, ns.id));
+    const [memex] = await tx
+      .insert(memexes)
+      .values({ namespaceId: ns.id, slug: "main", name: "Main", visibility })
+      .returning();
+    createdMemexIds.push(memex.id);
+    createdNamespaceIds.push(ns.id);
+    return { memexId: memex.id, slug: ns.slug };
+  });
+}
+
+beforeAll(async () => {
+  savedFlag = process.env[VAR];
+  const pub = await makeMemex("public");
+  publicSlug = pub.slug;
+  publicMemexId = pub.memexId;
+  const priv = await makeMemex("private");
+  privateSlug = priv.slug;
+
+  // Real figures behind the gate, so "no figures" is a fact about the response
+  // rather than a fact about an empty table.
+  const sessionId = unique("cp-anon-sess");
+  const [user] = await db
+    .insert(users)
+    .values({ email: `${unique("cp-anon-user")}@example.com` })
+    .returning();
+  createdUserIds.push(user.id);
+  createdSessionIds.push(sessionId);
+  await db.insert(mcpSessions).values({ sessionId, userId: user.id });
+  await db.insert(mcpToolCalls).values({
+    sessionId,
+    userId: user.id,
+    memexId: publicMemexId,
+    toolName: "secret_cost_tool",
+    argsJson: {},
+    durationMs: 5,
+    resultTextLength: 31337,
+    footerTextLength: 1234,
+  });
+
+  // Both Memexes ARE on the allowlist — so anything withheld below is withheld
+  // by the membership layer, not by the rollout gate.
+  process.env[VAR] = `${publicSlug}/main,${privateSlug}/main`;
+});
+
+afterAll(async () => {
+  if (savedFlag === undefined) delete process.env[VAR];
+  else process.env[VAR] = savedFlag;
+  if (createdSessionIds.length > 0) {
+    await db
+      .delete(mcpToolCalls)
+      .where(inArray(mcpToolCalls.sessionId, createdSessionIds));
+    await db
+      .delete(mcpSessions)
+      .where(inArray(mcpSessions.sessionId, createdSessionIds));
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+  // The PUBLIC memex here MUST be removed. spec-111-visibility-schema scans the
+  // WHOLE memexes table and fails if any row is non-private, so a leaked
+  // fixture reds a DIFFERENT suite and reads as an unrelated regression
+  // [per std-37]. Learned the hard way: it did.
+  if (createdMemexIds.length > 0) {
+    await db
+      .delete(memexes)
+      .where(inArray(memexes.id, createdMemexIds))
+      .catch(() => {});
+  }
+  if (createdNamespaceIds.length > 0) {
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.id, createdNamespaceIds))
+      .catch(() => {});
+  }
+});
+
+describe("GET /analytics/cost-panel — a truly anonymous caller (ac-11)", () => {
+  // PROVE THE PREMISE FIRST. Without this the whole file is a second
+  // non-member test wearing an anonymity label: dev@memex.ai is not a member of
+  // either seeded Memex either, so "anonymous" and "signed-in non-member"
+  // produce byte-identical responses. The assertions below cannot tell them
+  // apart — only this one can.
+  it("really is anonymous: dev-mode auth is OFF in this file", () => {
+    tagAc(AC(11));
+    expect(isDevMode()).toBe(false);
+  });
+
+  it("gets 200 with NO figures on a public Memex, not a rejection", async () => {
+    tagAc(AC(11));
+    const res = await app.request(
+      `/api/${publicSlug}/main/analytics/cost-panel`,
+      withApexHost()
+    );
+    // 200 rather than 401/404 on purpose: the eight sibling /analytics/*
+    // endpoints answer 200 here, and Insights.tsx runs Promise.all over all of
+    // them — a rejection would blank the entire page for this visitor.
+    expect(res.status).toBe(200);
+
+    const raw = await res.text();
+    expect(JSON.parse(raw).available).toBe(false);
+    // Membership gates the figures, and the figures exist — so their absence is
+    // the gate working, not an empty table.
+    expect(raw).not.toContain("secret_cost_tool");
+    expect(raw).not.toContain("31337");
+    expect(raw).not.toContain("1234");
+  });
+
+  it("gets 404 on a private Memex — indistinguishable from nonexistent", async () => {
+    tagAc(AC(11));
+    const res = await app.request(
+      `/api/${privateSlug}/main/analytics/cost-panel`,
+      withApexHost()
+    );
+    // [per std-7 cl-2] readability decides the 404, and it fires before the
+    // capability question is asked. A 200 here would confirm the Memex exists.
+    expect(res.status).toBe(404);
+
+    const nonexistent = await app.request(
+      "/api/no-such-namespace-anywhere/main/analytics/cost-panel",
+      withApexHost()
+    );
+    expect(nonexistent.status).toBe(404);
+    // Same status AND same body: the two must not be told apart.
+    expect(await res.text()).toBe(await nonexistent.text());
+  });
+});
+
+describe("the route surface this work claims (ac-16)", () => {
+  it("confiscates no namespace slug — nothing was added to RESERVED_SLUGS", async () => {
+    tagAc(AC(16));
+    // The words this work could plausibly have claimed as a top-level path.
+    // A public cost page would have needed one (dec-7, dissolved); the panel
+    // rides the tenant-scoped analytics router instead, so none is reserved.
+    for (const word of ["cost", "cost-panel", "costs", "usage", "tokens"]) {
+      expect(RESERVED_SLUGS.has(word)).toBe(false);
+      expect(validateSlugFormat(word).valid).toBe(true);
+    }
+  });
+
+  it("is reachable only under the tenant-scoped path, never at a top-level root", async () => {
+    tagAc(AC(16));
+    // Tenant-scoped: resolves (404 here only because the namespace is unknown,
+    // which is the resolver doing its job — not a missing route).
+    const scoped = await app.request(
+      "/api/some-unknown-ns/main/analytics/cost-panel",
+      withApexHost()
+    );
+    expect(scoped.status).toBe(404);
+
+    // And NOT mounted flat. A flat `/api/<root>` mount is the memexResolver
+    // trap: its bare path works while its subpaths 404 in prod unless the root
+    // is in RESERVED_API_ROOTS. Nothing here takes that shape.
+    for (const flat of ["/api/cost-panel", "/api/cost-panel/summary"]) {
+      const res = await app.request(flat, withApexHost());
+      expect(res.status).not.toBe(200);
+    }
+  });
+});

--- a/packages/server/src/routes/analytics-cost-panel.integration.test.ts
+++ b/packages/server/src/routes/analytics-cost-panel.integration.test.ts
@@ -1,0 +1,375 @@
+// spec-552 t-3 — the gated cost aggregate: GET /analytics/cost-panel.
+//
+// Written BEFORE the endpoint (TDD). The four assertions that matter are the
+// authorization matrix and the migration-straddle arithmetic; the happy path is
+// the easy part.
+//
+// TWO LAYERS, and neither alone passes (dec-9):
+//   readability decides the 404      — a non-member of a PRIVATE memex must not
+//                                      learn it exists [per std-7 cl-2]
+//   membership decides the figures   — a non-member of a PUBLIC memex gets 200
+//                                      with none, because a 404 there would
+//                                      blank all eight existing Insights cards
+//                                      under Insights.tsx's Promise.all
+//
+// Real Postgres + real app routing, same shape as analytics.integration.test.ts.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { eq, inArray } from "drizzle-orm";
+
+// Dev-mode auth so app.request() carries the dev user without minting a JWT.
+vi.hoisted(() => {
+  process.env.GOOGLE_CLIENT_ID = "";
+  return undefined;
+});
+
+import { db } from "../db/connection.js";
+import {
+  mcpSessions,
+  mcpToolCalls,
+  memexes,
+  namespaces,
+  orgs,
+  users,
+} from "../db/schema.js";
+import { app } from "../app.js";
+import { makeTestMemexWithDevAdmin } from "../services/test-helpers.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-552/acs/ac-${n}`;
+
+const VAR = "COST_PANEL_MEMEXES";
+
+function withApexHost(init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Host: "memex.ai" } };
+}
+
+let seq = 0;
+function unique(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${Date.now().toString(36)}-${seq}`.toLowerCase();
+}
+
+// A memex the dev user is NOT a member of. Mirrors makeTestMemexWithDevAdmin
+// minus the org_memberships insert — that omission IS the fixture.
+async function makeForeignMemex(
+  visibility: "public" | "private"
+): Promise<{ memexId: string; slug: string }> {
+  const slug = unique("cp-foreign");
+  return db.transaction(async (tx) => {
+    const [ns] = await tx
+      .insert(namespaces)
+      .values({ slug, kind: "org" })
+      .returning();
+    const [org] = await tx
+      .insert(orgs)
+      .values({ namespaceId: ns.id, name: `Foreign ${slug}` })
+      .returning();
+    await tx
+      .update(namespaces)
+      .set({ ownerOrgId: org.id })
+      .where(eq(namespaces.id, ns.id));
+    const [memex] = await tx
+      .insert(memexes)
+      .values({ namespaceId: ns.id, slug: "main", name: "Main", visibility })
+      .returning();
+    createdNamespaceIds.push(ns.id);
+    return { memexId: memex.id, slug: ns.slug };
+  });
+}
+
+// One mcp_tool_calls row. `resultLen` null models a row written BEFORE
+// migration 0144 — the straddle case that must not be counted.
+async function seedCall(over: {
+  memexId: string;
+  toolName: string;
+  verb?: string | null;
+  resultLen: number | null;
+  footerLen?: number | null;
+}): Promise<void> {
+  const sessionId = unique("cp-sess");
+  const [user] = await db
+    .insert(users)
+    .values({ email: `${unique("cp-user")}@example.com` })
+    .returning();
+  createdUserIds.push(user.id);
+  createdSessionIds.push(sessionId);
+  await db.insert(mcpSessions).values({ sessionId, userId: user.id });
+  await db.insert(mcpToolCalls).values({
+    sessionId,
+    userId: user.id,
+    memexId: over.memexId,
+    toolName: over.toolName,
+    verb: over.verb ?? null,
+    argsJson: {},
+    durationMs: 5,
+    resultTextLength: over.resultLen,
+    footerTextLength: over.footerLen ?? null,
+  });
+}
+
+const createdUserIds: string[] = [];
+const createdSessionIds: string[] = [];
+const createdMemexIds: string[] = [];
+const createdNamespaceIds: string[] = [];
+
+let memberSlug: string;
+let memberMemexId: string;
+let savedFlag: string | undefined;
+
+beforeAll(async () => {
+  savedFlag = process.env[VAR];
+  const member = await makeTestMemexWithDevAdmin("cp-member");
+  memberSlug = member.slug;
+  memberMemexId = member.memexId;
+  createdMemexIds.push(member.memexId);
+});
+
+afterAll(async () => {
+  if (savedFlag === undefined) delete process.env[VAR];
+  else process.env[VAR] = savedFlag;
+  if (createdSessionIds.length > 0) {
+    await db
+      .delete(mcpToolCalls)
+      .where(inArray(mcpToolCalls.sessionId, createdSessionIds));
+    await db
+      .delete(mcpSessions)
+      .where(inArray(mcpSessions.sessionId, createdSessionIds));
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+  // Remove the memexes and their namespaces. The PUBLIC one especially:
+  // spec-111-visibility-schema scans the WHOLE memexes table and fails if any
+  // row is non-private, so a leaked fixture reds a DIFFERENT suite and reads as
+  // an unrelated regression [per std-37]. Learned the hard way: it did.
+  if (createdMemexIds.length > 0) {
+    await db
+      .delete(memexes)
+      .where(inArray(memexes.id, createdMemexIds))
+      .catch(() => {});
+  }
+  if (createdNamespaceIds.length > 0) {
+    await db
+      .delete(namespaces)
+      .where(inArray(namespaces.id, createdNamespaceIds))
+      .catch(() => {});
+  }
+});
+
+function pathFor(slug: string): string {
+  return `/api/${slug}/main/analytics/cost-panel`;
+}
+
+function openTo(...slugs: string[]): void {
+  process.env[VAR] = slugs.map((s) => `${s}/main`).join(",");
+}
+
+// ── the happy path ───────────────────────────────────────────────────────────
+
+describe("GET /analytics/cost-panel — a member of an allowlisted Memex", () => {
+  it("returns per-operation counts, median and p90 in CHARACTERS", async () => {
+    tagAc(AC(1));
+    openTo(memberSlug);
+    // Five calls with known lengths: median 300, p90 ~460 (interpolated).
+    for (const len of [100, 200, 300, 400, 500]) {
+      await seedCall({
+        memexId: memberMemexId,
+        toolName: "get_doc",
+        resultLen: len,
+        footerLen: 50,
+      });
+    }
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.available).toBe(true);
+    const row = body.operations.find(
+      (o: { tool: string }) => o.tool === "get_doc"
+    );
+    expect(row).toBeDefined();
+    expect(row.calls).toBe(5);
+    expect(row.medianChars).toBe(300);
+    expect(row.p90Chars).toBeGreaterThan(400);
+    // Guidance is carried separately so the card can show the share; the ANSWER
+    // half is derived (result − footer) and never stored.
+    expect(row.guidanceChars).toBeGreaterThan(0);
+    // Characters, not tokens — dec-5 keeps the conversion in the UI.
+    expect(JSON.stringify(body)).not.toMatch(/token/i);
+  });
+
+  it("counts only rows that HAVE a length, so the window may straddle migration 0144", async () => {
+    tagAc(AC(1));
+    openTo(memberSlug);
+    // Three measured rows and two pre-migration NULLs for one tool.
+    for (const len of [1000, 2000, 3000]) {
+      await seedCall({
+        memexId: memberMemexId,
+        toolName: "straddle_tool",
+        resultLen: len,
+        footerLen: 100,
+      });
+    }
+    await seedCall({ memexId: memberMemexId, toolName: "straddle_tool", resultLen: null });
+    await seedCall({ memexId: memberMemexId, toolName: "straddle_tool", resultLen: null });
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    const body = await res.json();
+    const row = body.operations.find(
+      (o: { tool: string }) => o.tool === "straddle_tool"
+    );
+    // The trap: count(*) would say 5 beside a median drawn from 3. n must
+    // describe the same set the median does.
+    expect(row.calls).toBe(3);
+    expect(row.medianChars).toBe(2000);
+  });
+
+  it("groups on (tool, verb): NULL verbs collapse, distinct verbs split", async () => {
+    tagAc(AC(14));
+    openTo(memberSlug);
+    // Today every row has verb NULL. After spec-511 the same tool name carries
+    // several verbs whose payloads differ by ~5.5x, so both shapes are proven
+    // now — before spec-511 exists.
+    await seedCall({ memexId: memberMemexId, toolName: "nullverb_tool", resultLen: 700 });
+    await seedCall({ memexId: memberMemexId, toolName: "nullverb_tool", resultLen: 900 });
+    await seedCall({ memexId: memberMemexId, toolName: "verbed_tool", verb: "create", resultLen: 100 });
+    await seedCall({ memexId: memberMemexId, toolName: "verbed_tool", verb: "resolve", resultLen: 5000 });
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    const body = await res.json();
+
+    const nullVerb = body.operations.filter(
+      (o: { tool: string }) => o.tool === "nullverb_tool"
+    );
+    expect(nullVerb).toHaveLength(1);
+    expect(nullVerb[0].calls).toBe(2);
+    expect(nullVerb[0].verb).toBeNull();
+
+    const verbed = body.operations
+      .filter((o: { tool: string }) => o.tool === "verbed_tool")
+      .sort((a: { verb: string }, b: { verb: string }) => a.verb.localeCompare(b.verb));
+    expect(verbed).toHaveLength(2);
+    expect(verbed.map((o: { verb: string }) => o.verb)).toEqual(["create", "resolve"]);
+    expect(verbed[0].medianChars).toBe(100);
+    expect(verbed[1].medianChars).toBe(5000);
+  });
+
+  it("never carries a user_id or a per-user row", async () => {
+    tagAc(AC(8));
+    openTo(memberSlug);
+    await seedCall({ memexId: memberMemexId, toolName: "anon_tool", resultLen: 400 });
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    const raw = await res.text();
+    // Anonymity that depends on the client declining to render a field it
+    // received is not anonymity — aggregate before the response leaves.
+    expect(raw).not.toMatch(/user_?id/i);
+    expect(raw).not.toMatch(/actor/i);
+  });
+
+  it("never leaks another tenant's rows — the memex_id predicate is the ONLY guarantee", async () => {
+    tagAc(AC(9));
+    // mcp_tool_calls is excluded from RLS (drizzle/0081:37), so there is no
+    // database-level second line. This is the assertion that stands in for it.
+    openTo(memberSlug);
+    const foreign = await makeForeignMemex("private");
+    createdMemexIds.push(foreign.memexId);
+    await seedCall({
+      memexId: foreign.memexId,
+      toolName: "other_tenant_tool",
+      resultLen: 9999,
+    });
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    const raw = await res.text();
+    expect(raw).not.toContain("other_tenant_tool");
+    expect(raw).not.toContain("9999");
+  });
+});
+
+// ── the authorization matrix (dec-9) ────────────────────────────────────────
+
+describe("GET /analytics/cost-panel — the two layers", () => {
+  it("a member of a Memex NOT on the allowlist gets 200 with no figures", async () => {
+    tagAc(AC(19));
+    process.env[VAR] = "someone-else/main";
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    // 200, not an error: Insights.tsx runs Promise.all over nine endpoints and
+    // one rejection blanks the whole page.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.available).toBe(false);
+    expect(body.operations).toBeUndefined();
+  });
+
+  it("a non-member of a PUBLIC Memex gets 200 with no figures, not a 404", async () => {
+    tagAc(AC(21));
+    const publicForeign = await makeForeignMemex("public");
+    createdMemexIds.push(publicForeign.memexId);
+    openTo(publicForeign.slug); // on the allowlist, but the caller is not a member
+    await seedCall({
+      memexId: publicForeign.memexId,
+      toolName: "public_foreign_tool",
+      resultLen: 4242,
+    });
+
+    const res = await app.request(pathFor(publicForeign.slug), withApexHost());
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    expect(JSON.parse(raw).available).toBe(false);
+    // Membership gates the FIGURES, so none of them appear.
+    expect(raw).not.toContain("public_foreign_tool");
+    expect(raw).not.toContain("4242");
+  });
+
+  it("a non-member of a PRIVATE Memex gets 404 — indistinguishable from nonexistent", async () => {
+    tagAc(AC(21));
+    const privateForeign = await makeForeignMemex("private");
+    createdMemexIds.push(privateForeign.memexId);
+    openTo(privateForeign.slug);
+
+    const res = await app.request(pathFor(privateForeign.slug), withApexHost());
+    // [per std-7 cl-2] readability decides the 404, and it happens BEFORE the
+    // capability question is asked — otherwise a 200 would confirm a private
+    // Memex exists.
+    expect(res.status).toBe(404);
+
+    const unknown = await app.request(
+      "/api/no-such-namespace-at-all/main/analytics/cost-panel",
+      withApexHost()
+    );
+    expect(unknown.status).toBe(404);
+  });
+
+  it("the two closed states are byte-identical, so the allowlist cannot be enumerated", async () => {
+    tagAc(AC(22));
+    // Closed because not a member (public foreign, on the list)…
+    const publicForeign = await makeForeignMemex("public");
+    createdMemexIds.push(publicForeign.memexId);
+    openTo(publicForeign.slug);
+    const notMember = await app.request(
+      pathFor(publicForeign.slug),
+      withApexHost()
+    );
+    const notMemberBody = await notMember.text();
+
+    // …and closed because not on the list (our own memex, member).
+    process.env[VAR] = "";
+    const notListed = await app.request(pathFor(memberSlug), withApexHost());
+    const notListedBody = await notListed.text();
+
+    expect(notMember.status).toBe(notListed.status);
+    expect(notMemberBody).toBe(notListedBody);
+  });
+
+  it("the gate defaults closed for a member when the flag is unset", async () => {
+    tagAc(AC(19));
+    delete process.env[VAR];
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    expect(res.status).toBe(200);
+    expect((await res.json()).available).toBe(false);
+  });
+});

--- a/packages/server/src/routes/analytics-cost-panel.integration.test.ts
+++ b/packages/server/src/routes/analytics-cost-panel.integration.test.ts
@@ -171,6 +171,9 @@ function openTo(...slugs: string[]): void {
 describe("GET /analytics/cost-panel — a member of an allowlisted Memex", () => {
   it("returns per-operation counts, median and p90 in CHARACTERS", async () => {
     tagAc(AC(1));
+    // ac-3's server half: every figure is computed from mcp_tool_calls rows
+    // seeded below, never authored. Change the rows and the numbers change.
+    tagAc(AC(3));
     openTo(memberSlug);
     // Five calls with known lengths: median 300, p90 ~460 (interpolated).
     for (const len of [100, 200, 300, 400, 500]) {

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -19,6 +19,8 @@ import {
   specAcVerification,
   specActivityAudit,
 } from "../services/analytics.js";
+import { costPanel } from "../services/cost-panel.js";
+import { costPanelEnabledFor } from "../services/cost-panel-flag.js";
 import { standardsGraph, DEFAULT_SEMANTIC_THRESHOLD } from "../services/standards-graph.js";
 import {
   knowledgeGraph,
@@ -68,6 +70,55 @@ function parseNonNegativeInt(raw: string | undefined, field: string): number | u
 analytics.get("/specs-over-time", async (c) => {
   const memexId = await resolveReadableMemexId(c);
   return c.json({ points: await specsOverTime(memexId) });
+});
+
+// GET /analytics/cost-panel — what Memex sent this Memex's agents (spec-552 t-3).
+//
+// ⚠ THIS ROUTE IS DELIBERATELY STRICTER THAN ITS EIGHT SIBLINGS. Do not "fix"
+// it to match them. (dec-9)
+//
+// The siblings resolve tenancy with resolveReadableMemexId alone, whose
+// fall-through to canReadMemex (mcp/auth.ts:377) returns true for ANY public
+// memex BEFORE it checks whether the caller is anonymous. That is correct for
+// them — their payloads describe the Memex's own published content. It is wrong
+// here: these figures describe what our platform costs the team using it, which
+// is billing-adjacent, not published. Mounted the sibling way, this endpoint
+// would publish the cost figures of every public Memex to anyone with the URL.
+//
+// So TWO LAYERS, and neither alone is correct:
+//
+//   1. READABILITY decides the 404. resolveReadableMemexId first, exactly as
+//      the siblings do. A caller who cannot see the Memex at all (private,
+//      non-member) gets 404 — indistinguishable from nonexistent [per std-7
+//      cl-2]. Answering 200 here would confirm a private Memex exists.
+//
+//   2. MEMBERSHIP decides the figures. A caller who CAN read the Memex but is
+//      not a member gets 200 with none. NOT a 404: Insights.tsx runs
+//      Promise.all over every /analytics/* call, so one rejection would blank
+//      the entire page — all eight existing cards — for any anonymous visitor
+//      to a public Memex. A guard that destroys working function is a
+//      regression, not a protection.
+//
+// The two closed states — "not a member" and "not on the rollout allowlist" —
+// are byte-identical by construction, so this endpoint cannot be probed to
+// enumerate which Memexes are on the allowlist.
+analytics.get("/cost-panel", async (c) => {
+  const memexId = await resolveReadableMemexId(c);
+
+  const isMember = c.get("currentMemexId") === memexId;
+  const namespace = c.get("namespace");
+  const memex = c.get("memex");
+  const enabled =
+    isMember &&
+    !!namespace &&
+    !!memex &&
+    costPanelEnabledFor(namespace.slug, memex.slug);
+
+  // One shape for both closed states. Keep it exactly this, or the allowlist
+  // becomes enumerable by comparing responses.
+  if (!enabled) return c.json({ available: false });
+
+  return c.json({ available: true, ...(await costPanel(memexId)) });
 });
 
 // GET /analytics/specs-by-phase — cumulative per current phase, stacked (ac-2).

--- a/packages/server/src/services/cost-panel.ts
+++ b/packages/server/src/services/cost-panel.ts
@@ -1,0 +1,118 @@
+// spec-552 t-3 (dec-1, dec-6, dec-8, dec-9) — what Memex sent this Memex's agents.
+//
+// One read-only aggregate over mcp_tool_calls, feeding the ninth Insights card.
+// Everything here is CHARACTERS: we store lengths, and the chars→tokens
+// conversion is a display concern the UI owns (dec-5, packages/ui/.../tokenEstimate.ts).
+//
+// THE PAYLOAD HAS TWO HALVES and only one is stored. result_text_length is the
+// whole response; footer_text_length is the platform guidance inside it. The
+// ANSWER half is DERIVED — result − footer — so the two can never disagree.
+//
+// n COUNTS THE MEASURED POPULATION, not the call population. Rows written
+// before migration 0144 carry a NULL result_text_length; percentile_cont skips
+// NULLs and count(*) does not, so a 30-day window straddling the deploy would
+// report "400 calls" beside a median drawn from the 120 rows that have a
+// length. count(result_text_length) makes n and the median describe the same set.
+//
+// GROUPING IS (tool_name, verb). Today verb is NULL everywhere and this
+// degenerates to tool_name — exactly today's behaviour. After spec-511 renames
+// 68 tools into ~25 verb-dispatched ones, it keeps `decision · resolve` (median
+// ~3,030 tokens) apart from `decision · update` (~548), a 5.5x spread that a
+// single collapsed row would average into a wrong number.
+//
+// [per std-39] the read is driven by the existing (memex_id, created_at) index.
+// No new index and no cache without a measurement — the read is authenticated
+// and tenant-scoped, so there is no abuse exposure to bound, only latency.
+
+import { sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+
+/** The window every figure on the card is measured over. */
+export const COST_PANEL_WINDOW_DAYS = 30;
+
+export interface CostPanelOperation {
+  /** The wire tool name. */
+  tool: string;
+  /** The operation within that tool — NULL until tools are verb-dispatched. */
+  verb: string | null;
+  /** Calls that carry a measurable length (see the migration-straddle note). */
+  calls: number;
+  /** Median total response size, in characters. */
+  medianChars: number;
+  /** p90 total response size, in characters. */
+  p90Chars: number;
+  /** Platform guidance across those calls, in characters. */
+  guidanceChars: number;
+  /** Whole responses across those calls, in characters. */
+  totalChars: number;
+}
+
+export interface CostPanelTotals {
+  calls: number;
+  totalChars: number;
+  guidanceChars: number;
+}
+
+export interface CostPanelData {
+  windowDays: number;
+  totals: CostPanelTotals;
+  operations: CostPanelOperation[];
+}
+
+interface Row {
+  tool: string;
+  verb: string | null;
+  calls: number;
+  median_chars: number;
+  p90_chars: number;
+  guidance_chars: number;
+  total_chars: number;
+}
+
+export async function costPanel(memexId: string): Promise<CostPanelData> {
+  // NOTE the cast shape: this driver returns the ROWS, not a { rows } envelope.
+  // Assuming the envelope (another driver's convention) yields an empty result
+  // with no error — a silently blank card, which is why the aggregate tests
+  // assert real numbers rather than just a 200.
+  const rows = (await db.execute(sql`
+    SELECT
+      tool_name                                         AS tool,
+      verb                                              AS verb,
+      count(result_text_length)::int                    AS calls,
+      percentile_cont(0.5) WITHIN GROUP (
+        ORDER BY result_text_length
+      )::int                                            AS median_chars,
+      percentile_cont(0.9) WITHIN GROUP (
+        ORDER BY result_text_length
+      )::int                                            AS p90_chars,
+      coalesce(sum(footer_text_length), 0)::bigint      AS guidance_chars,
+      coalesce(sum(result_text_length), 0)::bigint      AS total_chars
+    FROM mcp_tool_calls
+    WHERE memex_id = ${memexId}
+      AND created_at >= now() - (${COST_PANEL_WINDOW_DAYS} || ' days')::interval
+      AND result_text_length IS NOT NULL
+    GROUP BY tool_name, verb
+    ORDER BY sum(result_text_length) DESC
+  `)) as unknown as Row[];
+
+  const operations: CostPanelOperation[] = rows.map((r) => ({
+    tool: r.tool,
+    verb: r.verb,
+    calls: Number(r.calls),
+    medianChars: Number(r.median_chars),
+    p90Chars: Number(r.p90_chars),
+    guidanceChars: Number(r.guidance_chars),
+    totalChars: Number(r.total_chars),
+  }));
+
+  const totals = operations.reduce<CostPanelTotals>(
+    (acc, op) => ({
+      calls: acc.calls + op.calls,
+      totalChars: acc.totalChars + op.totalChars,
+      guidanceChars: acc.guidanceChars + op.guidanceChars,
+    }),
+    { calls: 0, totalChars: 0, guidanceChars: 0 }
+  );
+
+  return { windowDays: COST_PANEL_WINDOW_DAYS, totals, operations };
+}

--- a/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
+++ b/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
@@ -1,0 +1,175 @@
+// Journey 73 — spec-552: a member sees what Memex sent their agents, computed
+// from real traffic, on the Insights page [per std-28].
+//
+//   ac-1 — both halves of every payload are recoverable from telemetry: the
+//          whole response AND the platform guidance inside it. Proven here the
+//          only way that really counts — the guidance share on screen is
+//          derived from footer bytes that REAL MCP calls wrote.
+//   ac-2 — a member sees, without leaving the product, how much Memex sent
+//          their agents over a stated window and what share was guidance,
+//          per operation, with a median and a p90 rather than one average.
+//   ac-3 — the figures are computed, not authored: nothing is seeded into the
+//          card, and the numbers appear only because tool calls happened.
+//
+// SEEDING IS REAL TRAFFIC, not fixture rows. The journey drives actual MCP
+// tool calls at `/mcp` (the same shape journey-20 uses), so `mcp_tool_calls`
+// is written by the production path — including `result_text_length` and
+// `footer_text_length`. No raw SQL [per std-28]; the tenant and Spec come from
+// the env-gated `/api/__test__` surface.
+//
+// WHAT THIS JOURNEY DOES NOT COVER, and why. The rollout gate reads
+// COST_PANEL_MEMEXES from the server env, which playwright.config.ts fixes to
+// "*" for the whole run (matching int, per dec-8). A journey therefore cannot
+// flip the gate, so the CARD-ABSENT state is proven one tier down: the
+// component renders null for an unavailable payload (CostPanelCard.test.tsx)
+// and the endpoint returns byte-identical closed responses for both closed
+// reasons (analytics-cost-panel*.integration.test.ts). Making it flippable
+// would need either a deterministic tenant slug — which breaks CI retries,
+// because seed-org is not idempotent — or a test endpoint that mutates server
+// env, which costs more than the coverage it buys.
+
+import { test, expect } from "./helpers/index.js";
+import {
+  seedOrgTenant,
+  seedSpec,
+  type SeededOrgTenant,
+} from "./helpers/retained.js";
+import { emitAcEvents } from "./helpers/emit-ac.js";
+
+const ACS = [
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-1",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-2",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-3",
+];
+
+const DEV_MCP_BEARER = "mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION";
+
+const MCP_URL =
+  (process.env.E2E_API_URL ??
+    `http://localhost:${process.env.E2E_SERVER_PORT ?? 8090}`) + "/mcp";
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  await emitAcEvents(
+    ACS,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts::${testInfo.title}`,
+    testInfo.duration
+  );
+});
+
+/** Drive one real MCP tool call, exactly as a coding agent would. */
+async function mcpToolCall(
+  request: import("@playwright/test").APIRequestContext,
+  name: string,
+  args: Record<string, unknown>
+): Promise<void> {
+  const res = await request.post(MCP_URL, {
+    headers: {
+      Authorization: `Bearer ${DEV_MCP_BEARER}`,
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    data: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+  });
+  expect(
+    res.ok(),
+    `MCP ${name} should respond over HTTP (got ${res.status()})`
+  ).toBeTruthy();
+}
+
+test("the cost card reports real MCP traffic, per operation, with a median and a p90", async ({
+  page,
+  request,
+  resources,
+}) => {
+  // ── 1. A tenant with a Spec to call tools against ──────────────────────────
+  const slug = resources.slug("costpanel");
+  const tenant: SeededOrgTenant = await seedOrgTenant({ slug });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Subject of the cost panel journey",
+    purpose: "spec-552 journey subject.",
+  });
+  const specRef = `${tenant.namespaceSlug}/${tenant.memexSlug}/specs/${spec.handle}`;
+
+  // ── 2. REAL traffic. Four calls clears MIN_CALLS_FOR_FIGURES (3) with room,
+  //      and get_doc responses carry the platform footer — which is what makes
+  //      the guidance share on screen a measurement rather than a constant.
+  for (let i = 0; i < 4; i += 1) {
+    await mcpToolCall(request, "get_doc", { ref: specRef });
+  }
+
+  // ── 3. The card, on the page a member actually visits ─────────────────────
+  await page.goto(`/${tenant.namespaceSlug}/${tenant.memexSlug}/insights`);
+
+  const card = page.getByText("What Memex sent your agents").first();
+  await expect(card).toBeVisible();
+
+  // The window is stated, and it comes from the response (ac-2).
+  await expect(page.getByText(/Last \d+ days/)).toBeVisible();
+
+  // Per-operation rows, and the operation named is the one we really called.
+  await expect(page.getByText("get_doc").first()).toBeVisible();
+
+  // Median AND p90 — never one number standing in for both (ac-2).
+  await expect(page.getByText("Median", { exact: false }).first()).toBeVisible();
+  await expect(page.getByText("p90", { exact: false }).first()).toBeVisible();
+
+  // Token figures are marked as estimates, and the characters behind them are
+  // on the row so a reader can recompute.
+  await expect(page.getByText(/≈/).first()).toBeVisible();
+  await expect(page.getByText(/estimated from characters/i)).toBeVisible();
+
+  // The refusal is on the card, not left to the reader to infer (ac-4's shape).
+  await expect(page.getByText(/can't measure|cannot measure/i)).toBeVisible();
+
+  // ── 4. ac-1, end to end: the guidance share is non-zero, which can only be
+  //      true if footer_text_length was captured on those calls alongside the
+  //      whole-response length. A fixture cannot fake this — the footer was
+  //      written by the server on a real Spec-tool response.
+  await expect(page.getByText("Of that, platform guidance")).toBeVisible();
+  const guidanceCell = page
+    .locator("div", { hasText: /^Of that, platform guidance$/ })
+    .first();
+  await expect(guidanceCell).toBeVisible();
+  // Any non-zero percentage proves both halves landed. Asserting a specific
+  // number would pin the guidance envelope, which spec-510 is about to change.
+  await expect(page.getByText(/[1-9]\d?%/).first()).toBeVisible();
+
+  // ── 5. The page is otherwise intact — the ninth card is an addition, and a
+  //      regression in it must not be mistaken for the page still working.
+  await expect(page.getByRole("heading", { name: "Insights" })).toBeVisible();
+});
+
+test("a Memex with barely any traffic is told so, instead of shown a statistic", async ({
+  page,
+  request,
+  resources,
+}) => {
+  const slug = resources.slug("costthin");
+  const tenant: SeededOrgTenant = await seedOrgTenant({ slug });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Barely any traffic",
+    purpose: "spec-552 thin-traffic subject.",
+  });
+
+  // ONE call — below MIN_CALLS_FOR_FIGURES. A median over one call is noise
+  // wearing a statistic's clothes, so the card must refuse to draw it.
+  await mcpToolCall(request, "get_doc", {
+    ref: `${tenant.namespaceSlug}/${tenant.memexSlug}/specs/${spec.handle}`,
+  });
+
+  await page.goto(`/${tenant.namespaceSlug}/${tenant.memexSlug}/insights`);
+
+  await expect(page.getByText("What Memex sent your agents")).toBeVisible();
+  await expect(page.getByText(/not enough activity/i)).toBeVisible();
+  // And no table: the header row is the tell.
+  await expect(page.getByText("Median", { exact: false })).toHaveCount(0);
+});

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -92,7 +92,21 @@ export default defineConfig({
           // build under test — silently green while proving nothing. Pin it to the
           // e2e API origin: the unsubscribe pages are server-rendered, so no Vite
           // proxy hop is needed for them.
-          command: `GOOGLE_CLIENT_ID="" MEMEX_ANTHROPIC_FAKE=1 JOURNEY_PREVIEW_DOMAINS="memex.ai" APP_BASE_URL="http://localhost:${SERVER_PORT}" SLACK_TOKEN_ENCRYPTION="${process.env.SLACK_TOKEN_ENCRYPTION ?? "plaintext"}" DATABASE_URL="${DATABASE_URL}" MEMEX_WORKSPACE_ID="${process.env.MEMEX_WORKSPACE_ID ?? ""}" PORT=${SERVER_PORT} pnpm --filter @memex/server dev`,
+          // COST_PANEL_MEMEXES="*": spec-552 t-6. The cost card's rollout gate
+          // defaults CLOSED, so without this every journey would see the card
+          // absent and the populated states would be unreachable. "*" is also
+          // exactly what int runs with (dec-8), so the journey exercises the
+          // same configuration the deployed environment has.
+          //
+          // The value is STATIC for the whole run, which is a real limit worth
+          // knowing: a journey cannot flip the gate mid-run, so the ABSENT
+          // state is proven at the component tier (CostPanelCard renders null)
+          // and the API tier (both closed responses are byte-identical), not
+          // here. Making it flippable would mean either a deterministic tenant
+          // slug — which breaks CI retries, since seed-org is not idempotent —
+          // or a test endpoint that mutates server env, which is worse than the
+          // coverage it buys.
+          command: `COST_PANEL_MEMEXES="*" GOOGLE_CLIENT_ID="" MEMEX_ANTHROPIC_FAKE=1 JOURNEY_PREVIEW_DOMAINS="memex.ai" APP_BASE_URL="http://localhost:${SERVER_PORT}" SLACK_TOKEN_ENCRYPTION="${process.env.SLACK_TOKEN_ENCRYPTION ?? "plaintext"}" DATABASE_URL="${DATABASE_URL}" MEMEX_WORKSPACE_ID="${process.env.MEMEX_WORKSPACE_ID ?? ""}" PORT=${SERVER_PORT} pnpm --filter @memex/server dev`,
           url: `http://localhost:${SERVER_PORT}/api/health`,
           reuseExistingServer: !process.env.CI,
           timeout: 60_000,

--- a/packages/ui/src/api/insights.ts
+++ b/packages/ui/src/api/insights.ts
@@ -354,3 +354,52 @@ export async function fetchSpecActivity(
     `${tBase()}/analytics/spec/${encodeURIComponent(specRef)}/activity${qs ? `?${qs}` : ''}`,
   );
 }
+
+// ── Cost panel (spec-552 t-3/t-5 — the ninth Insights card) ──────────────────
+// Mirrors packages/server/src/services/cost-panel.ts exactly. CHARACTERS
+// throughout: the server stores lengths and the chars→tokens conversion is a
+// display concern this package owns (dec-5, components/insights/tokenEstimate).
+
+export interface CostPanelOperation {
+  /** The wire tool name. */
+  tool: string;
+  /** The operation within that tool — null until tools are verb-dispatched. */
+  verb: string | null;
+  /** Calls carrying a measurable length (rows predating the column are excluded). */
+  calls: number;
+  medianChars: number;
+  p90Chars: number;
+  /** Platform guidance across those calls. */
+  guidanceChars: number;
+  /** Whole responses across those calls. */
+  totalChars: number;
+}
+
+export interface CostPanelTotals {
+  calls: number;
+  totalChars: number;
+  guidanceChars: number;
+}
+
+/**
+ * `available: false` is NOT an error — it is the answer for a Memex outside the
+ * rollout allowlist, and for a caller who may read the Memex but is not a
+ * member (dec-9). The card renders nothing in that case and the page is
+ * unchanged; a rejection here would blank every other card, since the page
+ * fetches them all with Promise.all.
+ */
+export type CostPanelResponse =
+  | { available: false }
+  | {
+      available: true;
+      windowDays: number;
+      totals: CostPanelTotals;
+      operations: CostPanelOperation[];
+    };
+
+export async function fetchCostPanel(): Promise<CostPanelResponse> {
+  return fetchJsonRaw<CostPanelResponse>(
+    fetchWithRetry,
+    `${tBase()}/analytics/cost-panel`,
+  );
+}

--- a/packages/ui/src/components/insights/CostPanelCard.test.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.test.tsx
@@ -1,0 +1,204 @@
+// spec-552 t-5 — the ninth Insights card.
+//
+// Written BEFORE the component (TDD). The assertions that matter are the two
+// honesty properties, because they are the card's whole value:
+//
+//   ac-10 — every figure, INCLUDING the window, comes from the response. A
+//           literal anywhere is a number that stops being true without
+//           anything detecting it.
+//   ac-13 — every token figure is marked as an estimate AND its exact
+//           character count is on the row, so a reader who distrusts our
+//           divisor can recompute instead of taking it on faith.
+//
+// Plus the three states: figures, not-enough-activity, and absent.
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { CostPanelCard } from './CostPanelCard';
+import type { CostPanelResponse } from '../../api/insights';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-552/acs/ac-${n}`;
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function populated(over: Partial<{ windowDays: number }> = {}): CostPanelResponse {
+  return {
+    available: true,
+    windowDays: over.windowDays ?? 30,
+    totals: { calls: 120, totalChars: 546_000, guidanceChars: 174_720 },
+    operations: [
+      {
+        tool: 'get_doc',
+        verb: null,
+        calls: 60,
+        medianChars: 4_428,
+        p90Chars: 31_947,
+        guidanceChars: 100_296,
+        totalChars: 400_000,
+      },
+      {
+        // The 95%-guidance shape — the row the card exists to make visible.
+        tool: 'add_comment',
+        verb: null,
+        calls: 60,
+        medianChars: 1_685,
+        p90Chars: 1_764,
+        guidanceChars: 96_000,
+        totalChars: 101_100,
+      },
+    ],
+  };
+}
+
+describe('CostPanelCard — the three states', () => {
+  it('renders nothing at all when the payload says the panel is unavailable', () => {
+    tagAc(AC(5));
+    // Not a placeholder, not an error, not an empty frame: the page must look
+    // exactly as it does today for a Memex outside the rollout, or for a caller
+    // who is not a member.
+    const { container } = render(<CostPanelCard data={{ available: false }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a not-enough-activity state instead of a statistic over a handful of calls', () => {
+    tagAc(AC(5));
+    const thin: CostPanelResponse = {
+      available: true,
+      windowDays: 30,
+      totals: { calls: 2, totalChars: 900, guidanceChars: 300 },
+      operations: [
+        {
+          tool: 'create_ac',
+          verb: null,
+          calls: 2,
+          medianChars: 450,
+          p90Chars: 460,
+          guidanceChars: 300,
+          totalChars: 900,
+        },
+      ],
+    };
+    render(<CostPanelCard data={thin} />);
+    expect(screen.getByText(/not enough activity/i)).toBeTruthy();
+    // A median drawn from two calls must not be presented as a figure.
+    expect(screen.queryByText('450')).toBeNull();
+  });
+
+  it('renders the per-operation rows once there is enough activity', () => {
+    tagAc(AC(2));
+    render(<CostPanelCard data={populated()} />);
+    expect(screen.getByText('get_doc')).toBeTruthy();
+    expect(screen.getByText('add_comment')).toBeTruthy();
+  });
+});
+
+describe('CostPanelCard — ac-10: every figure comes from the response', () => {
+  it('renders the window from the payload, not a hardcoded label', () => {
+    tagAc(AC(10));
+    // ac-3's render half: the displayed figure tracks the response, so a number
+    // that stopped being true cannot survive on screen. Paired with the server
+    // half (the aggregate computing from real rows) this is the whole claim.
+    tagAc(AC(3));
+    const { unmount } = render(<CostPanelCard data={populated({ windowDays: 30 })} />);
+    expect(screen.getByText(/last 30 days/i)).toBeTruthy();
+    unmount();
+
+    // Change the response and the label must change with it. A literal "30"
+    // would pass the first assertion and fail this one — which is the point.
+    render(<CostPanelCard data={populated({ windowDays: 7 })} />);
+    expect(screen.getByText(/last 7 days/i)).toBeTruthy();
+    expect(screen.queryByText(/last 30 days/i)).toBeNull();
+  });
+
+  it('no cost figure or window number is a literal in the source', () => {
+    tagAc(AC(10));
+    // Comments are stripped first: the file's own prose cites measured figures,
+    // and a naive scan matches its documentation rather than its code. (Every
+    // source guard on this Spec has tripped on exactly that.)
+    const code = readFileSync(join(HERE, 'CostPanelCard.tsx'), 'utf8')
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('//'))
+      .join('\n')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // A window length or a payload size written into the component would be a
+    // number that silently stops being true.
+    for (const forbidden of ['30 days', '4,428', '31,947', '1,685']) {
+      expect(code).not.toContain(forbidden);
+    }
+    // The threshold is the one exception and it is a named constant, not an
+    // inline digit in the JSX.
+    expect(code).toMatch(/MIN_CALLS_FOR_FIGURES/);
+  });
+});
+
+describe('CostPanelCard — ac-13: estimates are marked, characters are reachable', () => {
+  it('marks every token figure as an estimate', () => {
+    tagAc(AC(13));
+    render(<CostPanelCard data={populated()} />);
+    // The card converts characters to tokens with a measured constant, not a
+    // known quantity — so no token figure may read as exact.
+    const approx = screen.getAllByText(/≈/);
+    expect(approx.length).toBeGreaterThan(0);
+    // And it says HOW, once, so the reader can judge the estimate.
+    expect(screen.getByText(/estimated from characters/i)).toBeTruthy();
+  });
+
+  it('puts the exact character count on the row beside the estimate', () => {
+    tagAc(AC(13));
+    render(<CostPanelCard data={populated()} />);
+    // get_doc's median is 4,428 characters. The token figure is derived; the
+    // character count is measured, so it is the one a sceptic recomputes from.
+    expect(screen.getByText(/4,428/)).toBeTruthy();
+  });
+
+  it('derives token figures through the shared constant, never its own arithmetic', () => {
+    tagAc(AC(13));
+    const code = readFileSync(join(HERE, 'CostPanelCard.tsx'), 'utf8');
+    // One conversion in the codebase (t-4). A second divisor here would put two
+    // disagreeing numbers on the same page with nothing failing.
+    expect(code).toMatch(/estimateTokens/);
+    expect(code).not.toMatch(/\/\s*2\.7|\/\s*3\b|CHARS_PER_TOKEN\s*\)/);
+  });
+});
+
+describe('CostPanelCard — ac-4: the unmeasurable question is answered in place', () => {
+  it('states that no comparison with not using Memex is offered', () => {
+    tagAc(AC(4));
+    render(<CostPanelCard data={populated()} />);
+    // A reader seeing a total immediately asks "versus what?". If the card is
+    // silent they invent a baseline; the Spec's finding is that no honest one
+    // exists, so the card says so rather than implying a saving.
+    expect(screen.getByText(/can't measure|cannot measure/i)).toBeTruthy();
+  });
+});
+
+describe('CostPanelCard — ac-2: median and p90, never a bare mean', () => {
+  it('shows both median and p90 per operation', () => {
+    tagAc(AC(2));
+    render(<CostPanelCard data={populated()} />);
+    expect(screen.getByText(/median/i)).toBeTruthy();
+    expect(screen.getByText(/p90/i)).toBeTruthy();
+  });
+
+  it('never labels a figure as an average or a mean', () => {
+    tagAc(AC(2));
+    render(<CostPanelCard data={populated()} />);
+    // get_doc runs 4,428 median against 31,947 p90 — a factor of 7. One number
+    // would tell most readers something false about their own usage.
+    expect(screen.queryByText(/\baverage\b/i)).toBeNull();
+    expect(screen.queryByText(/\bmean\b/i)).toBeNull();
+  });
+
+  it('shows the guidance share per operation as its own column', () => {
+    tagAc(AC(2));
+    render(<CostPanelCard data={populated()} />);
+    // add_comment is 96,000 of 101,100 characters — 95% guidance. That is the
+    // half that is ours to cut, so it belongs in the reader's line of sight.
+    expect(screen.getByText(/95%/)).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/insights/CostPanelCard.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.tsx
@@ -1,0 +1,252 @@
+// spec-552 t-5 — the ninth Insights card: what Memex sent this Memex's agents.
+//
+// The reader is a person asking a budget question, so the craft here is
+// information design rather than typography. Three properties are load-bearing
+// and each has a test:
+//
+//   MEDIAN AND P90, NEVER A BARE MEAN (ac-2). get_doc measures 1,600 tokens at
+//   the median and 11,700 at p90 — a factor of seven on one operation. A single
+//   number per row tells most readers something false about their own usage.
+//
+//   EVERY FIGURE COMES FROM THE RESPONSE (ac-10), the window included. A
+//   literal here is a number that stops being true with nothing detecting it —
+//   which is the whole argument dec-3 settled.
+//
+//   ESTIMATES ARE MARKED AND CHARACTERS ARE REACHABLE (ac-13). Tokens are
+//   derived from a measured constant, not counted, so no token figure may read
+//   as exact; and the character count that IS measured sits on the row, so a
+//   reader who distrusts our divisor can recompute rather than take it on faith.
+//
+// And one thing the card says rather than implies: we do not compare against
+// not using Memex, because no honest comparison exists (Overview, question 3).
+// A reader seeing a total asks "versus what?" — if the card is silent they
+// invent a baseline.
+//
+// Hues follow theme.ts's fixed semantics [per std-27]: the ANSWER half takes
+// the app accent (blue, the "human" hue) and PLATFORM GUIDANCE takes violet
+// (the agent/platform hue). Rose stays reserved for failure and amber / cyan /
+// emerald for phases; none is borrowed.
+
+import type { CostPanelOperation, CostPanelResponse } from '../../api/insights';
+import { estimateTokens } from './tokenEstimate';
+import { useChartPalette } from './theme';
+
+/**
+ * Below this many measured calls the card shows a state, not a statistic.
+ *
+ * Mirrors the page's own convention — `MIN_SPECS_FOR_CHARTS` in Insights.tsx
+ * withholds every chart under three Specs — rather than inventing a second kind
+ * of threshold. The unit differs (calls, not Specs) because that is what this
+ * card measures; the rule is the page's.
+ */
+export const MIN_CALLS_FOR_FIGURES = 3;
+
+function pct(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 100);
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+/** "≈ 1,622" — the marker is not decoration; it is the honesty requirement. */
+function approxTokens(chars: number): string {
+  return `≈ ${fmt(estimateTokens(chars))}`;
+}
+
+interface RowProps {
+  op: CostPanelOperation;
+  guidanceHue: string;
+  track: string;
+}
+
+function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement {
+  const share = pct(op.guidanceChars, op.totalChars);
+  // The high-guidance rows are the actionable ones — those are ours to cut, and
+  // spec-510 is the work that cuts them. Emphasis puts them in the eye-line.
+  const hot = share >= 75;
+  const label = op.verb ? `${op.tool} · ${op.verb}` : op.tool;
+
+  return (
+    <tr>
+      <td className="py-2 font-mono text-xs text-primary">{label}</td>
+      <td className="py-2 text-right font-mono tabular-nums text-primary">
+        {fmt(op.calls)}
+      </td>
+      <td className="py-2 text-right font-mono tabular-nums text-primary">
+        {approxTokens(op.medianChars)}
+        {/* The measured number, beside the derived one (ac-13). */}
+        <span className="ml-2 text-[11px] text-muted">{fmt(op.medianChars)} ch</span>
+      </td>
+      <td className="py-2 text-right font-mono tabular-nums text-secondary">
+        {approxTokens(op.p90Chars)}
+      </td>
+      <td className="py-2 pl-4">
+        <span className="flex items-center justify-end gap-2">
+          <span
+            className="h-[5px] flex-1 min-w-[40px] rounded-full overflow-hidden"
+            style={{ background: track }}
+            aria-hidden="true"
+          >
+            <span
+              className="block h-full rounded-full"
+              style={{ width: `${share}%`, background: guidanceHue }}
+            />
+          </span>
+          <span
+            className="w-9 text-right font-mono text-xs"
+            style={hot ? { color: guidanceHue, fontWeight: 500 } : undefined}
+          >
+            {share}%
+          </span>
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+export function CostPanelCard({ data }: { data: CostPanelResponse }): React.ReactElement | null {
+  const palette = useChartPalette();
+  // Answer = the app accent (human hue); guidance = the agent/platform hue.
+  const answerHue = palette.actor.human;
+  const guidanceHue = palette.actor.mcp_agent;
+
+  // Not available is not a failure: render NOTHING. No placeholder, no error,
+  // no empty frame — the page must look exactly as it does today for a Memex
+  // outside the rollout or a caller who is not a member (dec-9).
+  if (!data.available) return null;
+
+  const { windowDays, totals, operations } = data;
+  const guidanceShare = pct(totals.guidanceChars, totals.totalChars);
+  const answerShare = 100 - guidanceShare;
+
+  return (
+    <div className="p-5 bg-panel border border-edge rounded-lg">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-sm font-semibold text-heading">
+            What Memex sent your agents
+          </h2>
+          <p className="text-xs text-secondary mt-1">
+            Every response has two parts: the answer your agent asked for, and
+            the platform guidance we attach.
+          </p>
+        </div>
+        <span className="text-[11px] text-secondary border border-edge rounded-full px-2.5 py-0.5 whitespace-nowrap">
+          Last {windowDays} days
+        </span>
+      </div>
+
+      {totals.calls < MIN_CALLS_FOR_FIGURES ? (
+        <div className="text-center py-8">
+          <div className="text-sm text-primary font-medium">
+            Not enough activity yet
+          </div>
+          <div className="text-xs text-secondary mt-1">
+            Figures appear once this Memex has a few days of agent traffic
+            behind it.
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-7 mt-5">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+                Sent to your agents
+              </div>
+              <div className="text-2xl font-semibold text-heading mt-0.5 tabular-nums">
+                {approxTokens(totals.totalChars)}{' '}
+                <span className="text-sm font-medium text-secondary">tokens</span>
+              </div>
+              <div className="text-xs text-secondary">
+                {fmt(totals.totalChars)} characters
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+                Of that, platform guidance
+              </div>
+              <div className="text-2xl font-semibold text-heading mt-0.5 tabular-nums">
+                {guidanceShare}
+                <span className="text-sm font-medium text-secondary">%</span>
+              </div>
+              <div className="text-xs text-secondary">
+                {approxTokens(totals.guidanceChars)} tokens
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+                Calls
+              </div>
+              <div className="text-2xl font-semibold text-heading mt-0.5 tabular-nums">
+                {fmt(totals.calls)}
+              </div>
+              <div className="text-xs text-secondary">
+                {operations.length} operations
+              </div>
+            </div>
+          </div>
+
+          <div
+            className="flex h-3 gap-0.5 rounded-sm my-4 overflow-hidden"
+            role="img"
+            aria-label={`${answerShare} percent answers, ${guidanceShare} percent platform guidance`}
+          >
+            <span
+              style={{
+                width: `${answerShare}%`,
+                background: `${answerHue}2e`,
+                boxShadow: `inset 0 0 0 1px ${answerHue}`,
+              }}
+            />
+            <span
+              style={{
+                width: `${guidanceShare}%`,
+                background: `${guidanceHue}2e`,
+                boxShadow: `inset 0 0 0 1px ${guidanceHue}`,
+              }}
+            />
+          </div>
+
+          <div className="overflow-x-auto mt-5">
+            <table className="w-full text-[13px] border-collapse min-w-[560px]">
+              <thead>
+                <tr className="text-[10.5px] font-semibold uppercase tracking-wider text-muted">
+                  <th className="text-left pb-2 border-b border-edge">Operation</th>
+                  <th className="text-right pb-2 border-b border-edge">Calls</th>
+                  <th className="text-right pb-2 border-b border-edge">Median</th>
+                  <th className="text-right pb-2 border-b border-edge">p90</th>
+                  <th className="text-right pb-2 pl-4 border-b border-edge">
+                    Guidance
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {operations.map((op) => (
+                  <OperationRow
+                    key={`${op.tool}:${op.verb ?? ''}`}
+                    op={op}
+                    guidanceHue={guidanceHue}
+                    track={palette.verification.untested}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-4 pt-3 border-t border-edge flex flex-wrap gap-y-2 gap-x-6 justify-between">
+            <p className="text-xs text-secondary m-0">
+              Tokens are estimated from characters; the exact character counts
+              are on each row.
+            </p>
+            <p className="text-xs text-secondary m-0">
+              We don&apos;t compare this with not using Memex — we can&apos;t
+              measure that honestly.
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/insights/tokenEstimate.test.ts
+++ b/packages/ui/src/components/insights/tokenEstimate.test.ts
@@ -52,8 +52,15 @@ describe("the chars-to-tokens divisor (spec-552 ac-12)", () => {
     // Comments are stripped first: this module's own prose discusses 3.0, 2.38
     // and the band edges, and a naive scan would match its own documentation.
     // (Both source guards written earlier today tripped on exactly that.)
+    // PRODUCTION files only. A test file legitimately quotes divisor SHAPES —
+    // CostPanelCard.test.tsx carries the very regex that hunts for them — and
+    // flagging those is a false positive that trains people to disable the
+    // guard. What must stay clean is the code that ships.
     const files = readdirSync(here).filter(
-      (f) => f.endsWith(".ts") || f.endsWith(".tsx")
+      (f) =>
+        (f.endsWith(".ts") || f.endsWith(".tsx")) &&
+        !f.includes(".test.") &&
+        !f.includes(".spec.")
     );
     const offenders: string[] = [];
     for (const file of files) {

--- a/packages/ui/src/pages/Insights.spec-179.test.tsx
+++ b/packages/ui/src/pages/Insights.spec-179.test.tsx
@@ -54,6 +54,11 @@ const fetchActivityByActor = vi.fn();
 const fetchAcVerification = vi.fn();
 const fetchAcsOverTime = vi.fn();
 const fetchTestRunVolume = vi.fn();
+// spec-552 t-5: the page's Promise.all now covers a ninth endpoint. It has to
+// be mocked here or every assertion in this file fails on the ERROR state —
+// one unmocked fetch rejects the batch and blanks the page, which is the same
+// coupling that made a 404 unacceptable for the gated case (dec-9).
+const fetchCostPanel = vi.fn();
 // Partial mock: AppShell's hooks (drift inbox count, …) pull other exports
 // from the client module, so everything else passes through unmocked.
 vi.mock(import('../api/client'), async (importOriginal) => {
@@ -68,6 +73,7 @@ vi.mock(import('../api/client'), async (importOriginal) => {
     fetchAcVerification: (...a: unknown[]) => fetchAcVerification(...a),
     fetchAcsOverTime: (...a: unknown[]) => fetchAcsOverTime(...a),
     fetchTestRunVolume: (...a: unknown[]) => fetchTestRunVolume(...a),
+    fetchCostPanel: (...a: unknown[]) => fetchCostPanel(...a),
   };
 });
 
@@ -101,6 +107,10 @@ beforeEach(() => {
   fetchAcVerification.mockReset().mockResolvedValue(VERIFICATION);
   fetchAcsOverTime.mockReset().mockResolvedValue([{ day: '2026-06-01', created: 5, verified: 3 }]);
   fetchTestRunVolume.mockReset().mockResolvedValue([{ day: '2026-06-01', pass: 40, fail: 2, error: 0 }]);
+  // The default is the CLOSED shape, which is what most Memexes will see while
+  // the rollout is narrow — and it keeps this file's assertions about the
+  // spec-179 charts unaffected by the ninth card.
+  fetchCostPanel.mockReset().mockResolvedValue({ available: false });
 });
 
 function renderInsights(path = '/acme/team/insights') {

--- a/packages/ui/src/pages/Insights.tsx
+++ b/packages/ui/src/pages/Insights.tsx
@@ -19,6 +19,8 @@ import {
   fetchAcVerification,
   fetchAcsOverTime,
   fetchTestRunVolume,
+  fetchCostPanel,
+  type CostPanelResponse,
   type SpecsOverTimePoint,
   type SpecsByPhasePoint,
   type PhaseDurations,
@@ -38,6 +40,7 @@ import { ActivityStreamChart } from '../components/insights/ActivityStreamChart'
 import { AcVerificationChart } from '../components/insights/AcVerificationChart';
 import { AcsOverTimeChart } from '../components/insights/AcsOverTimeChart';
 import { TestRunVolumeChart } from '../components/insights/TestRunVolumeChart';
+import { CostPanelCard } from '../components/insights/CostPanelCard';
 
 // Below this many specs the charts are noise — show the unlock note instead.
 const MIN_SPECS_FOR_CHARTS = 3;
@@ -51,6 +54,10 @@ interface InsightsData {
   verification: AcVerificationSummary;
   acsOverTime: AcsOverTimePoint[];
   testRuns: TestRunVolumePoint[];
+  // spec-552 t-5. `available: false` is the normal answer for a Memex outside
+  // the rollout allowlist or a caller who is not a member — NOT an error, so it
+  // sits in the ready state like any other field and the card self-hides.
+  costPanel: CostPanelResponse;
 }
 
 type LoadState =
@@ -76,8 +83,9 @@ export function Insights() {
       fetchAcVerification(),
       fetchAcsOverTime(),
       fetchTestRunVolume(),
+      fetchCostPanel(),
     ])
-      .then(([overTime, byPhase, durations, funnel, activity, verification, acsOT, testRuns]) => {
+      .then(([overTime, byPhase, durations, funnel, activity, verification, acsOT, testRuns, costPanel]) => {
         if (cancelled) return;
         setState({
           kind: 'ready',
@@ -90,6 +98,7 @@ export function Insights() {
             verification,
             acsOverTime: acsOT,
             testRuns,
+            costPanel,
           },
         });
       })
@@ -202,6 +211,19 @@ export function Insights() {
               <ActivityStreamChart points={state.data.activity} />
             </Card>
           )}
+        </div>
+      )}
+
+      {/* spec-552 t-5 — the cost card sits OUTSIDE the MIN_SPECS_FOR_CHARTS
+          gate on purpose. That gate counts Specs, which is not what this card
+          measures; the card carries its own floor on measured CALLS
+          (MIN_CALLS_FOR_FIGURES). Nesting it would stack two thresholds, the
+          outer one gauging the wrong thing — a Memex with two Specs and real
+          agent traffic would see nothing. It renders null when the panel is
+          unavailable, so an ungated Memex's page is unchanged. */}
+      {state.kind === 'ready' && (
+        <div className="mt-4">
+          <CostPanelCard data={state.data.costPanel} />
         </div>
       )}
         </div>


### PR DESCRIPTION
Completes **spec-552** on top of PR #692 (which shipped the measurement substrate and is already deployed to int). Delivers **t-3, t-5 and t-6**: the aggregate, the card, and the journey + post-deploy smoke.

**spec-552 now reads 22 / 22 ACs verified.**

## What a user gets

A ninth card on the per-Memex Insights page: *what Memex sent your agents*, over a stated window, split into the answer the agent asked for and the platform guidance we attach, broken down per operation.

**Median and p90 per operation — never one average.** `get_doc` runs ~1,600 tokens at the median against ~11,700 at p90. A single number per row would tell most readers something false about their own usage.

**Every token figure is marked as an estimate, with the exact character count on the row beside it**, so a reader who distrusts our divisor (2.73, measured — see #692) recomputes rather than takes it on faith.

**And the card says, rather than implies, that we do not compare against not using Memex.** A reader seeing a total asks "versus what?"; if the card is silent they invent a baseline, and this Spec's central finding is that no honest baseline exists.

Three states: figures; "not enough activity yet" below three measured calls; and — for a Memex outside the rollout, or a caller who is not a member — **nothing at all**. No placeholder, no error, no empty frame.

## The authorization work, which is the real work

`GET /analytics/cost-panel` has **two layers, and neither alone is correct**:

| | |
|---|---|
| **readability** decides the 404 | `resolveReadableMemexId` first, exactly as the eight siblings do, so a caller who cannot see the Memex gets 404 before the capability question is asked |
| **membership** decides the figures | a caller who *can* read it but is not a member gets 200 with none |

The two closed states — "not a member" and "not on the allowlist" — are **byte-identical**, so the endpoint cannot be probed to enumerate the rollout allowlist. That falls out of the shape rather than being bolted on.

`mcp_tool_calls` is **excluded from RLS** (`drizzle/0081:37` — a deliberate exclusion whose nullable-safe policy was never written), so the `memex_id` predicate is the *entire* tenancy guarantee with no database-level second line. It is tested as such, in both directions.

## Four corrections to the plan, all found by reading the code

1. **It is a ninth `/analytics/*` endpoint, not a field.** dec-8 said the aggregate rides an existing payload as an optional field, on the reading that `Insights.tsx` makes one fetch. It runs `Promise.all` over **eight separate** calls.
2. **The gate must answer 200, never 404.** Under `Promise.all` one rejection fails the batch, so an endpoint that errors for a gated Memex would blank the **entire page — all eight existing cards**. A protection that destroys working function is a regression wearing a guard's clothes.
3. **And the first answer to that violated std-7.** Returning 200 to every non-member would confirm a *private* Memex exists (cl-2: membership-fail and not-found must be indistinguishable). The standards surfaced at the phase transition caught it; the plan as written would have shipped the leak. Hence the two layers.
4. **The 30-day window straddles migration 0144.** Rows predating it carry a NULL length; `percentile_cont` skips NULLs and `count(*)` does not, so a naive aggregate reports "400 calls" beside a median drawn from 120 rows — wrong in a way no test would catch. `count(result_text_length)` makes `n` and the median describe the same set.

## Test plan

- [x] **15 tagged tests** for the aggregate across two files. The split is load-bearing: dev-mode auth supplies a user on every request, so anonymity is unreachable in the first. The second disables it and **proves its own premise** with `expect(isDevMode()).toBe(false)` — without that assertion the file is a second non-member test wearing an anonymity label
- [x] `n` counts the measured population — asserted with a fixture mixing 3 measured rows and 2 pre-migration NULLs: `n` is 3, not 5
- [x] Grouping proven for **both** shapes (NULL verb and mixed verbs) before spec-511 exists
- [x] Cross-tenant leak, 404-vs-200 matrix, and byte-identical closed states all asserted directly
- [x] **12 tagged tests** for the card, including the window test that renders twice with different `windowDays` — a hardcoded "30" passes the first assertion and fails the second
- [x] A **Playwright journey** that seeds by driving **real MCP traffic** at `/mcp`, not fixture rows, so the guidance share on screen is non-zero *because both payload halves were captured on real calls* — a fixture cannot fake that
- [x] **Post-deploy smoke** written: every row since the run carries a length (read from an actual row, counts printed so a pass is distinguishable from a skipped tier), the `result >= footer` inequality, and the gate
- [x] Full server suite **724 files / 6,695 tests**; full UI suite **357 / 2,416**; `make check`, `make typecheck` and the real UI `build` gate all clean
- [x] **22 / 22 ACs verified**, confirmed by reading `list_acs` back rather than inferred from a green suite

### ⚠ `make e2e-cold` is NOT green locally — please let CI arbitrate

**146 passed, including the new journey-73. 14 failed:** journey-8, journey-12, journey-16 (all seven), journey-47, journey-55, journey-56 — all SSE / reactivity / streaming.

Three facts argue they are unrelated to this PR: they touch no surface it changes (journey-8 polls an agent conversation for persisted messages); `logToolCall` swallows its own errors by design, so a telemetry write cannot break an agent turn; and **CI's `e2e (1..3)` were green on PR #692 for this same suite**.

But that is reasoning, not evidence. They fail in isolation too, so it is not exhaustion from a long run, and the A/B that would settle it needs a fresh worktree a worktree-isolated session cannot create. **CI is the clean room.** Flagging this rather than claiming green — if `e2e` passes here, the local failures were environmental; if it fails, this PR owns them.

## Two limits recorded rather than papered over

**The journey cannot reach the card-absent state.** The gate is read from server env, which `playwright.config.ts` fixes for the whole run (`*`, matching int per dec-8). Absent is proven one tier down — the component renders null, the endpoint returns byte-identical closed responses. The alternatives are worse than the gap: a deterministic tenant slug breaks CI retries (`seed-org` is not idempotent), and a test endpoint that mutates server env costs more than the coverage.

**The smoke verifies one gate direction per environment.** int runs `*`, so only the open direction exists there; the closed direction is verifiable on prod, where the value names the dogfood Memex alone. The file says so in its header: do not read a green int smoke as proof the gate can refuse.

## Deploy notes

- **No migration** — 0144 shipped with #692 and is applied on int (verified from the deploy log).
- **`COST_PANEL_MEMEXES` still needs a GitHub Environment variable per env** — the one link of the four that cannot live in the repo. Suggested: `*` on int; on prod leave it **unset until you want the card visible**, since unset means nobody.
- Post-deploy [per std-17]: run the smoke added here, and read its printed counts — a skipped tier looks identical to a passing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
