### PR TITLE
fix(spec-552): a per-operation p90 appears only where a row has the calls to support one

### DIFF
--- a/packages/server/src/routes/analytics-cost-panel.integration.test.ts
+++ b/packages/server/src/routes/analytics-cost-panel.integration.test.ts
@@ -230,6 +230,33 @@ describe("GET /analytics/cost-panel — a member of an allowlisted Memex", () =>
     expect(row.medianChars).toBe(2000);
   });
 
+  it("returns p90Chars on a single-call row too — the display gates, not the API", async () => {
+    tagAc(AC(26));
+    openTo(memberSlug);
+    // dec-10 withholds a thin row's p90 IN THE CARD. The temptation once that
+    // ships is to "finish the job" server-side and null the column here, which
+    // would break spec-458 dec-5 — the endpoint always returns the truth, and
+    // display gating is a page concern. It would also silently disarm the UI
+    // test: a card asked to hide a value it never receives would pass for the
+    // wrong reason.
+    await seedCall({
+      memexId: memberMemexId,
+      toolName: "lonely_tool",
+      resultLen: 4242,
+      footerLen: 42,
+    });
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    const body = await res.json();
+    const row = body.operations.find(
+      (o: { tool: string }) => o.tool === "lonely_tool"
+    );
+    expect(row.calls).toBe(1);
+    // Present, numeric, and equal to the only observation there is.
+    expect(row.p90Chars).toBe(4242);
+    expect(row.medianChars).toBe(4242);
+  });
+
   it("groups on (tool, verb): NULL verbs collapse, distinct verbs split", async () => {
     tagAc(AC(14));
     openTo(memberSlug);

--- a/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
+++ b/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
@@ -14,6 +14,11 @@
 //          calls to support one, and is withheld with a stated reason where it
 //          does not. Both sides come from real traffic at two volumes, so the
 //          threshold is exercised end to end rather than mocked.
+//   ac-28 — and the column itself is only drawn because one row earns it. The
+//          all-thin case (no column at all) is a component-tier test: it needs
+//          a payload where every row is below the floor, which would mean
+//          seeding no operation above it — and then the mixed case, which is
+//          the one a real Memex reaches, would go uncovered here.
 //
 // SEEDING IS REAL TRAFFIC, not fixture rows. The journey drives actual MCP
 // tool calls at `/mcp` (the same shape journey-20 uses), so `mcp_tool_calls`
@@ -46,6 +51,7 @@ const ACS = [
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-3",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-23",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-24",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-28",
 ];
 
 const DEV_MCP_BEARER = "mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION";
@@ -146,10 +152,19 @@ test("the cost card reports real MCP traffic, per operation, with a median and a
   ).toBeVisible();
   await expect(page.getByRole("columnheader", { name: /p90/i })).toBeVisible();
 
-  // dec-10, both sides, from real traffic (ac-23 / ac-24):
-  //   the 10-call row earns its p90, and the 1-call row is told it cannot.
-  // The withheld cell's reason is spoken-only, so it is found by text, not
-  // sight — exactly how a screen-reader user meets it.
+  // dec-10, both sides, from real traffic (ac-23 / ac-24 / ac-28):
+  //   the 10-call row earns its p90 — which is also what puts the header above
+  //   on screen at all, since ac-28 drops the whole column when no row does —
+  //   and the 1-call row is told it cannot. The withheld cell's reason is
+  //   spoken-only, so it is found by text rather than by sight, which is
+  //   exactly how a screen-reader user meets it.
+  //
+  // ⚠ THE COUNT ENCODES THE SEEDING. `toHaveCount(1)` holds because exactly ONE
+  // seeded operation sits below the floor. Seed a third tool thinly and this
+  // fails on the count rather than on anything meaningful — so change the
+  // number here in the same edit, or assert a range. Deliberately exact rather
+  // than `>= 1`: a range would also pass if the qualifying row were withheld
+  // too, which is the regression worth catching.
   await expect(page.getByText(/too few calls for a p90/i)).toHaveCount(1);
   await expect(page.getByText("list_tasks").first()).toBeVisible();
 

--- a/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
+++ b/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
@@ -10,6 +10,10 @@
 //          per operation, with a median and a p90 rather than one average.
 //   ac-3 — the figures are computed, not authored: nothing is seeded into the
 //          card, and the numbers appear only because tool calls happened.
+//   ac-23/ac-24 — a per-operation p90 appears only where the row has enough
+//          calls to support one, and is withheld with a stated reason where it
+//          does not. Both sides come from real traffic at two volumes, so the
+//          threshold is exercised end to end rather than mocked.
 //
 // SEEDING IS REAL TRAFFIC, not fixture rows. The journey drives actual MCP
 // tool calls at `/mcp` (the same shape journey-20 uses), so `mcp_tool_calls`
@@ -40,6 +44,8 @@ const ACS = [
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-1",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-2",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-3",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-23",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-24",
 ];
 
 const DEV_MCP_BEARER = "mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION";
@@ -98,12 +104,26 @@ test("the cost card reports real MCP traffic, per operation, with a median and a
   });
   const specRef = `${tenant.namespaceSlug}/${tenant.memexSlug}/specs/${spec.handle}`;
 
-  // ── 2. REAL traffic. Four calls clears MIN_CALLS_FOR_FIGURES (3) with room,
-  //      and get_doc responses carry the platform footer — which is what makes
-  //      the guidance share on screen a measurement rather than a constant.
-  for (let i = 0; i < 4; i += 1) {
+  // ── 2. REAL traffic, ACROSS THE P90 FLOOR (dec-10) ────────────────────────
+  //      Two operations at different volumes, so one row earns a p90 and the
+  //      other is withheld — the threshold proved on the production path, not
+  //      simulated from a fixture.
+  //
+  //      Ten get_doc calls clear MIN_CALLS_FOR_P90; get_doc responses also
+  //      carry the platform footer, which is what makes the guidance share on
+  //      screen a measurement rather than a constant.
+  //      ONE list_tasks call sits below the floor.
+  //      Eleven calls together clear MIN_CALLS_FOR_FIGURES (3) with room.
+  //
+  //      The literal 10 is deliberate here, and it is NOT the duplication
+  //      ac-25 forbids: an e2e file cannot import a React module, and a
+  //      mismatch with the constant reds this run loudly. What ac-25 protects
+  //      against is a test that stays GREEN on the wrong side of the
+  //      threshold, which is a unit-test hazard, not this one.
+  for (let i = 0; i < 10; i += 1) {
     await mcpToolCall(request, "get_doc", { ref: specRef });
   }
+  await mcpToolCall(request, "list_tasks", { ref: specRef });
 
   // ── 3. The card, on the page a member actually visits ─────────────────────
   await page.goto(`/${tenant.namespaceSlug}/${tenant.memexSlug}/insights`);
@@ -117,9 +137,21 @@ test("the cost card reports real MCP traffic, per operation, with a median and a
   // Per-operation rows, and the operation named is the one we really called.
   await expect(page.getByText("get_doc").first()).toBeVisible();
 
-  // Median AND p90 — never one number standing in for both (ac-2).
-  await expect(page.getByText("Median", { exact: false }).first()).toBeVisible();
-  await expect(page.getByText("p90", { exact: false }).first()).toBeVisible();
+  // Median AND p90 — never one number standing in for both (ac-2). Asserted on
+  // the column HEADERS by role: `getByText("p90").first()` matched the header
+  // and would have stayed green with every value cell withheld — green for the
+  // wrong reason, which is the failure this whole Spec keeps meeting.
+  await expect(
+    page.getByRole("columnheader", { name: /median/i })
+  ).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: /p90/i })).toBeVisible();
+
+  // dec-10, both sides, from real traffic (ac-23 / ac-24):
+  //   the 10-call row earns its p90, and the 1-call row is told it cannot.
+  // The withheld cell's reason is spoken-only, so it is found by text, not
+  // sight — exactly how a screen-reader user meets it.
+  await expect(page.getByText(/too few calls for a p90/i)).toHaveCount(1);
+  await expect(page.getByText("list_tasks").first()).toBeVisible();
 
   // Token figures are marked as estimates, and the characters behind them are
   // on the row so a reader can recompute.

--- a/packages/ui/src/components/insights/CostPanelCard.test.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.test.tsx
@@ -312,6 +312,60 @@ describe('CostPanelCard — dec-10: a row too thin for a percentile', () => {
     render(<CostPanelCard data={acrossTheFloor()} />);
     // A bare <td> announces nothing to a screen reader, and "missing" and
     // "deliberately withheld" are the same experience. The reason is text.
+    const reason = screen.getByText(/too few calls/i);
+    expect(reason).toBeTruthy();
+
+    // The string being in the DOM is NOT the claim — testing-library ignores
+    // CSS, so `getByText` would find it inside an aria-hidden subtree just as
+    // happily. What ac-27 promises is that a screen reader REACHES it, so
+    // assert the two halves carry opposite visibility: the reason is spoken and
+    // the dash is not. Without this the test passes on markup no reader hears.
+    expect(reason.closest('[aria-hidden="true"]')).toBeNull();
+    const dash = screen.getByText('—');
+    expect(dash.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('draws no p90 column at all when NO row clears the floor', () => {
+    tagAc(AC(28));
+    // The state a young Memex actually lives in: enough total calls for the
+    // panel to show figures, no single operation near the floor. This is the
+    // dogfood card as measured on prod 2026-09-09 — twelve operations, the
+    // busiest at n=2 — where a p90 header would have stood over twelve em
+    // dashes for weeks.
+    const allThin: CostPanelResponse = {
+      available: true,
+      windowDays: 30,
+      totals: { calls: 3, totalChars: 30_000, guidanceChars: 9_000 },
+      operations: [1, 1, 1].map((calls, i) => ({
+        tool: `thin_tool_${i}`,
+        verb: null,
+        calls,
+        medianChars: 10_000,
+        p90Chars: 10_000,
+        guidanceChars: 3_000,
+        totalChars: 10_000,
+      })),
+    };
+    render(<CostPanelCard data={allThin} />);
+
+    // The table is drawn — this is not the not-enough-activity state.
+    expect(screen.getByRole('columnheader', { name: /median/i })).toBeTruthy();
+    expect(screen.getByText('thin_tool_0')).toBeTruthy();
+
+    // But no p90 header, and no withheld-cell dashes either: an absent column
+    // needs no per-row apology.
+    expect(screen.queryByRole('columnheader', { name: /p90/i })).toBeNull();
+    expect(screen.queryByText(/too few calls/i)).toBeNull();
+  });
+
+  it('brings the column back as soon as one row earns it', () => {
+    tagAc(AC(28));
+    // The other direction, because a gate that never opens is the same bug as
+    // one that never closes. `acrossTheFloor` has exactly one qualifying row.
+    render(<CostPanelCard data={acrossTheFloor()} />);
+    expect(screen.getByRole('columnheader', { name: /p90/i })).toBeTruthy();
+    // And the thin row beside it is withheld rather than dropped from view.
+    expect(screen.getByText('update_doc')).toBeTruthy();
     expect(screen.getByText(/too few calls/i)).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/insights/CostPanelCard.test.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.test.tsx
@@ -18,7 +18,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tagAc } from '@memex-ai-ac/vitest';
-import { CostPanelCard } from './CostPanelCard';
+import { CostPanelCard, MIN_CALLS_FOR_FIGURES, MIN_CALLS_FOR_P90 } from './CostPanelCard';
+import { estimateTokens } from './tokenEstimate';
 import type { CostPanelResponse } from '../../api/insights';
 
 const AC = (n: number) =>
@@ -181,8 +182,12 @@ describe('CostPanelCard — ac-2: median and p90, never a bare mean', () => {
   it('shows both median and p90 per operation', () => {
     tagAc(AC(2));
     render(<CostPanelCard data={populated()} />);
-    expect(screen.getByText(/median/i)).toBeTruthy();
-    expect(screen.getByText(/p90/i)).toBeTruthy();
+    // Headers by role. A text query here passed only because this fixture's
+    // rows both clear MIN_CALLS_FOR_P90; dropping one below it would have made
+    // the withheld cell's spoken reason a second /p90/i match and reddened
+    // this test for a reason that has nothing to do with ac-2 (dec-10).
+    expect(screen.getByRole('columnheader', { name: /median/i })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: /p90/i })).toBeTruthy();
   });
 
   it('never labels a figure as an average or a mean', () => {
@@ -200,5 +205,113 @@ describe('CostPanelCard — ac-2: median and p90, never a bare mean', () => {
     // add_comment is 96,000 of 101,100 characters — 95% guidance. That is the
     // half that is ours to cut, so it belongs in the reader's line of sight.
     expect(screen.getByText(/95%/)).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dec-10 (t-7) — the P90 floor.
+//
+// Observed on prod 2026-09-09: ten of twelve rows carried n=1, and every one
+// still printed a MEDIAN and a P90. At n=1 those are the same observation under
+// two headers; at n=2 the p90 is `percentile_cont` interpolating 90% of the way
+// between the only two calls seen. Below n=10 no observation actually sits in
+// the top decile, so the cell claims a tail it has not observed.
+//
+// THE FIXTURE IS DERIVED FROM THE CONSTANT, NOT FROM 10 (ac-25). A test that
+// hardcoded 9 would, the day someone raises the floor to 30, silently start
+// asserting the ABOVE-floor case twice and prove nothing about suppression —
+// green, for the wrong reason. Reading the constant re-aims it instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The card's own arithmetic, so the expectation cannot drift from it. */
+const approx = (chars: number): string =>
+  `≈ ${estimateTokens(chars).toLocaleString('en-US')}`;
+
+/**
+ * One payload, both sides of the floor. Deliberately ONE fixture rather than
+ * two: a regression that blanks EVERY p90 must fail, and it would pass a
+ * suppression-only test (ac-24 is the other half of ac-23).
+ */
+function acrossTheFloor(): CostPanelResponse {
+  return {
+    available: true,
+    windowDays: 30,
+    totals: { calls: 2 * MIN_CALLS_FOR_P90 - 1, totalChars: 300_000, guidanceChars: 90_000 },
+    operations: [
+      {
+        // AT the floor — the p90 renders.
+        tool: 'get_doc',
+        verb: null,
+        calls: MIN_CALLS_FOR_P90,
+        medianChars: 2_000,
+        p90Chars: 888_888,
+        guidanceChars: 60_000,
+        totalChars: 200_000,
+      },
+      {
+        // ONE BELOW the floor — the p90 is withheld, the median is not.
+        tool: 'update_doc',
+        verb: null,
+        calls: MIN_CALLS_FOR_P90 - 1,
+        medianChars: 1_000,
+        p90Chars: 999_999,
+        guidanceChars: 30_000,
+        totalChars: 100_000,
+      },
+    ],
+  };
+}
+
+describe('CostPanelCard — dec-10: a row too thin for a percentile', () => {
+  it('withholds the p90 on a row below the floor while still showing its median', () => {
+    tagAc(AC(23));
+    render(<CostPanelCard data={acrossTheFloor()} />);
+
+    // The thin row is present and its median — meaningful at any n, because it
+    // IS the value — still renders with its exact character count beside it.
+    expect(screen.getByText('update_doc')).toBeTruthy();
+    expect(screen.getByText(approx(1_000))).toBeTruthy();
+    expect(screen.getByText('1,000 ch')).toBeTruthy();
+
+    // But its p90 figure is nowhere on the card. 999,999 characters is a value
+    // no other cell in this fixture can produce, so this cannot pass by
+    // coincidence.
+    expect(screen.queryByText(approx(999_999))).toBeNull();
+  });
+
+  it('still renders the p90 on a row at the floor — a threshold, not a removal', () => {
+    tagAc(AC(24));
+    render(<CostPanelCard data={acrossTheFloor()} />);
+
+    expect(screen.getByText(approx(888_888))).toBeTruthy();
+    // And the column itself survives: ac-2 committed to a median AND a p90.
+    // By ROLE, not by text: the withheld cell's spoken reason also contains
+    // "p90", so a text query matches two nodes and throws. The claim was
+    // always about the HEADER anyway.
+    expect(screen.getByRole('columnheader', { name: /p90/i })).toBeTruthy();
+  });
+
+  it('derives the floor from the exported constant rather than a literal', () => {
+    tagAc(AC(25));
+    // The constant is what the card reads, so the card and this test cannot
+    // disagree about where the threshold is. Asserted as a property of the
+    // fixture: exactly one row sits below it and one at it.
+    const { operations } = acrossTheFloor() as Extract<
+      CostPanelResponse,
+      { available: true }
+    >;
+    expect(operations.filter((o) => o.calls < MIN_CALLS_FOR_P90)).toHaveLength(1);
+    expect(operations.filter((o) => o.calls >= MIN_CALLS_FOR_P90)).toHaveLength(1);
+    // A floor at or below the panel's own gate would be inert: every row that
+    // reaches the table would clear it, and nothing would ever be suppressed.
+    expect(MIN_CALLS_FOR_P90).toBeGreaterThan(MIN_CALLS_FOR_FIGURES);
+  });
+
+  it('says why the cell is empty rather than leaving a silent blank', () => {
+    tagAc(AC(27));
+    render(<CostPanelCard data={acrossTheFloor()} />);
+    // A bare <td> announces nothing to a screen reader, and "missing" and
+    // "deliberately withheld" are the same experience. The reason is text.
+    expect(screen.getByText(/too few calls/i)).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/insights/CostPanelCard.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.tsx
@@ -65,6 +65,24 @@ export const MIN_CALLS_FOR_FIGURES = 3;
  */
 export const MIN_CALLS_FOR_P90 = 10;
 
+/**
+ * Does ANY row have enough calls to carry a p90? If not, the column is not
+ * drawn at all — no header, no cells (dec-10, owner's call 2026-09-09).
+ *
+ * Withholding a cell is right; leaving a header standing over nothing but em
+ * dashes for its whole height is not. A young Memex has every row below the
+ * floor, so that is the state it would live in for weeks — and the first thing
+ * a reader does with an empty column is wonder what broke. The column comes
+ * back on its own the day one operation reaches the floor.
+ *
+ * This does not weaken ac-2's median-AND-p90 commitment: the p90 is computed,
+ * returned by the API for every row, and shown wherever it can mean something.
+ * What is gated is drawing a header for a statistic nothing on screen has.
+ */
+function anyRowEarnsP90(operations: readonly CostPanelOperation[]): boolean {
+  return operations.some((op) => op.calls >= MIN_CALLS_FOR_P90);
+}
+
 function pct(part: number, whole: number): number {
   if (whole <= 0) return 0;
   return Math.round((part / whole) * 100);
@@ -83,9 +101,11 @@ interface RowProps {
   op: CostPanelOperation;
   guidanceHue: string;
   track: string;
+  /** Whether the table is drawing a p90 column at all (see anyRowEarnsP90). */
+  showP90: boolean;
 }
 
-function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement {
+function OperationRow({ op, guidanceHue, track, showP90 }: RowProps): React.ReactElement {
   const share = pct(op.guidanceChars, op.totalChars);
   // The high-guidance rows are the actionable ones — those are ours to cut, and
   // spec-510 is the work that cuts them. Emphasis puts them in the eye-line.
@@ -103,23 +123,29 @@ function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement 
         {/* The measured number, beside the derived one (ac-13). */}
         <span className="ml-2 text-[11px] text-muted">{fmt(op.medianChars)} ch</span>
       </td>
-      <td className="py-2 text-right font-mono tabular-nums text-secondary">
-        {op.calls >= MIN_CALLS_FOR_P90 ? (
-          approxTokens(op.p90Chars)
-        ) : (
-          <>
-            {/* An em dash reads as "deliberately nothing" where a blank reads
-                as broken. The WHY is the call count already on this row, so
-                nothing new is asserted — but a sighted reader gets it from the
-                Calls column and a screen reader gets nothing, hence the
-                spoken-only reason beside it (dec-10, ac-27). */}
-            <span aria-hidden="true" className="text-muted">
-              &mdash;
-            </span>
-            <span className="sr-only">Too few calls for a p90</span>
-          </>
-        )}
-      </td>
+      {showP90 && (
+        <td className="py-2 text-right font-mono tabular-nums text-secondary">
+          {op.calls >= MIN_CALLS_FOR_P90 ? (
+            approxTokens(op.p90Chars)
+          ) : (
+            <>
+              {/* An em dash reads as "deliberately nothing" where a blank reads
+                  as broken. The WHY is the call count already on this row, so
+                  nothing new is asserted — but a sighted reader gets it from the
+                  Calls column and a screen reader gets nothing, hence the
+                  spoken-only reason beside it (dec-10, ac-27).
+
+                  The dash is aria-hidden and the reason is not: a reader who
+                  can see the dash needs no sentence, and a reader who cannot
+                  needs the sentence and not a dash announced as "em dash". */}
+              <span aria-hidden="true" className="text-muted">
+                &mdash;
+              </span>
+              <span className="sr-only">Too few calls for a p90</span>
+            </>
+          )}
+        </td>
+      )}
       <td className="py-2 pl-4">
         <span className="flex items-center justify-end gap-2">
           <span
@@ -158,6 +184,7 @@ export function CostPanelCard({ data }: { data: CostPanelResponse }): React.Reac
   const { windowDays, totals, operations } = data;
   const guidanceShare = pct(totals.guidanceChars, totals.totalChars);
   const answerShare = 100 - guidanceShare;
+  const showP90 = anyRowEarnsP90(operations);
 
   return (
     <div className="p-5 bg-panel border border-edge rounded-lg">
@@ -254,7 +281,9 @@ export function CostPanelCard({ data }: { data: CostPanelResponse }): React.Reac
                   <th className="text-left pb-2 border-b border-edge">Operation</th>
                   <th className="text-right pb-2 border-b border-edge">Calls</th>
                   <th className="text-right pb-2 border-b border-edge">Median</th>
-                  <th className="text-right pb-2 border-b border-edge">p90</th>
+                  {showP90 && (
+                    <th className="text-right pb-2 border-b border-edge">p90</th>
+                  )}
                   <th className="text-right pb-2 pl-4 border-b border-edge">
                     Guidance
                   </th>
@@ -267,6 +296,7 @@ export function CostPanelCard({ data }: { data: CostPanelResponse }): React.Reac
                     op={op}
                     guidanceHue={guidanceHue}
                     track={palette.verification.untested}
+                    showP90={showP90}
                   />
                 ))}
               </tbody>

--- a/packages/ui/src/components/insights/CostPanelCard.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.tsx
@@ -8,6 +8,12 @@
 //   the median and 11,700 at p90 — a factor of seven on one operation. A single
 //   number per row tells most readers something false about their own usage.
 //
+//   ...BUT ONLY WHERE A P90 MEANS SOMETHING (dec-10, ac-23/ac-24). The first
+//   real prod read showed ten of twelve rows at n=1, each printing a median and
+//   a p90 that were the same observation under two headers. Below
+//   MIN_CALLS_FOR_P90 the cell is withheld, because a column header a reader
+//   has to discount per row is a header that has stopped working.
+//
 //   EVERY FIGURE COMES FROM THE RESPONSE (ac-10), the window included. A
 //   literal here is a number that stops being true with nothing detecting it —
 //   which is the whole argument dec-3 settled.
@@ -40,6 +46,24 @@ import { useChartPalette } from './theme';
  * card measures; the rule is the page's.
  */
 export const MIN_CALLS_FOR_FIGURES = 3;
+
+/**
+ * Below this many calls on ONE OPERATION, that row's p90 is withheld (dec-10).
+ *
+ * Not a rounder version of the constant above — a different claim. The panel
+ * gate asks "does this Memex have enough traffic to show figures at all?"; this
+ * asks "does this ROW have enough calls for a 90th percentile to be a statement
+ * about variability?" Ten is where the answer turns: below it no observation
+ * actually falls in the top decile, so `percentile_cont` is interpolating
+ * between the last two values whatever the data does. A p90 there is arithmetic
+ * wearing a statistic's label.
+ *
+ * A plain constant, deliberately. spec-458 dec-1 made its honesty floor
+ * env-tunable; the sibling threshold in this very file is a constant, and
+ * consistency with the file a reader is looking at beats consistency with
+ * another Spec's deployment surface.
+ */
+export const MIN_CALLS_FOR_P90 = 10;
 
 function pct(part: number, whole: number): number {
   if (whole <= 0) return 0;
@@ -80,7 +104,21 @@ function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement 
         <span className="ml-2 text-[11px] text-muted">{fmt(op.medianChars)} ch</span>
       </td>
       <td className="py-2 text-right font-mono tabular-nums text-secondary">
-        {approxTokens(op.p90Chars)}
+        {op.calls >= MIN_CALLS_FOR_P90 ? (
+          approxTokens(op.p90Chars)
+        ) : (
+          <>
+            {/* An em dash reads as "deliberately nothing" where a blank reads
+                as broken. The WHY is the call count already on this row, so
+                nothing new is asserted — but a sighted reader gets it from the
+                Calls column and a screen reader gets nothing, hence the
+                spoken-only reason beside it (dec-10, ac-27). */}
+            <span aria-hidden="true" className="text-muted">
+              &mdash;
+            </span>
+            <span className="sr-only">Too few calls for a p90</span>
+          </>
+        )}
       </td>
       <td className="py-2 pl-4">
         <span className="flex items-center justify-end gap-2">


### PR DESCRIPTION
## What this fixes, and how it was found

The first real production read of the cost card — `mindset-prod/memex-building-itself`, 2026-09-09 — showed fifteen calls across twelve operations, **ten of them at n=1**, and every row still printing a `MEDIAN` and a `P90`.

`update_doc`: one call, 63 characters. Median ≈23. P90 ≈23. The same single observation under two different column headers.

`get_doc` at n=2 looked more credible (≈9,763 against ≈17,451) and was not — that is `percentile_cont` interpolating 90% of the way between the only two calls observed.

Nothing displayed was false. The numbers are exactly what the SQL returned, the `CALLS` column truthfully reads 1, and the character count sits beside the estimate. **The column header was doing the misleading**: "P90" promises something about variability, and a reader does not audit each cell's sample size before trusting a header.

Raised as `issue-1`, resolved as `dec-10`, delivered as `t-7`.

## The two decisions behind the diff

**Withhold the cell, not the median** (`dec-10`, option B). Against annotating the row and letting the reader discount — which is closer to how this card behaves everywhere else — because [spec-255 dec-5](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-255) removed the per-minute rate number rather than annotate it: *"a 30-min average can never agree with the live end-dot, and the number was noise."* Against collapsing thin rows into an "other operations" line, which destroys the per-tool breakdown `ac-2` commits to on exactly the quiet Memexes that need it. The median stays on every row: at n=1 it **is** the value.

**The floor is 10, not 3.** Below ten calls no observation actually falls in the top decile, so the p90 is an interpolation between the last two values whatever the data does. Ten is the first n at which the 90th percentile lands on a real order-statistic boundary. Three was the cheap alternative — it matches `MIN_CALLS_FOR_FIGURES` and would have left the journey untouched — and was rejected as cosmetic: it removes only the case where median and p90 print identically.

**Then a second call, on seeing the consequence.** With *any* floor, every row of the current dogfood card is suppressed — the busiest operation is at n=2, so 3 and 10 produce the identical screen today. What the floor value decides is when the column comes *back*, not whether it is empty now. A "p90" header standing over nothing but em dashes for its full height, for weeks, for the only person who can see the card, is worse than no column. So: **when no row clears the floor, the column is not drawn at all** (`ac-28`). It returns the day one operation reaches ten calls.

The gate is display-only [per spec-458 dec-5 — *the endpoint always returns the truth; display gating is a page concern*]. `ac-26` guards that server-side, because a card asked to hide a value it never receives would pass `ac-23` for the wrong reason.

## Two "green for the wrong reason" findings, both in code that predates this change

**1. `journey-73` would NOT have gone red at the new floor** — contrary to what `dec-10`'s own resolution predicted. Its assertions read `getByText("p90").first()`, which matches the column *header*, so it would have stayed green with every value cell withheld. **Hollow green, worse than the red I forecast.** A red stops the PR; a hollow green ships and keeps reporting coverage it no longer has.

It now asserts headers by `getByRole("columnheader", …)` and drives **two operations at two volumes** — 10 × `get_doc`, 1 × `list_tasks` — so both sides of the floor are proved from real MCP traffic rather than simulated. That is more coverage than the journey had before. Correction recorded on `dec-10` as comment `c-3`.

**2. The pre-existing `ac-2` assertion carried the identical ambiguity**, surviving only because its fixture's rows both sit above the floor. Hardened to the same role query — this change is what introduced a second DOM node containing "p90", so it would have become a landmine for whoever next lowered a fixture's call count.

The transferable lesson: **a locator ending in `.first()` has already decided that ambiguity is acceptable**, and it will absorb the disappearance of the very thing the test is named after.

## TDD, stated honestly

- `ac-23` and `ac-27` were written first and went red **on the shipped card, for the right reason** — the p90 was found where the test says it must not be, and the reason text did not exist.
- `ac-24` was **green before the fix, deliberately.** It is the other half: its job is to still be green afterwards, so a regression that blanks every p90 cannot pass.
- `ac-26` was also born green, so it was **mutation-tested**: nulling thin p90s in the SQL (`CASE WHEN count(...) >= 10 THEN percentile_cont(0.9) END`) reds it. Original restored byte-identically.
- `ac-27`'s test initially asserted only that the reason *string* was in the DOM. testing-library ignores CSS, so it would have passed on markup no screen reader reaches. It now asserts the two halves carry opposite visibility: the reason is not inside an `aria-hidden` subtree, and the em dash is.
- `ac-25` was **amended mid-build**. As first written it required the journey to read the floor constant. Mis-aimed: an e2e file cannot import a React module, and a literal that disagrees reds the run *loudly*. What needs protecting is a unit test staying green on the **wrong side** of the threshold — so the unit fixture derives from the constant (`floor − 1`, `floor`) and the journey keeps its literal with the reasoning beside it [per std-50].

Both card tests mount the component [per std-45].

## Test plan

- [x] `CostPanelCard.test.tsx` — 18 passed (was 14)
- [x] `analytics-cost-panel.integration.test.ts` — 11 passed
- [x] `ac-26` mutation-tested red-capable, then restored
- [x] full `@memex/ui` vitest — 357 files / 2,420 passed
- [x] full `@memex/server` vitest — 724 files / 6,697 passed (one unrelated failure: `spec-129-ci-emission-key`, which asserts `MEMEX_EMIT_KEY` is set when emission is on; it was absent from the shell — environmental, and this diff touches no env)
- [x] `make check` (offline battery), `make typecheck`, `pnpm --filter @memex/ui build`
- [x] `.husky/pre-push` — 2,159 passed
- [x] `journey-73` against a cold DB — 2 passed, twice (before and after the column change)
- [x] `make e2e-cold` full — **145 passed, 15 failed**, and the failures are proven pre-existing, see below
- [x] 28/28 ACs verified on the board, confirmed via `list_acs` rather than from the absence of an emitter warning

### About the 15 e2e failures

`journey-73` passed **inside** the full run (tests 147 and 148). The 15 failures were then A/B'd rather than argued: the same eight files re-run at `origin/develop` (`6fbf5566`, detached, without either commit here) failed **14 of 15 identically, same test names** — `journey-16-reactivity` ×7, `journey-55-spec-300-skills` ×2, and one each in `journey-8`, `-12`, `-15`, `-47`, `-56`. The run log carries that family's usual signature: `activity_log insert failed (advisory — swallowed)` plus `Failed to fetch ACs: 404`, i.e. fixture data disappearing under a serial shared-DB run.

The fifteenth (`journey-61-spec-479-memex-rename`) did not reproduce, so it was re-run alone on this branch: 2 passed. A flake under full-suite load, on a journey that imports nothing this change edits.

**This is not a claim that the local suite is green.** It is evidence that the local reds predate this branch and that the journey covering this change passes. CI's e2e shards are the arbiter [per std-28].

## Deploy notes

Nothing to configure. `MIN_CALLS_FOR_P90` is a plain module constant, deliberately not env-tunable: spec-458 dec-1 made its honesty floor tunable, but the sibling threshold in this same file is a constant, and consistency with the file a reader is looking at wins.

No migration, no API shape change, no new flag. `COST_PANEL_MEMEXES` is untouched and stays at the dogfood Memex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
