### PR TITLE
fix(spec-525): the gate's mode check could skip in silence, and shadow is now a decision rather than a stage

### DIFF
--- a/packages/server/src/__smoke__/emission-gate.smoke.test.ts
+++ b/packages/server/src/__smoke__/emission-gate.smoke.test.ts
@@ -41,11 +41,15 @@ const AC_MARKER = "mindset-prod/memex-building-itself/specs/spec-525/acs/ac-20";
 /**
  * The mode each deployed environment is INTENDED to run.
  *
- * Both are `shadow` today: the rollout's first deploy runs shadow everywhere, and
- * enforcement is turned on later by configuration (t-10) after the window has produced
- * the numbers ac-2 requires. **When t-10 flips prod, this table is the edit that keeps
- * the smoke honest** — and a deploy that flips the secret without editing here fails,
- * which is the point. An intent nobody wrote down is not an intent the smoke can check.
+ * Both are `shadow`, and dec-8 made that TERMINAL rather than transitional: enforcement
+ * is declined, not deferred, so this table is not waiting on t-10 to flip prod. That
+ * inverts what this check is for. It used to guard a rollout in progress; it now guards
+ * a standing decision — if either environment ever serves `enforcing`, the gate starts
+ * refusing at a ceiling of 2 against a measured p99 of 8 and a max of 28, dropping
+ * verification data silently, which is exactly what ac-4 forbids.
+ *
+ * So a deploy that flips the secret without editing here fails, and that IS the point.
+ * An intent nobody wrote down is not an intent the smoke can check.
  */
 const INTENDED_MODE: Record<string, "shadow" | "enforcing"> = {
   int: "shadow",
@@ -94,29 +98,48 @@ describe(`emission admission gate smoke @ ${SMOKE_BASE_URL}`, () => {
     ).not.toBeNull();
   });
 
-  it.skipIf(!INTENDED_MODE[SMOKE_ENV])(
-    "the EFFECTIVE mode matches what this environment intended",
-    async () => {
-      tagAc(AC_MARKER);
-      const intended = INTENDED_MODE[SMOKE_ENV];
-      const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "{}",
-        redirect: "manual",
-      });
+  it("the EFFECTIVE mode matches what this environment intended", async () => {
+    tagAc(AC_MARKER);
+    // NOT skipIf, deliberately (spec-525 ac-29). This assertion used to be gated on
+    // `!INTENDED_MODE[SMOKE_ENV]`, and SMOKE_ENV defaults to "" while SMOKE_BASE_URL
+    // defaults to a REAL deployed host — so an invocation that forgot the variable
+    // still probed int, still passed the other three checks, and silently dropped the
+    // only one that proves the mode. A green run where this skipped was indistinguishable
+    // from one where it passed, which is this Spec's own fault reproduced inside its own
+    // guard: dec-8 made this check the mechanism that holds "the gate stays in shadow",
+    // and a guard that can decline to run is a guard you cannot rely on.
+    //
+    // std-50's third branch is the one that applies: read, declared, or REFUSED — never
+    // defaulted in silence. There is nothing to read and nothing safe to assume (guessing
+    // "int" would assert int's intent against a prod host and pass by coincidence, since
+    // both are shadow today), so it refuses and says how to fix it.
+    const intended = INTENDED_MODE[SMOKE_ENV];
+    expect(
+      intended,
+      `SMOKE_ENV=${JSON.stringify(SMOKE_ENV)} names no known environment, so this run ` +
+        `cannot know which mode ${SMOKE_BASE_URL} is supposed to serve. It is NOT skipped: ` +
+        `a silent skip here is the failure this check exists to catch. Run the suite as ` +
+        `\`make smoke-int\` / \`make smoke-prod\` (both export SMOKE_ENV), or set ` +
+        `SMOKE_ENV to one of: ${Object.keys(INTENDED_MODE).join(", ")}.`,
+    ).toBeDefined();
 
-      expect(
-        res.headers.get(EMISSION_GATE_HEADER),
-        `${SMOKE_ENV} is running a different mode than intended. Either the ` +
-          `MEMEX_EMISSION_GATE_MODE wiring in deploy.sh / deploy-config.sh was missed ` +
-          `(so the environment silently took the code default), or the canonical ` +
-          `memex-${SMOKE_ENV}-deploy-env secret changed without updating INTENDED_MODE ` +
-          `in this file. Both are the failure t-9 exists to catch — do not "fix" it by ` +
-          `editing the expectation until you know which.`,
-      ).toBe(intended);
-    },
-  );
+    const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      redirect: "manual",
+    });
+
+    expect(
+      res.headers.get(EMISSION_GATE_HEADER),
+      `${SMOKE_ENV} is running a different mode than intended. Either the ` +
+        `MEMEX_EMISSION_GATE_MODE wiring in deploy.sh / deploy-config.sh was missed ` +
+        `(so the environment silently took the code default), or the canonical ` +
+        `memex-${SMOKE_ENV}-deploy-env secret changed without updating INTENDED_MODE ` +
+        `in this file. Both are the failure t-9 exists to catch — do not "fix" it by ` +
+        `editing the expectation until you know which.`,
+    ).toBe(intended);
+  });
 
   it("the marker leaks nothing beyond the mode", async () => {
     tagAc(AC_MARKER);

--- a/packages/server/src/services/admission/emission-gate.ts
+++ b/packages/server/src/services/admission/emission-gate.ts
@@ -120,12 +120,23 @@ export type Acquisition =
 export type GateMode = "shadow" | "enforcing";
 
 /**
- * SHADOW, deliberately.
+ * SHADOW, deliberately — and since dec-8, PERMANENTLY.
  *
- * t-6 must wire `MEMEX_EMISSION_GATE_MODE` into both `deploy.sh` and the canonical
- * `memex-<env>-deploy-env` secret. Miss either edit and prod silently takes this default —
- * so the default has to be the direction that under-protects rather than the one that
- * enforces limits nobody has measured yet. An unrecognised value falls here too.
+ * t-6 wires `MEMEX_EMISSION_GATE_MODE` into both `deploy.sh` and the canonical
+ * `memex-<env>-deploy-env` secret (both environments declare `shadow` explicitly today,
+ * read off the serving revisions 2026-09-09). Miss either edit and an environment
+ * silently takes this default — so the default has to be the direction that
+ * under-protects rather than the one that enforces limits nobody has measured. An
+ * unrecognised value falls here too.
+ *
+ * dec-8 changed what that means. Shadow is no longer the first stage of a rollout whose
+ * second stage is enforcement: enforcement is DECLINED. spec-332 dec-2's transaction-mode
+ * pooling dissolves the connection scarcity the requests term was derived from, and the
+ * events term — which bounds heap, and which no pooler touches — sits ~2-3x below c-18's
+ * danger threshold on concurrency and ~60x below it on batch size. So this constant is
+ * the decided posture, not a waypoint, and `enforcing` is not a state this system is
+ * travelling toward. The post-deploy smoke asserts the SERVED mode against that decision
+ * (ac-29) rather than trusting this default to hold.
  */
 export const DEFAULT_GATE_MODE: GateMode = "shadow";
 

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -254,9 +254,13 @@ fi
 #                               the one that bounds what a queued request actually costs
 #                               (a parsed body, 1.1–1.5× its wire bytes; c-18). Default
 #                               20000, deliberately unreachable at today's ceiling of 2
-#                               (2 × 500 events max), so it cannot refuse before t-10 has
-#                               measured. Read the value to set from the heartbeat's
-#                               `inFlightEvents`, not from a guess.
+#                               (2 × 500 events max). It is NOT waiting on a measurement:
+#                               dec-8 declined enforcement, so the gate stays in shadow and
+#                               this term never refuses. The default IS the declaration, on
+#                               purpose. It becomes a live knob only if dec-8 re-opens (its
+#                               tripwire is spec-533 making batches bigger), and then the
+#                               value is read from the heartbeat's `inFlightEvents` against
+#                               c-18's heap figures, never from a guess.
 #
 # The CEILING is deliberately absent: ac-12 requires it computed from the resolved pool,
 # so it follows DB_POOL_MAX. A hand-set ceiling is a number someone raises during a busy


### PR DESCRIPTION
## Why

`spec-525` `dec-8` (decided today) **declines enforcement**: the emission admission gate stays in `shadow` permanently, as an instrument. It counts what enforcing would have refused and admits every caller, so `201` keeps meaning *persisted* by posture rather than only by argument.

That promotes `t-9`'s post-deploy mode check from "a check on a rollout in progress" to **the mechanism that holds the decision**. Which is why it matters that it could quietly not run.

## The defect

```js
it.skipIf(!INTENDED_MODE[SMOKE_ENV])("the EFFECTIVE mode matches what this environment intended", …)
```

- `SMOKE_ENV` defaults to `""` (`smoke-env.ts`), and `INTENDED_MODE` holds only `int` / `prod` → `INTENDED_MODE[""]` is `undefined` → `!undefined` is true → **the test vanishes**.
- `SMOKE_BASE_URL` independently defaults to `https://int.memex.ai`, so the run still probes a **real deployed host** and the three checks that need no intent still pass.
- Net effect: a green run against a live environment where the only assertion proving the gate's mode **did not execute** — indistinguishable from one where it passed. Nobody counts skips in a CI log.

That is `spec-525`'s own `ac-4` (*"shedding is never silent"*) violated inside `spec-525`'s own instrument.

**Blast radius today: nil.** All four invocation paths export `SMOKE_ENV` — `deploy.sh` → `make smoke-{int,prod}`, and `scripts/smoke-with-db.sh`. The hole opens on any other invocation: a bare `vitest`, an IDE run, or a future CI step calling vitest directly. Nothing that exists turns red from this change.

## The fix

It **refuses** instead of skipping, per `std-50`'s third branch — read, declared, or **refused**, never defaulted in silence. Nothing here is safe to assume: guessing `int` would assert int's intent against a prod host and pass *by coincidence*, since both are shadow today. The failure message names the remedy (`make smoke-int` / `make smoke-prod`, or set `SMOKE_ENV`).

Skips for genuinely absent credentials are deliberately untouched (`std-26`): **a skip for a missing credential is honest; a skip for a missing *intent* is not.** The comment in the file says so, so the next reader does not "simplify" this back.

## Also: prose that had drifted past `dec-8`

Two comments still described shadow as stage one of a rollout whose stage two is enforcement, and pointed at `t-10` for a measurement that will now never be taken:

- `emission-gate.ts` — `DEFAULT_GATE_MODE`'s doc
- `scripts/deploy-config.sh` — the `MEMEX_EMISSION_EVENT_BUDGET` note

Both now say shadow is the decided posture, why (`spec-332` `dec-2`'s transaction-mode pooling dissolves the requests term's premise; the events term bounds heap and sits far below `c-18`'s threshold), and what would re-open it.

## Test plan

- [x] **Red proven on real behaviour, not a mutant** [per std-52] — `SMOKE_ENV` unset: `1 failed | 3 passed`, **exit 1**. Prior shape on the same tree: `1 skipped | 3 passed`, **exit 0**.
- [x] **Green** — `SMOKE_ENV=int`: `4 passed`, exit 0.
- [x] **Full smoke vs int** — 21 passed, 0 unexpected skips. The 23 remaining skips are the credentialled tiers with no `SMOKE_MCP_TOKEN` / `SMOKE_SESSION_TOKEN`, by design.
- [x] `make check` — offline guard battery, exit 0.
- [x] `make typecheck` — exit 0 (server `tsc --noEmit` + ui `tsc -b`).
- [x] Admission + knobs-regression suites — 12 files / 104 tests passed.
- [x] Pre-push battery — 235 files / 2159 passed, 5 skipped, no flake.
- [ ] **The one that only CI can do: `ac-20` / `ac-29` go green from the next keyed deploy smoke.** Every local run above carried no `MEMEX_EMIT_KEY`, so `tagAc` batched a 401 and **no criterion moved**. Stated explicitly because a green suite that emitted nothing looks exactly like one that did.
- [ ] Reviewer sanity check: confirm no CI step invokes the smoke suite without `SMOKE_ENV`. I grepped the workflows, the Makefile, `deploy.sh` and `smoke-with-db.sh` and found none — a second pair of eyes on that is the one way this could turn a green pipeline red.

**std-28**: no user-facing flow added or altered — this is a post-deploy smoke assertion plus two doc comments — so no Playwright journey is added or extended.

## Notes for the reviewer

`dec-8`'s resolution carries **two correction blocks** worth reading before this diff, because they are why the change is three files and not thirty. I twice claimed a `std-50` configuration gap that did not exist (the mode *is* declared in both environments; `MEMEX_EMISSION_MAX_WAITERS` is documented as deliberately *derived*, and `MEMEX_EMISSION_EVENT_BUDGET` as a deliberately unreachable default). Both were refuted by reading the running system and then the file. The genuine defect was one line inside a guard that already existed, and it was only visible by **exercising** the guard's behaviour rather than reading its configuration.

`ac-30` was deleted rather than satisfied: it asked for the waiter bound to be pinned in a test, and that value is derived by design, so the test would have been manufactured to flip a badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
