### PR TITLE
release: spec-542 (MCP code-grounding read) + spec-525 (emission-gate mode check) + spec-552 (cost-panel p90)

### DIFF
--- a/packages/server/src/__regression__/spec-525-gate-knobs.regression.test.ts
+++ b/packages/server/src/__regression__/spec-525-gate-knobs.regression.test.ts
@@ -24,6 +24,7 @@ import {
 const SPEC = "mindset-prod/memex-building-itself/specs/spec-525/acs";
 const AC_SHADOW = `${SPEC}/ac-17`; // shadow/enforcing is configuration, not a code change
 const AC_BOUNDS = `${SPEC}/ac-18`; // interval and ceiling configurable without a code change
+const AC_GUARD = `${SPEC}/ac-29`; // the guard that holds dec-8 cannot decline to run
 
 const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
 const DEPLOY_SH = readFileSync(
@@ -32,6 +33,10 @@ const DEPLOY_SH = readFileSync(
 );
 const DEPLOY_CONFIG = readFileSync(
   join(REPO_ROOT, "scripts", "deploy-config.sh"),
+  "utf-8",
+);
+const GATE_SMOKE = readFileSync(
+  join(REPO_ROOT, "packages", "server", "src", "__smoke__", "emission-gate.smoke.test.ts"),
   "utf-8",
 );
 
@@ -106,5 +111,66 @@ describe("spec-525 t-6: an unconfigured environment runs correctly, and safely",
     expect(resolveWaitConfig({ MEMEX_EMISSION_WAIT_MS: "0" }).waitMs).toBe(DEFAULT_WAIT_MS);
     expect(resolveWaitConfig({ MEMEX_EMISSION_WAIT_MS: "-5" }).waitMs).toBe(DEFAULT_WAIT_MS);
     expect(resolveWaitConfig({ MEMEX_EMISSION_MAX_WAITERS: "abc" }).maxWaiters).toBeUndefined();
+  });
+});
+
+// spec-525 dec-8 / ac-29 — the mode check must not be able to decline to run.
+//
+// dec-8 declined enforcement: the gate stays in shadow permanently. That promotes t-9's
+// mode assertion from "a check on a rollout in progress" to THE mechanism holding the
+// decision — so its ability to silently not run stopped being a nuisance and became the
+// thing that would let the decision quietly stop being true.
+//
+// It could. The assertion was gated on `it.skipIf(!INTENDED_MODE[SMOKE_ENV])`, SMOKE_ENV
+// defaults to "" and SMOKE_BASE_URL defaults to a REAL deployed host — so an invocation
+// that omitted the variable probed int, passed the three checks needing no intent, and
+// dropped the only one proving the mode. Green run, assertion absent.
+//
+// WHY THIS LIVES HERE AND IS A SOURCE READ. The claim is "the assertion runs
+// unconditionally", which is a property of the file rather than of any single run: a live
+// smoke run that PASSES proves the mode was right, not that the check was incapable of
+// skipping. Only reading the source can distinguish those, and this file already reads
+// deploy.sh and deploy-config.sh for exactly that class of claim. It is also offline —
+// no DB, no network — unlike the smoke suite itself.
+describe("spec-525 dec-8: the mode guard cannot skip in silence (ac-29)", () => {
+  /** The smoke test whose absence would leave dec-8 unenforced. */
+  const MODE_TEST = "the EFFECTIVE mode matches what this environment intended";
+
+  it("the mode assertion is present and NOT gated by skipIf", () => {
+    tagAc(AC_GUARD);
+    expect(GATE_SMOKE).toContain(MODE_TEST);
+    // The defective form, in either spelling vitest accepts. Named rather than matched
+    // loosely, so this fails on the shape that actually shipped rather than on any
+    // mention of the word.
+    expect(GATE_SMOKE).not.toMatch(
+      /it\s*\.\s*skipIf\s*\([^)]*INTENDED_MODE|describe\s*\.\s*skipIf\s*\([^)]*INTENDED_MODE/,
+    );
+  });
+
+  it("an unrecognised SMOKE_ENV is REFUSED, and the failure says how to fix it", () => {
+    tagAc(AC_GUARD);
+    // std-50's third branch: read, declared, or refused — never defaulted in silence.
+    // Asserting the message matters as much as the refusal: a bare `toBeDefined()` with
+    // no message would refuse correctly and tell the operator nothing, and the whole
+    // point is that the person who caused the silence can act on it immediately.
+    expect(GATE_SMOKE).toContain("names no known environment");
+    expect(GATE_SMOKE).toContain("It is NOT skipped");
+    expect(GATE_SMOKE).toContain("make smoke-int");
+  });
+
+  it("skips for genuinely ABSENT CREDENTIALS are left alone", () => {
+    tagAc(AC_GUARD);
+    // The fix must not become "no skipIf anywhere". A skip for a missing credential is
+    // honest — std-26 allows the credentialled tier to be skipped when its token is
+    // unset — while a skip for a missing INTENT is not. If this ever goes red because
+    // someone removed the credential gating too, the fix is to restore it, not to delete
+    // this assertion: an unset SMOKE_MCP_TOKEN would then fail every authed-tier check
+    // on every developer machine.
+    expect(GATE_SMOKE + DEPLOY_CONFIG + DEPLOY_SH).toBeTruthy();
+    const authedTier = readFileSync(
+      join(REPO_ROOT, "packages", "server", "src", "__smoke__", "smoke-env.ts"),
+      "utf-8",
+    );
+    expect(authedTier).toContain("SMOKE_MCP_TOKEN");
   });
 });

--- a/packages/server/src/__smoke__/emission-gate.smoke.test.ts
+++ b/packages/server/src/__smoke__/emission-gate.smoke.test.ts
@@ -41,11 +41,15 @@ const AC_MARKER = "mindset-prod/memex-building-itself/specs/spec-525/acs/ac-20";
 /**
  * The mode each deployed environment is INTENDED to run.
  *
- * Both are `shadow` today: the rollout's first deploy runs shadow everywhere, and
- * enforcement is turned on later by configuration (t-10) after the window has produced
- * the numbers ac-2 requires. **When t-10 flips prod, this table is the edit that keeps
- * the smoke honest** — and a deploy that flips the secret without editing here fails,
- * which is the point. An intent nobody wrote down is not an intent the smoke can check.
+ * Both are `shadow`, and dec-8 made that TERMINAL rather than transitional: enforcement
+ * is declined, not deferred, so this table is not waiting on t-10 to flip prod. That
+ * inverts what this check is for. It used to guard a rollout in progress; it now guards
+ * a standing decision — if either environment ever serves `enforcing`, the gate starts
+ * refusing at a ceiling of 2 against a measured p99 of 8 and a max of 28, dropping
+ * verification data silently, which is exactly what ac-4 forbids.
+ *
+ * So a deploy that flips the secret without editing here fails, and that IS the point.
+ * An intent nobody wrote down is not an intent the smoke can check.
  */
 const INTENDED_MODE: Record<string, "shadow" | "enforcing"> = {
   int: "shadow",
@@ -94,29 +98,48 @@ describe(`emission admission gate smoke @ ${SMOKE_BASE_URL}`, () => {
     ).not.toBeNull();
   });
 
-  it.skipIf(!INTENDED_MODE[SMOKE_ENV])(
-    "the EFFECTIVE mode matches what this environment intended",
-    async () => {
-      tagAc(AC_MARKER);
-      const intended = INTENDED_MODE[SMOKE_ENV];
-      const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "{}",
-        redirect: "manual",
-      });
+  it("the EFFECTIVE mode matches what this environment intended", async () => {
+    tagAc(AC_MARKER);
+    // NOT skipIf, deliberately (spec-525 ac-29). This assertion used to be gated on
+    // `!INTENDED_MODE[SMOKE_ENV]`, and SMOKE_ENV defaults to "" while SMOKE_BASE_URL
+    // defaults to a REAL deployed host — so an invocation that forgot the variable
+    // still probed int, still passed the other three checks, and silently dropped the
+    // only one that proves the mode. A green run where this skipped was indistinguishable
+    // from one where it passed, which is this Spec's own fault reproduced inside its own
+    // guard: dec-8 made this check the mechanism that holds "the gate stays in shadow",
+    // and a guard that can decline to run is a guard you cannot rely on.
+    //
+    // std-50's third branch is the one that applies: read, declared, or REFUSED — never
+    // defaulted in silence. There is nothing to read and nothing safe to assume (guessing
+    // "int" would assert int's intent against a prod host and pass by coincidence, since
+    // both are shadow today), so it refuses and says how to fix it.
+    const intended = INTENDED_MODE[SMOKE_ENV];
+    expect(
+      intended,
+      `SMOKE_ENV=${JSON.stringify(SMOKE_ENV)} names no known environment, so this run ` +
+        `cannot know which mode ${SMOKE_BASE_URL} is supposed to serve. It is NOT skipped: ` +
+        `a silent skip here is the failure this check exists to catch. Run the suite as ` +
+        `\`make smoke-int\` / \`make smoke-prod\` (both export SMOKE_ENV), or set ` +
+        `SMOKE_ENV to one of: ${Object.keys(INTENDED_MODE).join(", ")}.`,
+    ).toBeDefined();
 
-      expect(
-        res.headers.get(EMISSION_GATE_HEADER),
-        `${SMOKE_ENV} is running a different mode than intended. Either the ` +
-          `MEMEX_EMISSION_GATE_MODE wiring in deploy.sh / deploy-config.sh was missed ` +
-          `(so the environment silently took the code default), or the canonical ` +
-          `memex-${SMOKE_ENV}-deploy-env secret changed without updating INTENDED_MODE ` +
-          `in this file. Both are the failure t-9 exists to catch — do not "fix" it by ` +
-          `editing the expectation until you know which.`,
-      ).toBe(intended);
-    },
-  );
+    const res = await fetch(`${SMOKE_BASE_URL}/api/test-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      redirect: "manual",
+    });
+
+    expect(
+      res.headers.get(EMISSION_GATE_HEADER),
+      `${SMOKE_ENV} is running a different mode than intended. Either the ` +
+        `MEMEX_EMISSION_GATE_MODE wiring in deploy.sh / deploy-config.sh was missed ` +
+        `(so the environment silently took the code default), or the canonical ` +
+        `memex-${SMOKE_ENV}-deploy-env secret changed without updating INTENDED_MODE ` +
+        `in this file. Both are the failure t-9 exists to catch — do not "fix" it by ` +
+        `editing the expectation until you know which.`,
+    ).toBe(intended);
+  });
 
   it("the marker leaks nothing beyond the mode", async () => {
     tagAc(AC_MARKER);

--- a/packages/server/src/formatting/formatters.spec-542-grounding-header.test.ts
+++ b/packages/server/src/formatting/formatters.spec-542-grounding-header.test.ts
@@ -1,0 +1,226 @@
+// spec-542 t-5 (ac-1, ac-8) — the grounding state, in the HEADER, before any
+// content, in every state, with its provenance.
+//
+// t-3/t-4 fixed the FOOTER: it no longer asserts a state it does not know. This
+// is the other half of the report — the agent could not SEE the flag at all.
+// The footer rides the bottom of a long read; ac-1 asks for the header, where an
+// agent reads it before acting. That is spec-371's stated reason for
+// `Checked out by:` being there, and grounding answers a question of the same
+// shape: has this been checked against real code, by whom, when.
+//
+// EMITTED IN EVERY STATE, never signalled by absence. The precedent is
+// `Response shape:` (spec-538 ac-13), whose own comment gives the rule:
+// "Emitted at EVERY tier ... because 'absence means complete' is the inference
+// this line exists to remove." Here the inference to remove is "absence means
+// ungrounded" — which is the defect this Spec exists to fix, one step quieter.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatFullDocState } from "./formatters.js";
+import { CODE_GROUNDING_HEADER_PROSE } from "@memex/shared";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-542/acs/ac-${n}`;
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "formatters.ts");
+const formattersSrc = readFileSync(SRC, "utf-8");
+
+const baseDate = new Date("2026-01-01T00:00:00Z");
+
+function makeDoc(
+  overrides: Partial<Doc> & { groundedStale?: boolean } = {},
+): Doc & { sections: DocSection[]; groundedStale?: boolean } {
+  return {
+    id: "spec-uuid-542",
+    memexId: "memex-building-itself",
+    handle: "spec-542",
+    title: "Grounding header spec",
+    docType: "spec",
+    description: null,
+    skillCapabilities: null,
+    status: "specify",
+    parentDocId: null,
+    createdByUserId: null,
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    archivedAt: null,
+    archiveReason: null,
+    archivedByUserId: null,
+    archivedByName: null,
+    supersededByDocId: null,
+    supersededAt: null,
+    supersessionNote: null,
+    narrativeLastConsolidatedAt: null,
+    isDemo: false,
+    groundedInCode: false,
+    groundedAt: null,
+    groundedByUserId: null,
+    groundedByName: null,
+    sensitive: false,
+    sensitiveByUserId: null,
+    sensitiveByName: null,
+    checkedOutBy: null,
+    checkedOutAt: null,
+    checkedOutThread: null,
+    version: 1,
+    ...overrides,
+    sections: [
+      {
+        id: "s-uuid-1",
+        docId: "spec-uuid-542",
+        sectionType: "overview",
+        title: "Overview",
+        description: null,
+        content: "Body.",
+        seq: 1,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      } as DocSection,
+    ],
+  } as Doc & { sections: DocSection[]; groundedStale?: boolean };
+}
+
+const render = (o: Partial<Doc> & { groundedStale?: boolean } = {}) =>
+  formatFullDocState(makeDoc(o), [], []);
+
+/** The header is everything before the first section body. */
+const headerOf = (out: string) => out.split("Body.")[0];
+
+const GROUNDED = {
+  groundedInCode: true,
+  groundedAt: baseDate,
+  groundedByName: "A. Reviewer",
+};
+
+describe("spec-542 — the grounding state is legible in the header (ac-1)", () => {
+  it("an UNGROUNDED Spec says so, in the header", () => {
+    tagAc(AC(1));
+
+    const header = headerOf(render({ groundedInCode: false }));
+    expect(header).toContain(CODE_GROUNDING_HEADER_PROSE.none);
+  });
+
+  it("a GROUNDED Spec names WHO and WHEN", () => {
+    tagAc(AC(1));
+
+    // The half the report was really about: the badge exists in the web UI and
+    // the MCP read rendered nothing at all.
+    const header = headerOf(render({ ...GROUNDED, groundedStale: false }));
+    expect(header).toMatch(/Code-grounding:/);
+    expect(header).toContain("A. Reviewer");
+  });
+
+  it("a STALE grounding is distinguishable from a fresh one in the header", () => {
+    tagAc(AC(1));
+
+    const fresh = headerOf(render({ ...GROUNDED, groundedStale: false }));
+    const stale = headerOf(render({ ...GROUNDED, groundedStale: true }));
+    expect(stale).not.toBe(fresh);
+    expect(stale).toContain("A. Reviewer");
+  });
+
+  it("provenance comes from the denormalised name, and absence is not faked", () => {
+    tagAc(AC(1));
+
+    // std-32: groundedByName is stamped at write so a later rename cannot
+    // rewrite history. When it is absent the line must still render the STATE —
+    // degrading to silence would drop the signal exactly when attribution
+    // failed — without naming nobody as if it were somebody.
+    const header = headerOf(
+      render({ groundedInCode: true, groundedAt: baseDate, groundedStale: false }),
+    );
+    expect(header).toMatch(/Code-grounding:/);
+    expect(header).not.toMatch(/by (null|undefined)/);
+  });
+
+  it("the line renders in EVERY state — never signalled by absence", () => {
+    tagAc(AC(1));
+
+    // The `Response shape:` rule (spec-538 ac-13) applied here. A line that
+    // appeared only when grounded would rebuild this defect quietly, because
+    // the reader would then infer state from silence.
+    for (const o of [
+      { groundedInCode: false },
+      { ...GROUNDED, groundedStale: false },
+      { ...GROUNDED, groundedStale: true },
+    ]) {
+      expect(headerOf(render(o)), `no grounding line for ${JSON.stringify(o)}`).toMatch(
+        /Code-grounding:/,
+      );
+    }
+  });
+
+  it("the line precedes the content it describes", () => {
+    tagAc(AC(1));
+
+    const out = render({ groundedInCode: false });
+    expect(out.indexOf("Code-grounding:")).toBeGreaterThan(-1);
+    expect(out.indexOf("Code-grounding:")).toBeLessThan(out.indexOf("Body."));
+  });
+
+  it("a non-Spec doc gets no grounding line", () => {
+    tagAc(AC(1));
+
+    // Grounding is a Spec concept. A free-form document has no decisions to
+    // check against source, so the honest output is nothing.
+    const header = headerOf(render({ docType: "document", status: "draft" }));
+    expect(header).not.toMatch(/Code-grounding:/);
+  });
+});
+
+describe("spec-542 — the header line obeys std-15 and the budget rules (ac-8)", () => {
+  it("the prose lives in the Scaffold, not in server/src", () => {
+    tagAc(AC(8));
+
+    // std-15: agent-facing prose has one home. This file is NOT on the drift
+    // guard's allowlist, so an inline sentence here would fail the build — but
+    // the intent is asserted directly rather than left to a guard whose failure
+    // would read as unrelated.
+    expect(CODE_GROUNDING_HEADER_PROSE.none.length).toBeGreaterThan(0);
+    expect(formattersSrc).toContain("CODE_GROUNDING_HEADER_PROSE");
+    expect(formattersSrc).not.toContain(CODE_GROUNDING_HEADER_PROSE.none);
+  });
+
+  it("the grounding lines are pushed one at a time, not as a block", () => {
+    tagAc(AC(8));
+
+    // The std-15 drift guard (scaffold-drift-guard.regression.test.ts) owns the
+    // "no markdown-shaped literal in server/src" rule and is the authority on
+    // it; this asserts only the narrow thing it can see soundly — that the
+    // lines THIS Spec added carry no embedded newline.
+    //
+    // A first version tried to re-implement the guard here with
+    // /`[^`]*\n[^`]*\n[^`]*`/ and matched 269 "literals" — the regex spans
+    // ordinary code between a closing and the next opening backtick, and
+    // backticks also appear in comments as markdown code spans. It would have
+    // been red for reasons unrelated to the change, and green only by accident.
+    const pushes = formattersSrc
+      .split("\n")
+      .filter((l) => l.includes("CODE_GROUNDING_HEADER_PROSE"));
+    expect(pushes.length, "expected the header pushes to be present").toBeGreaterThan(0);
+    for (const line of pushes) {
+      expect(line, `a grounding push spans lines: ${line}`).not.toMatch(/\\n/);
+    }
+  });
+
+  it("the grounding line is emitted at every response tier, never rationed", () => {
+    tagAc(AC(8));
+
+    // spec-538 ac-9: "Signals are never rationed to buy room." A huge doc must
+    // not lose the grounding line to make space for prose.
+    const huge = makeDoc({ ...GROUNDED, groundedStale: false });
+    huge.sections = [
+      {
+        ...huge.sections[0],
+        content: "x".repeat(400_000),
+      } as DocSection,
+    ];
+    const out = formatFullDocState(huge, [], []);
+    expect(out).toMatch(/Response shape: (EXCERPTED|SECTION MAP)/);
+    expect(out, "the grounding line was dropped to buy room").toMatch(/Code-grounding:/);
+  });
+});

--- a/packages/server/src/formatting/formatters.spec-542-grounding-state.test.ts
+++ b/packages/server/src/formatting/formatters.spec-542-grounding-state.test.ts
@@ -1,0 +1,223 @@
+// spec-542 t-4 (ac-13, ac-7) — the server derives the grounding state from the
+// doc and hands it to BOTH toNudge call sites.
+//
+// t-3 fixed the projection: given a state, the Scaffold selects the right prose.
+// Nothing produced that state yet. This closes the wiring, at the two places in
+// formatters.ts that compose the nudge:
+//
+//   :~1631  renderSpecPhaseGuidance  — the EMISSION
+//   :~191   estimateEnvelopeChars    — the response-BUDGET measurement
+//
+// The second is the one easily missed, and missing it is a real defect rather
+// than an omission: the estimate would size the envelope from a string that is
+// never emitted. That function's own comment forbids it — "a COMPUTATION over
+// the same projection the seat will use, not a guess about it [per std-50 cl-1]".
+// Hence the structural assertion below as well as the behavioural ones: only a
+// source-level check can see that BOTH sites were wired.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { formatSpecGuidance } from "./formatters.js";
+import type { Doc, DocSection } from "../db/schema.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-542/acs/ac-${n}`;
+
+const formattersSrc = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "formatters.ts"),
+  "utf-8",
+);
+
+/**
+ * The source with comment lines removed.
+ *
+ * A first version of the call-site assertion below counted 4 `toNudge({...})`
+ * matches instead of 2: two real call sites plus two doc-comments that QUOTE
+ * the call shape. Counting prose as code is the kind of structural assertion
+ * that passes or fails for reasons unrelated to the code, so comments go first.
+ */
+const formattersCode = formattersSrc
+  .split("\n")
+  .filter((l) => {
+    const t = l.trim();
+    return !t.startsWith("//") && !t.startsWith("*") && !t.startsWith("/*");
+  })
+  .join("\n");
+
+const baseDate = new Date("2026-01-01T00:00:00Z");
+
+// `groundedStale` is DERIVED, not a column, so it is not on `Doc`. It rides the
+// enriched object `getDoc` returns, which is what reaches the footer seat
+// (fullDocState → getDoc). The fixture mirrors that shape.
+function makeSpecDoc(
+  overrides: Partial<Doc> & { groundedStale?: boolean } = {},
+): Doc & { sections: DocSection[]; groundedStale?: boolean } {
+  return {
+    id: "spec-uuid-542",
+    memexId: "memex-building-itself",
+    handle: "spec-542",
+    title: "Grounding state spec",
+    docType: "spec",
+    description: null,
+    skillCapabilities: null,
+    status: "specify",
+    parentDocId: null,
+    createdByUserId: null,
+    createdAt: baseDate,
+    statusChangedAt: baseDate,
+    archivedAt: null,
+    archiveReason: null,
+    archivedByUserId: null,
+    archivedByName: null,
+    supersededByDocId: null,
+    supersededAt: null,
+    supersessionNote: null,
+    narrativeLastConsolidatedAt: null,
+    isDemo: false,
+    groundedInCode: false,
+    groundedAt: null,
+    groundedByUserId: null,
+    groundedByName: null,
+    sensitive: false,
+    sensitiveByUserId: null,
+    sensitiveByName: null,
+    checkedOutBy: null,
+    checkedOutAt: null,
+    checkedOutThread: null,
+    version: 1,
+    ...overrides,
+    sections: [
+      {
+        id: "s-uuid-1",
+        docId: "spec-uuid-542",
+        sectionType: "overview",
+        title: "Overview",
+        description: null,
+        content: "Body.",
+        seq: 1,
+        createdAt: baseDate,
+        updatedAt: baseDate,
+      } as DocSection,
+    ],
+  } as Doc & { sections: DocSection[]; groundedStale?: boolean };
+}
+
+const NEGATIVE = /No code-grounding on this Spec/;
+const AFFIRMATIVE = /Code-grounding affirmed by agent/;
+const STALE = /Treat the grounding as out of date/;
+
+const guidanceFor = (o: Partial<Doc> & { groundedStale?: boolean }) =>
+  formatSpecGuidance(makeSpecDoc(o), [], []);
+
+describe("spec-542 — the footer reports the state the document actually holds", () => {
+  it("an UNGROUNDED Spec is told so", () => {
+    tagAc(AC(13));
+
+    const out = guidanceFor({ groundedInCode: false });
+    expect(out).toMatch(NEGATIVE);
+    expect(out).not.toMatch(AFFIRMATIVE);
+  });
+
+  it("a GROUNDED Spec is no longer told the opposite", () => {
+    tagAc(AC(13));
+
+    // The reported defect, at the server seat rather than in the projection.
+    const out = guidanceFor({
+      groundedInCode: true,
+      groundedAt: baseDate,
+      groundedByName: "someone",
+      groundedStale: false,
+    });
+    expect(out, "a grounded Spec is still being told it has no grounding").not.toMatch(
+      NEGATIVE,
+    );
+    expect(out).toMatch(AFFIRMATIVE);
+  });
+
+  it("a STALE-grounded Spec is told to re-check, not that grounding is absent", () => {
+    tagAc(AC(13));
+
+    const out = guidanceFor({
+      groundedInCode: true,
+      groundedAt: baseDate,
+      groundedStale: true,
+    });
+    expect(out).toMatch(STALE);
+    expect(out).not.toMatch(AFFIRMATIVE);
+    expect(out).not.toMatch(NEGATIVE);
+  });
+
+  it("grounded-but-staleness-UNKNOWN asserts nothing about grounding", () => {
+    tagAc(AC(7));
+
+    // `groundedStale` is optional on the shape the formatter accepts, so it CAN
+    // be absent. Rendering "grounded" then would assert freshness nobody
+    // checked — a silent default, which std-50 forbids and which is this Spec's
+    // whole defect class. So: no claim. On the real path (fullDocState → getDoc)
+    // the flag is always derived, making this a defensive branch, not an
+    // expected one — pinned so it cannot quietly become a default later.
+    const out = guidanceFor({ groundedInCode: true, groundedAt: baseDate });
+    expect(out).not.toMatch(NEGATIVE);
+    expect(out).not.toMatch(AFFIRMATIVE);
+    expect(out).not.toMatch(STALE);
+  });
+
+  it("the state-independent ask survives in every case", () => {
+    tagAc(AC(13));
+
+    // Splitting the block must not cost the specify→build gate prompt.
+    for (const o of [
+      { groundedInCode: false },
+      { groundedInCode: true, groundedAt: baseDate, groundedStale: false },
+      { groundedInCode: true, groundedAt: baseDate, groundedStale: true },
+    ]) {
+      expect(guidanceFor(o)).toMatch(/Call assess_spec again with `codeGrounding`/);
+    }
+  });
+});
+
+describe("spec-542 — BOTH toNudge call sites receive the state (ac-13)", () => {
+  it("every toNudge call in formatters.ts passes `grounding`", () => {
+    tagAc(AC(13));
+
+    // Structural by necessity: `estimateEnvelopeChars` is private and its
+    // effect is a size, not text, so no behavioural assertion can see whether
+    // it was wired. A state passed at only one site would silently mis-size the
+    // envelope for every Spec read — the exact "measure one thing, emit
+    // another" defect std-50 cl-1 names.
+    const calls = formattersCode.match(/toNudge\(\{[\s\S]*?\}\)/g) ?? [];
+    expect(calls.length, "expected both toNudge call sites").toBe(2);
+    for (const call of calls) {
+      expect(call, `a toNudge call site does not pass grounding:\n${call}`).toMatch(
+        /grounding[,:]/,
+      );
+    }
+  });
+
+  it("the state is derived by ONE helper, not re-derived per call site", () => {
+    tagAc(AC(13));
+
+    // Two independent derivations are how the emission and the estimate drift
+    // apart. One definition, called from both.
+    const defs = formattersCode.match(/function groundingStateOf/g) ?? [];
+    expect(defs.length, "groundingStateOf must be defined exactly once").toBe(1);
+    expect(formattersCode.match(/groundingStateOf\(/g)?.length ?? 0).toBeGreaterThanOrEqual(
+      3,
+    );
+  });
+
+  it("no grounding prose is written in server/src — it all comes from the Scaffold", () => {
+    tagAc(AC(8));
+
+    // std-15: the prose has one home. A replacement sentence written here would
+    // also trip the scaffold drift-guard, since this file is not on its
+    // allowlist. Asserted directly so the intent is visible, not just enforced
+    // elsewhere by a guard whose failure would be read as unrelated.
+    expect(formattersSrc).not.toMatch(NEGATIVE);
+    expect(formattersSrc).not.toMatch(AFFIRMATIVE);
+    expect(formattersSrc).not.toMatch(STALE);
+  });
+});

--- a/packages/server/src/formatting/formatters.ts
+++ b/packages/server/src/formatting/formatters.ts
@@ -26,6 +26,7 @@ import {
   BASE_SCAFFOLD,
   BUILD_AC_NAG_PROSE,
   SENSITIVE_WARNING_PROSE,
+  CODE_GROUNDING_HEADER_PROSE,
   GET_PROMPT_PROSE,
   toNudge,
   toHandoffEssence,
@@ -34,6 +35,8 @@ import {
   type GuidanceBlock,
   type PhaseNode,
   type SpecPhase,
+  // spec-542: the grounding dimension the Scaffold selects on.
+  type GroundingState,
 } from "@memex/shared";
 import type { AcWithVerification } from "../services/acs.js";
 
@@ -183,7 +186,47 @@ function formatTagStrip(tags: Tag[] | undefined): string | null {
  * maximum. Reserving MEASURED_ENVELOPE_MAX_CHARS flat would pull the majority of
  * reads into tier 2/3 and collide with ac-26 — the objection that still holds.
  */
-function estimateEnvelopeChars(doc: Doc, nudge?: NudgeContext): number {
+/**
+ * The Spec's grounding state, as a value the Scaffold can select on (spec-542).
+ *
+ * ONE definition, called from both `toNudge` call sites in this file. Two
+ * independent derivations are exactly how the emission and the response-budget
+ * estimate drift apart, and the estimate exists to measure what the seat will
+ * emit — "a COMPUTATION over the same projection the seat will use, not a guess
+ * about it [per std-50 cl-1]".
+ *
+ * Pure, and free: `groundedInCode` is a column, and `groundedStale` is already
+ * derived once per read by `getDoc` (spec-409 dec-4), which is the read the
+ * footer seat performs anyway (`fullDocState` -> `getDoc`). No extra query.
+ *
+ * Returns `undefined` for "not enough known", which makes NO grounding claim at
+ * all rather than a reassuring one:
+ *   - a doc that is not a Spec has no grounding concept;
+ *   - grounded with staleness ABSENT is grounded-but-unverified-freshness.
+ *     Rendering `grounded` there would assert freshness nobody checked — a
+ *     silent default, which std-50 forbids and which is this Spec's own defect
+ *     class. On the real path the flag is always derived, so that branch is
+ *     defensive rather than expected.
+ *
+ * There is deliberately no `not_applicable`: it is transient to an assess_spec
+ * call and never persisted, so no read can know it (dec-3).
+ */
+function groundingStateOf(
+  doc: Doc & { groundedStale?: boolean },
+): GroundingState | undefined {
+  if (doc.docType !== "spec") return undefined;
+  if (!doc.groundedInCode) return "not_grounded";
+  if (doc.groundedStale === undefined) return undefined;
+  return doc.groundedStale ? "grounded_stale" : "grounded";
+}
+
+function estimateEnvelopeChars(
+  // spec-542: `groundedStale` is derived, not a column, so it is not on `Doc`.
+  // Optional for the same reason `checkoutHolder` is optional on
+  // formatFullDocState — plain-Doc callers keep compiling.
+  doc: Doc & { groundedStale?: boolean },
+  nudge?: NudgeContext,
+): number {
   const phase = doc.status as SpecPhase;
   let guidance = 0;
   let handoff = 0;
@@ -192,6 +235,9 @@ function estimateEnvelopeChars(doc: Doc, nudge?: NudgeContext): number {
       dataset: BASE_SCAFFOLD,
       tool: nudge?.tool,
       phase,
+      // spec-542 ac-13: the SAME state the seat will emit with. Measuring
+      // without it would size the envelope from a string never emitted.
+      grounding: groundingStateOf(doc),
       orgBlocks: nudge?.orgBlocks,
     }).length;
     handoff =
@@ -213,6 +259,13 @@ export function formatFullDocState(
   doc: Doc & {
     sections: DocSection[];
     checkoutHolder?: { name: string | null; email: string | null } | null;
+    // spec-542: derived read-time by `getDoc` (spec-409 dec-4), not a column, so
+    // it is not on `Doc`. Declared here rather than left to ride the object
+    // untyped: the value is owned by getDoc and depended on by the grounding
+    // state this function's envelope estimate measures with [per std-50] —
+    // read, declared, or refused, never defaulted in silence. Optional for the
+    // same reason `checkoutHolder` is, so plain-Doc callers keep compiling.
+    groundedStale?: boolean;
   },
   // spec-445 dec-2 — each decision/task may carry its stored true facet keys, surfaced
   // on retrieval as context (attached by fullDocState; absent for facet-less callers).
@@ -325,6 +378,30 @@ export function formatFullDocState(
     );
     const ago = mins < 1 ? "less than a minute ago" : `${mins} minute${mins === 1 ? "" : "s"} ago`;
     lines.push(`Checked out by: ${who} (${ago})`);
+  }
+  // spec-542 ac-1 — the code-grounding state, next to the checkout signal it is
+  // the sibling of. spec-371 put `Checked out by:` here "so a reader, or an
+  // agent about to edit, sees it before stepping on a colleague"; grounding
+  // answers a question of the same shape — has this been checked against real
+  // code, by whom, when — and until now the MCP read answered it nowhere, while
+  // the web UI had rendered a badge since spec-409.
+  //
+  // Emitted in EVERY state, following `Response shape:` below (spec-538 ac-13):
+  // a line present in only one state forces the reader to infer the rest from
+  // silence, and here that inference is "absence means ungrounded" — this
+  // Spec's defect, one step quieter. `groundingStateOf` returns undefined only
+  // when the answer is genuinely unknown (a non-Spec doc, or grounded with
+  // staleness underived), and then nothing is claimed at all.
+  //
+  // Pushed as single lines from Scaffold constants (std-15): this file is not
+  // on the drift guard's allowlist, so the prose cannot live here.
+  const groundingState = groundingStateOf(doc);
+  if (groundingState === "not_grounded") {
+    lines.push(CODE_GROUNDING_HEADER_PROSE.none);
+  } else if (groundingState === "grounded") {
+    lines.push(CODE_GROUNDING_HEADER_PROSE.verified(doc.groundedByName ?? null, timeAgo(doc.groundedAt)));
+  } else if (groundingState === "grounded_stale") {
+    lines.push(CODE_GROUNDING_HEADER_PROSE.stale(doc.groundedByName ?? null, timeAgo(doc.groundedAt)));
   }
   if (appBaseUrl) {
     lines.push(`URL: ${docUrl(appBaseUrl, doc.docType, doc.handle)}`);
@@ -1563,7 +1640,7 @@ export function renderAcNagFooter(
 // prefixes the one delimiter, preserving its self-contained contract for direct
 // callers/tests (returns `null`-free, leads with the delimiter for a Spec).
 export function formatSpecGuidanceBody(
-  doc: Doc,
+  doc: Doc & { groundedStale?: boolean },
   decs: Decision[],
   tasksList: TaskWithBlockers[],
   nudge?: NudgeContext,
@@ -1578,7 +1655,7 @@ export function formatSpecGuidanceBody(
 }
 
 export function formatSpecGuidance(
-  doc: Doc,
+  doc: Doc & { groundedStale?: boolean },
   decs: Decision[],
   tasksList: TaskWithBlockers[],
   nudge?: NudgeContext,
@@ -1604,7 +1681,7 @@ export function formatSpecGuidance(
  * further code changes.
  */
 function renderSpecPhaseGuidance(
-  doc: Doc,
+  doc: Doc & { groundedStale?: boolean },
   phase: SpecPhase,
   decs: Decision[],
   tasksList: TaskWithBlockers[],
@@ -1632,6 +1709,10 @@ function renderSpecPhaseGuidance(
     dataset: BASE_SCAFFOLD,
     tool: nudge?.tool,
     phase,
+    // spec-542: the grounding claim is now state-keyed in the Scaffold, so the
+    // seat has to say WHICH state. Passing nothing emits no claim, which is
+    // correct for a read that does not know (ac-7) and wrong as a default.
+    grounding: groundingStateOf(doc),
     orgBlocks: nudge?.orgBlocks,
   });
   if (nudgeText.length > 0) {

--- a/packages/server/src/routes/analytics-cost-panel.integration.test.ts
+++ b/packages/server/src/routes/analytics-cost-panel.integration.test.ts
@@ -230,6 +230,33 @@ describe("GET /analytics/cost-panel — a member of an allowlisted Memex", () =>
     expect(row.medianChars).toBe(2000);
   });
 
+  it("returns p90Chars on a single-call row too — the display gates, not the API", async () => {
+    tagAc(AC(26));
+    openTo(memberSlug);
+    // dec-10 withholds a thin row's p90 IN THE CARD. The temptation once that
+    // ships is to "finish the job" server-side and null the column here, which
+    // would break spec-458 dec-5 — the endpoint always returns the truth, and
+    // display gating is a page concern. It would also silently disarm the UI
+    // test: a card asked to hide a value it never receives would pass for the
+    // wrong reason.
+    await seedCall({
+      memexId: memberMemexId,
+      toolName: "lonely_tool",
+      resultLen: 4242,
+      footerLen: 42,
+    });
+
+    const res = await app.request(pathFor(memberSlug), withApexHost());
+    const body = await res.json();
+    const row = body.operations.find(
+      (o: { tool: string }) => o.tool === "lonely_tool"
+    );
+    expect(row.calls).toBe(1);
+    // Present, numeric, and equal to the only observation there is.
+    expect(row.p90Chars).toBe(4242);
+    expect(row.medianChars).toBe(4242);
+  });
+
   it("groups on (tool, verb): NULL verbs collapse, distinct verbs split", async () => {
     tagAc(AC(14));
     openTo(memberSlug);

--- a/packages/server/src/services/admission/emission-gate.ts
+++ b/packages/server/src/services/admission/emission-gate.ts
@@ -120,12 +120,23 @@ export type Acquisition =
 export type GateMode = "shadow" | "enforcing";
 
 /**
- * SHADOW, deliberately.
+ * SHADOW, deliberately — and since dec-8, PERMANENTLY.
  *
- * t-6 must wire `MEMEX_EMISSION_GATE_MODE` into both `deploy.sh` and the canonical
- * `memex-<env>-deploy-env` secret. Miss either edit and prod silently takes this default —
- * so the default has to be the direction that under-protects rather than the one that
- * enforces limits nobody has measured yet. An unrecognised value falls here too.
+ * t-6 wires `MEMEX_EMISSION_GATE_MODE` into both `deploy.sh` and the canonical
+ * `memex-<env>-deploy-env` secret (both environments declare `shadow` explicitly today,
+ * read off the serving revisions 2026-09-09). Miss either edit and an environment
+ * silently takes this default — so the default has to be the direction that
+ * under-protects rather than the one that enforces limits nobody has measured. An
+ * unrecognised value falls here too.
+ *
+ * dec-8 changed what that means. Shadow is no longer the first stage of a rollout whose
+ * second stage is enforcement: enforcement is DECLINED. spec-332 dec-2's transaction-mode
+ * pooling dissolves the connection scarcity the requests term was derived from, and the
+ * events term — which bounds heap, and which no pooler touches — sits ~2-3x below c-18's
+ * danger threshold on concurrency and ~60x below it on batch size. So this constant is
+ * the decided posture, not a waypoint, and `enforcing` is not a state this system is
+ * travelling toward. The post-deploy smoke asserts the SERVED mode against that decision
+ * (ac-29) rather than trusting this default to hold.
  */
 export const DEFAULT_GATE_MODE: GateMode = "shadow";
 

--- a/packages/server/src/services/spec-542-grounding-interaction.integration.test.ts
+++ b/packages/server/src/services/spec-542-grounding-interaction.integration.test.ts
@@ -1,0 +1,439 @@
+// spec-542 t-7 (ac-4) — the spec-424 interaction, proven rather than assumed.
+//
+// ac-4's claim is an INTERACTION, and it says so: a grounding push that fires at
+// Specs already grounded gets *worse* as spec-424's delivery gets better. So the
+// claim is not "the push is gone" — it is that the push now travels with the
+// state an agent needs to skip re-grounding, while an ungrounded Spec still gets
+// pushed. A fix that suppressed the push everywhere would satisfy half of that
+// and break spec-424 outright, which is why both directions are asserted in ONE
+// test below rather than in two that could pass separately.
+//
+// WHY AN INTEGRATION TEST. The unit guards in @memex/shared prove `toNudge`
+// discriminates; they say nothing about whether `resolve_decision` and
+// `create_ac` responses actually carry the discriminated text. That is the
+// claim ac-4 makes, so this drives the REAL tools through `createMcpServer`
+// against REAL rows, with real grounding columns set.
+//
+// ───────────────────────────────────────────────────────────────────────────
+// DRIFT FLAGGED (t-7 said to check before asserting, and to flag rather than
+// test whatever is there now — so: the finding, recorded where it will be read).
+//
+// t-7's premise: "spec-424 … delivered on `resolve_decision` / `create_ac` via
+// `STEER_BY_TOOL`". Checked, 2026-09-09:
+//
+//   • spec-424 is in BUILD with 0 of 3 tasks complete and 14 of 14 ACs
+//     untested. It has shipped nothing. There is no per-tool grounding steer.
+//   • `STEER_BY_TOOL` (agent/handlers/guidance-envelope.ts:98) still exists by
+//     that name — but it holds exactly ONE entry, `update_section`. No
+//     `resolve_decision` entry, no `create_ac` entry.
+//   • The grounding push that DOES reach these two tools today is the global
+//     ask in BASE_GUIDANCE (`id: 'code-grounding'`, `target: {}`) — matching
+//     every tool and every phase. The other push is the specify handoff BUTTON
+//     prose, a human→agent surface, not a per-tool steer.
+//
+// So the premise is drifted but the CLAIM is intact, and lands one layer down
+// from where t-7 expected: the pushed ask reaches these tools globally, and
+// after t-3 it travels with a state-keyed claim instead of a fixed one. That is
+// what is asserted here. If spec-424 later adds per-tool entries, this test
+// keeps holding — it asserts the response an agent reads, not the registry.
+// ───────────────────────────────────────────────────────────────────────────
+//
+// ONE FINDING THAT CHANGED THIS TEST, recorded because the first version of it
+// was green and wrong. It asserted the plain affirmative claim ("Code-grounding
+// affirmed by agent.") on the grounded side of both mutating tools, and passed
+// — but only because the fixture stamped `grounded_at` 60 SECONDS INTO THE
+// FUTURE. `ground_spec` stamps `now()`, so production cannot order it that way,
+// and both tools here mutate the very rows staleness is derived from. With a
+// realistic past `grounded_at` the responses render the STALE claim, which is
+// also the honest answer: you just moved a decision, so re-check. The
+// assertions now follow the reachable paths — stale for the mutating tools,
+// the clean affirmative through `get_doc`, which mutates nothing. On a Spec
+// whose subject is "no response asserts something untrue", pinning a string no
+// agent can ever see would have been precisely the wrong thing to ship.
+//
+// ON "WATCHED FAIL, THEN PASS": the implementation landed in t-3/t-5, so this
+// cannot be watched red against unfixed code. Red-CAPABILITY was proven instead
+// by mutation, and this records the exact one that was run rather than a
+// plausible-sounding one: changing the `not_grounded` guidance block's target
+// from `{ grounding: 'not_grounded' }` back to `{}` in scaffold-data.ts — the
+// original defect, restored — reds the both-directions test below on the
+// grounded Spec being told it has no code-grounding. A test that cannot fail
+// proves nothing (std-52), so that was executed and reverted, not assumed.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  documents,
+  decisions,
+  tasks,
+  acs,
+  users,
+} from "../db/schema.js";
+import { createMcpServer } from "../mcp/tools.js";
+import { createDocDraft } from "./documents.js";
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-542/acs/ac-${n}`;
+
+// The three claims, as an agent reads them in the response.
+const UNGROUNDED_PUSH = /No code-grounding on this Spec/;
+const GROUNDED_CLAIM = /Code-grounding affirmed by agent/;
+const HEADER_VERIFIED = /Code-grounding: verified by /;
+const HEADER_NONE = /Code-grounding: none —/;
+// The stale pair. These are what a MUTATING tool on a grounded Spec actually
+// renders — see the fixture note on `specWithDecision`.
+const STALE_CLAIM = /Treat the grounding as out of date/;
+const HEADER_STALE = /Code-grounding: verified by .*, but decisions or acceptance criteria changed since/;
+// The state-INDEPENDENT ask. spec-424 depends on this surviving in BOTH
+// directions: it is the specify→build gate prompt, not a claim about this Spec.
+// If a future "fix" suppresses the push globally, this is what it would take
+// with it, so it is asserted on the grounded side too.
+const THE_ASK = /Call assess_spec again with `codeGrounding`/;
+
+const created = { users: [] as string[], memexes: [] as string[], docs: [] as string[] };
+
+afterAll(async () => {
+  if (created.docs.length) {
+    await db.delete(acs).where(inArray(acs.briefId, created.docs)).catch(() => {});
+    await db.delete(tasks).where(inArray(tasks.docId, created.docs)).catch(() => {});
+    await db.delete(decisions).where(inArray(decisions.docId, created.docs)).catch(() => {});
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+// std-37: per-worker-unique identifiers, so parallel workers never collide.
+async function setupActor(prefix: string) {
+  const sub = `${prefix}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`.toLowerCase();
+  const [u] = await db.insert(users).values({ email: `${sub}@memex.ai` } as never).returning();
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db
+    .insert(orgs)
+    .values({ namespaceId: ns.id, name: `Test ${sub}` })
+    .returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [a] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` })
+    .returning();
+  created.memexes.push(a.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  return { user: u, memexId: a.id, nsSlug: ns.slug };
+}
+
+interface ToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+interface RegisteredToolLike {
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResult> | ToolResult;
+}
+
+async function callTool(
+  userId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const server = createMcpServer(userId);
+  const registry = (
+    server as unknown as { _registeredTools: Record<string, RegisteredToolLike> }
+  )._registeredTools;
+  const tool = registry[name];
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return await tool.handler(args, {} as unknown);
+}
+
+const textOf = (res: ToolResult) => res.content.map((c) => c.text).join("\n");
+
+/**
+ * A specify-phase Spec with one open decision, grounded or not.
+ *
+ * `grounded` writes the real spec-409 columns rather than stubbing a derived
+ * value — `groundedStale` is DERIVED per read from `grounded_at` vs the
+ * decisions'/ACs' timestamps, so a stub would prove nothing about the
+ * derivation this Spec depends on.
+ *
+ * `grounded_at` IS IN THE PAST, because that is the only ordering production
+ * can produce: `ground_spec` stamps `now()`, so by the time any later tool call
+ * runs, the grounding is already older than anything that call touches.
+ *
+ * That ordering has a consequence worth stating, because an earlier version of
+ * this test hid it. `isGroundingStale` reds when a decision's `resolved_at` (or
+ * `created_at`), or an AC's `updated_at`, is newer than `grounded_at`. Both
+ * tools under test here MUTATE exactly those rows: `resolve_decision` stamps
+ * `resolved_at = now()`, `create_ac` inserts a row. So on a grounded Spec these
+ * two tools ALWAYS derive `grounded_stale` — the plain affirmative claim is
+ * structurally unreachable through them, and asserting it required shifting
+ * `grounded_at` 60s into the FUTURE, an ordering `ground_spec` cannot create.
+ *
+ * That shift is gone. The stale claim is asserted for the mutating tools, and
+ * the fresh-grounded branch is asserted through `get_doc`, which mutates
+ * nothing and is therefore where production can actually reach it. On a Spec
+ * whose whole subject is "no response asserts something untrue", a green test
+ * pinning a string no agent can ever see would have been the wrong thing to
+ * ship.
+ */
+async function specWithDecision(title: string, grounded: boolean) {
+  const doc = await createDocDraft(actor.memexId, title, "Purpose.", "spec");
+  created.docs.push(doc.id);
+  await db
+    .update(documents)
+    .set(
+      grounded
+        ? {
+            status: "specify",
+            groundedInCode: true,
+            groundedAt: new Date(Date.now() - 60_000),
+            groundedByName: "A. Reviewer",
+            groundedByUserId: actor.user.id,
+          }
+        : { status: "specify" },
+    )
+    .where(eq(documents.id, doc.id));
+  const [dec] = await db
+    .insert(decisions)
+    .values({
+      memexId: actor.memexId,
+      docId: doc.id,
+      seq: 1,
+      title: "A fork this Spec has to settle",
+      status: "open",
+      source: "human",
+    } as never)
+    .returning();
+  const ref = `${actor.nsSlug}/main/specs/${doc.handle}`;
+  return { ref, decRef: `${ref}/decisions/dec-${dec.seq}` };
+}
+
+let actor: Awaited<ReturnType<typeof setupActor>>;
+beforeAll(async () => {
+  actor = await setupActor("spec542-interaction");
+});
+
+describe("spec-542 ac-4 — the grounding push carries state the agent can act on", () => {
+  // ── BOTH DIRECTIONS, ONE TEST ────────────────────────────────────────────
+  // Deliberately not split. Two separate tests would BOTH pass under a global
+  // suppression of the push (each would only be checking its own half), and
+  // that suppression is precisely the wrong fix ac-4 warns about. Asserting the
+  // pair together means the only way to green is to actually discriminate.
+  it("an already-grounded Spec is not pushed to re-ground, and an ungrounded one still is", async () => {
+    tagAc(AC(4));
+
+    const groundedSpec = await specWithDecision("Grounded Interaction Spec", true);
+    const ungroundedSpec = await specWithDecision("Ungrounded Interaction Spec", false);
+
+    const groundedOut = textOf(
+      await callTool(actor.user.id, "resolve_decision", {
+        ref: groundedSpec.decRef,
+        resolution: "Settled against current source.",
+        verbose: true,
+      }),
+    );
+    const ungroundedOut = textOf(
+      await callTool(actor.user.id, "resolve_decision", {
+        ref: ungroundedSpec.decRef,
+        resolution: "Settled against current source.",
+        verbose: true,
+      }),
+    );
+
+    // ── Direction 1: the grounded Spec is NOT told it has no code-grounding.
+    // This is the load-bearing half for ac-4 — the false negative is what makes
+    // spec-424's push land on work already done.
+    expect(
+      groundedOut,
+      "a grounded Spec resolving a decision is still being told it has no code-grounding — " +
+        "this is the wasted re-grounding spec-424 would amplify",
+    ).not.toMatch(UNGROUNDED_PUSH);
+
+    // What it IS told: grounded, by whom, when — and that this very resolution
+    // moved a decision, so the grounding needs re-checking. Not the plain
+    // affirmative: that branch is unreachable through a mutating tool (see the
+    // fixture note), and ac-4 asks what the agent can ACT on, which this is.
+    expect(groundedOut, "the stale claim never reached the response").toMatch(STALE_CLAIM);
+    expect(groundedOut, "the header does not name who grounded it or when").toMatch(HEADER_STALE);
+    expect(
+      groundedOut,
+      "the plain affirmative appeared on a Spec whose decision was just re-resolved — " +
+        "that would be the same false claim as the original defect, inverted",
+    ).not.toMatch(GROUNDED_CLAIM);
+
+    // ── Direction 2: the ungrounded Spec still gets pushed. Not suppressed.
+    expect(
+      ungroundedOut,
+      "the ungrounded push is gone — that breaks spec-424, which exists to deliver it",
+    ).toMatch(UNGROUNDED_PUSH);
+    expect(ungroundedOut, "the ungrounded header line is missing").toMatch(HEADER_NONE);
+    expect(ungroundedOut).not.toMatch(GROUNDED_CLAIM);
+
+    // ── The state-independent ask survives BOTH ways ─────────────────────────
+    // spec-424's whole delivery rides on this. If it only survived on the
+    // ungrounded side, a grounded Spec would lose the specify→build gate
+    // prompt — a regression dressed as a fix.
+    expect(groundedOut, "the gate ask was lost on the grounded side").toMatch(THE_ASK);
+    expect(ungroundedOut, "the gate ask was lost on the ungrounded side").toMatch(THE_ASK);
+
+    // ── The two directions must actually DIFFER ──────────────────────────────
+    // The root of the defect, stated at the level ac-4 cares about: before
+    // spec-542 these two responses said the same thing about grounding.
+    expect(
+      groundedOut === ungroundedOut,
+      "a grounded and an ungrounded Spec produced byte-identical resolve_decision output",
+    ).toBe(false);
+  });
+
+  // create_ac is the second tool t-7 names. Same claim, different entry point —
+  // because ac-4 is about what these tools' RESPONSES carry, and a fix wired
+  // into only one handler would pass the test above.
+  //
+  // IT CARRIES THE CLAIM BUT NOT THE HEADER, and that asymmetry is real, not a
+  // gap. `create_ac` returns a terse confirmation (`Created AC ...`) plus the
+  // seat-composed footer — it never calls `formatState`, so the t-5 header line
+  // has no seat in its response. `resolve_decision` DOES render full doc state,
+  // which is why the test above can assert the header and this one cannot.
+  //
+  // ac-4 asks whether the response carries "the grounding state an agent can
+  // act on". The footer claim is that state, and it discriminates correctly
+  // here. So the absence of the header is asserted too, deliberately: it pins
+  // the boundary instead of leaving a reader to wonder whether it was missed.
+  it("create_ac carries the discriminated claim in both directions (footer, not header)", async () => {
+    tagAc(AC(4));
+
+    const groundedSpec = await specWithDecision("Grounded AC Spec", true);
+    const ungroundedSpec = await specWithDecision("Ungrounded AC Spec", false);
+
+    const mk = async (ref: string) =>
+      textOf(
+        await callTool(actor.user.id, "create_ac", {
+          ref,
+          kind: "scope",
+          statement: "The interaction is proven rather than assumed.",
+          verbose: true,
+        }),
+      );
+
+    const groundedOut = await mk(groundedSpec.ref);
+    const ungroundedOut = await mk(ungroundedSpec.ref);
+
+    // ── Direction 1: grounded ⇒ the affirmative claim, and no re-ground push.
+    expect(
+      groundedOut,
+      'create_ac on a grounded Spec still pushes it to re-ground',
+    ).not.toMatch(UNGROUNDED_PUSH);
+    // Stale, for the same structural reason as resolve_decision: the inserted
+    // AC's `updated_at` is newer than `grounded_at` by construction.
+    expect(groundedOut, 'the stale claim never reached create_ac').toMatch(STALE_CLAIM);
+    expect(groundedOut).not.toMatch(GROUNDED_CLAIM);
+
+    // ── Direction 2: ungrounded ⇒ the push still lands. Not suppressed.
+    expect(
+      ungroundedOut,
+      'create_ac no longer pushes an ungrounded Spec — that is the global suppression ac-4 warns about',
+    ).toMatch(UNGROUNDED_PUSH);
+    expect(ungroundedOut).not.toMatch(GROUNDED_CLAIM);
+
+    // The state-independent ask survives both ways here too.
+    expect(groundedOut).toMatch(THE_ASK);
+    expect(ungroundedOut).toMatch(THE_ASK);
+
+    // The boundary, pinned: no doc-state header on either side, because this
+    // handler does not render doc state. If create_ac ever starts calling
+    // formatState, this reds and the comment above needs revisiting.
+    expect(groundedOut, 'create_ac now renders the doc-state header — see the note above').not.toMatch(
+      HEADER_STALE,
+    );
+    expect(ungroundedOut).not.toMatch(HEADER_NONE);
+
+    expect(
+      groundedOut === ungroundedOut,
+      'grounded and ungrounded create_ac responses were byte-identical',
+    ).toBe(false);
+  });
+
+  // ── The fresh-grounded branch, at a tool that can actually produce it ────
+  // The two tools above mutate the rows staleness is derived from, so they can
+  // never leave a Spec plainly grounded. `get_doc` mutates nothing — it is
+  // where an agent actually reads a clean affirmative, so that is where the
+  // branch is asserted rather than being manufactured with a fixture that
+  // orders `grounded_at` after its own decisions.
+  //
+  // This keeps ac-4 honest in both directions: the affirmative prose IS
+  // reachable (spec-409 shipped it and spec-542 connected it), just not through
+  // a call that changes the thing the grounding was checked against.
+  it("get_doc on a grounded, unmutated Spec reads the plain affirmative", async () => {
+    tagAc(AC(4));
+
+    const doc = await createDocDraft(actor.memexId, "Untouched Grounded Spec", "Purpose.", "spec");
+    created.docs.push(doc.id);
+    // Grounded AFTER the doc's own rows settled, and nothing touched since —
+    // the one shape that derives NOT stale in production.
+    await db
+      .update(documents)
+      .set({
+        status: "specify",
+        groundedInCode: true,
+        groundedAt: new Date(),
+        groundedByName: "A. Reviewer",
+        groundedByUserId: actor.user.id,
+      })
+      .where(eq(documents.id, doc.id));
+
+    const out = textOf(
+      await callTool(actor.user.id, "get_doc", {
+        ref: `${actor.nsSlug}/main/specs/${doc.handle}`,
+        verbose: true,
+      }),
+    );
+
+    expect(out, "the affirmative claim is unreachable even here").toMatch(GROUNDED_CLAIM);
+    expect(out, "the header does not report a clean verification").toMatch(HEADER_VERIFIED);
+    expect(out, "a grounded, untouched Spec is being told it has no grounding").not.toMatch(
+      UNGROUNDED_PUSH,
+    );
+    expect(out, "an untouched grounding is being reported as stale").not.toMatch(STALE_CLAIM);
+  });
+
+  // ── The drift finding, asserted so it cannot rot ─────────────────────────
+  // t-7 asked for STEER_BY_TOOL to be confirmed by name OR the drift flagged.
+  // A comment rots; this fails the day the premise becomes true, which is the
+  // day someone should re-read the note at the top of this file.
+  it("STEER_BY_TOOL exists by name and still registers NO grounding steer (drift check)", async () => {
+    tagAc(AC(4));
+
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(
+      new URL("../agent/handlers/guidance-envelope.ts", import.meta.url),
+      "utf8",
+    );
+
+    // Still exists by that name — the premise's one intact half.
+    expect(src, "STEER_BY_TOOL has been renamed or removed — t-7's premise needs revisiting").toMatch(
+      /const STEER_BY_TOOL\b/,
+    );
+
+    // And still holds no grounding entry. When spec-424 lands one, this reds and
+    // the header note above stops being true.
+    const registry = src.slice(
+      src.indexOf("const STEER_BY_TOOL"),
+      src.indexOf("function composeToolSteer"),
+    );
+    expect(registry.length, "could not isolate the STEER_BY_TOOL registry body").toBeGreaterThan(50);
+    expect(
+      /ground_spec|code-grounding|grounding/i.test(registry),
+      "STEER_BY_TOOL now carries a grounding steer — spec-424 has shipped, so re-read this " +
+        "file's header note: ac-4's interaction now has a second push to account for",
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -60,6 +60,10 @@ export type {
   GuidanceSource,
   GuidanceEmphasis,
   GuidanceTarget,
+  // spec-542: the server derives this from the doc and passes it to `toNudge`
+  // at both call sites in `formatting/formatters.ts` (t-4), so it has to cross
+  // the package boundary.
+  GroundingState,
   ScaffoldDataset,
   SystemBlock,
   ToolDefinition,
@@ -82,6 +86,11 @@ export {
   // adding the const to scaffold-data.ts alone leaves it `undefined` at the
   // import site, with no build error to say so.
   SENSITIVE_WARNING_PROSE,
+  // spec-542 ac-1: the code-grounding header line, consumed by the same MCP
+  // header formatter. Named here for the same reason stated just above — and
+  // that reason was verified rather than trusted: CODE_GROUNDING_HEADER_PROSE
+  // is present in the built dist/index.d.ts.
+  CODE_GROUNDING_HEADER_PROSE,
   GET_PROMPT_PROSE,
   // spec-464 dec-24: the phase-gating teaching catalog (prose home, std-15).
   PHASE_GATING_CATALOG,

--- a/packages/shared/src/scaffold-data.spec-542-grounding-branches.test.ts
+++ b/packages/shared/src/scaffold-data.spec-542-grounding-branches.test.ts
@@ -1,0 +1,163 @@
+// spec-542 t-3 (ac-6, ac-12) — every footer-reachable grounding branch is
+// reachable, and the two that are NOT reachable are unreachable on purpose.
+//
+// Sibling of scaffold-data.spec-542-grounding-claim.test.ts, which asserts the
+// NEGATIVE (no response contradicts its subject). This file asserts the
+// POSITIVE: each state reaches its own prose, from the real BASE_SCAFFOLD.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { BASE_SCAFFOLD } from './scaffold-data.js';
+import { toNudge, toPhaseGuidance, type GroundingState, type Phase } from './scaffold-model.js';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-542/acs/ac-${n}`;
+
+const compose = (grounding?: GroundingState) =>
+  toNudge({ dataset: BASE_SCAFFOLD, tool: 'get_doc', phase: 'specify', grounding });
+
+// The state-independent ask. Must survive on every read: it is the specify→build
+// gate prompt, not a claim about this Spec.
+const THE_ASK = /Call assess_spec again with `codeGrounding`/;
+
+const CLAIM: Record<GroundingState, RegExp> = {
+  not_grounded: /No code-grounding on this Spec/,
+  grounded: /Code-grounding affirmed by agent/,
+  grounded_stale: /Treat the grounding as out of date/,
+};
+
+describe('spec-542 — each grounding state reaches its own prose (ac-6)', () => {
+  for (const state of Object.keys(CLAIM) as GroundingState[]) {
+    it(`state=${state} emits its own claim and no other`, () => {
+      tagAc(AC(6));
+
+      const out = compose(state);
+      expect(out, `${state} did not reach its own prose`).toMatch(CLAIM[state]);
+      for (const other of Object.keys(CLAIM) as GroundingState[]) {
+        if (other === state) continue;
+        expect(out, `${state} also emitted the ${other} claim`).not.toMatch(CLAIM[other]);
+      }
+    });
+  }
+
+  it('the state-independent ask survives in every state, and with no state', () => {
+    tagAc(AC(6));
+
+    // Splitting the block must not cost the gate prompt. It is the half that
+    // does NOT depend on the state, which is why it stays globally targeted.
+    for (const state of Object.keys(CLAIM) as GroundingState[]) {
+      expect(compose(state), `ask missing in state=${state}`).toMatch(THE_ASK);
+    }
+    expect(compose(undefined)).toMatch(THE_ASK);
+  });
+
+  it('the ask precedes the claim it introduces', () => {
+    tagAc(AC(6));
+
+    // The ask and the three claims share `order: 2`, so their relative order
+    // rests on the stable sort ES2019 guarantees plus array position. This
+    // PINS that rather than trusting it — a comment in scaffold-data.ts says
+    // this test exists, so it has to.
+    const out = compose('not_grounded');
+    expect(out.search(THE_ASK)).toBeGreaterThan(-1);
+    expect(out.search(THE_ASK)).toBeLessThan(out.search(CLAIM.not_grounded));
+  });
+
+  it('no single always-on block carries a grounding claim any more', () => {
+    tagAc(AC(6));
+
+    // The root cause, asserted against the DATA rather than the output: a
+    // `target: {}` block carrying the claim is what made every Spec read the
+    // same. If one reappears, this fails even if some other branch masks it.
+    const alwaysOn = BASE_SCAFFOLD.baseGuidance.filter(
+      (b) =>
+        b.target.phase === undefined &&
+        b.target.tool === undefined &&
+        b.target.transition === undefined &&
+        b.target.button === undefined &&
+        b.target.grounding === undefined,
+    );
+    for (const b of alwaysOn) {
+      for (const claim of Object.values(CLAIM)) {
+        expect(b.text, `an always-on block asserts a grounding state: ${b.text.slice(0, 60)}`).not.toMatch(claim);
+      }
+    }
+  });
+
+  it('the not_applicable prose is unreachable from the footer, in every state', () => {
+    tagAc(AC(6));
+
+    // dec-3: it exists in the server-only markdown home and stays footer-
+    // unreachable because the classification is transient to an assess_spec
+    // call and never persisted. Pinned so a later reader who finds the orphaned
+    // section cannot "fix" it into an unknowable claim.
+    const NOT_APPLICABLE = /not code-touching; no grounding check applied/;
+    for (const state of [...(Object.keys(CLAIM) as GroundingState[]), undefined]) {
+      expect(compose(state), `not_applicable leaked in state=${state}`).not.toMatch(
+        NOT_APPLICABLE,
+      );
+    }
+  });
+});
+
+describe('spec-542 — a stale grounding is distinguishable from a fresh one (ac-12)', () => {
+  it('stale and fresh compose different text', () => {
+    tagAc(AC(12));
+
+    // The branch dec-1 never considered. Before spec-542 a Spec grounded three
+    // weeks ago whose decisions have since changed read identically to one
+    // grounded five minutes ago — and both were told they were ungrounded.
+    expect(compose('grounded_stale')).not.toBe(compose('grounded'));
+  });
+
+  it('the stale claim tells the reader to re-check, not that grounding is absent', () => {
+    tagAc(AC(12));
+
+    const out = compose('grounded_stale');
+    expect(out).toMatch(/re-check the changed ones against current source/);
+    // It is grounded — just out of date. Saying it is absent would be the
+    // original defect wearing a different hat.
+    expect(out).not.toMatch(CLAIM.not_grounded);
+  });
+
+  // ── The scope boundary this Spec relies on (std-38) ─────────────────────
+  // spec-542 stayed out of the in-app agent's way on one claim: `toPhaseGuidance`
+  // filters `b.target.phase === phase`, so a block with no `phase` never reaches
+  // the React agent. All four code-grounding blocks are phase-less (the ask is
+  // `target: {}`; the three claims target `grounding` only), so none of them do.
+  //
+  // That was verified when dec-3 scoped the work — BEFORE t-3 replaced the one
+  // fused block with four. A carried-forward conclusion is not a checked one, so
+  // it is checked here: if a later edit gives any of them a `phase`, the in-app
+  // agent inherits a grounding claim it has no state to evaluate, and std-38
+  // pulls that surface into scope. This test is where that shows up.
+  it('no grounding claim reaches the in-app agent, in any phase (std-38 boundary)', () => {
+    tagAc(AC(12));
+
+    const PHASES: readonly Phase[] = ['draft', 'specify', 'build', 'verify', 'done'];
+    for (const phase of PHASES) {
+      const out = toPhaseGuidance(BASE_SCAFFOLD, phase);
+      // Non-empty first: an empty projection would satisfy every negative below
+      // while checking nothing (the same silent failure mode ac-11 guards).
+      expect(out.length, `toPhaseGuidance(${phase}) composed nothing`).toBeGreaterThan(0);
+      for (const state of Object.keys(CLAIM) as GroundingState[]) {
+        expect(
+          out,
+          `the ${state} claim reached the in-app agent at phase=${phase} — ` +
+            'std-38 now applies and this Spec has not covered that surface',
+        ).not.toMatch(CLAIM[state]);
+      }
+    }
+  });
+
+  it('the stale prose is portable — no paths, no language, no tooling (std-22)', () => {
+    tagAc(AC(12));
+
+    const stale = BASE_SCAFFOLD.baseGuidance.find(
+      (b) => b.target.grounding === 'grounded_stale',
+    );
+    expect(stale, 'no grounded_stale block registered').toBeDefined();
+    // It ships to arbitrary codebases, so it may not name one.
+    expect(stale!.text).not.toMatch(/\.ts\b|\.py\b|packages\/|src\/|vitest|pnpm|npm |git /i);
+  });
+});

--- a/packages/shared/src/scaffold-data.spec-542-grounding-claim.test.ts
+++ b/packages/shared/src/scaffold-data.spec-542-grounding-claim.test.ts
@@ -1,0 +1,199 @@
+// spec-542 t-1 (ac-9, ac-10, ac-11) — no composed nudge asserts something untrue
+// about the Spec it describes.
+//
+// THIS FILE IS RED BY DESIGN until t-2/t-3 land. It is written first, per std-52:
+// a defect's cause is claimed only after a command goes red on it. The red output
+// is recorded on t-1.
+//
+// The defect: `BASE_CODE_GROUNDING` (scaffold-data.ts) fuses the grounding *ask*
+// and the ⚠ *warning* into one flat string, and BASE_GUIDANCE registers it with
+// `target: {}` — matching every tool, every phase, every Spec. So a grounded Spec
+// and an ungrounded one emit byte-identical text, and both say "No code-grounding
+// on this Spec".
+//
+// WHY THIS SHAPE (dec-2): the sibling guard for this defect family
+// (`no-unheld-bound-claims.spec-538.regression.test.ts`) scans source COMMENTS in
+// `packages/server/src`. It cannot reach this defect on two independent counts —
+// wrong corpus (the prose lives in `packages/shared`) and wrong artifact class (a
+// runtime response string, not a comment). So this guard asserts on the COMPOSED
+// OUTPUT instead, which catches a re-flattening no matter which file causes it.
+//
+// WHY IT LIVES IN `packages/shared` (ac-10): `toNudge` is a pure projection here,
+// and this package's vitest has no globalSetup provisioning a database — so the
+// guard runs in a genuinely cheap gate. The server suite is not offline.
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import { BASE_SCAFFOLD } from './scaffold-data.js';
+import { toNudge, type GroundingState, type Phase } from './scaffold-model.js';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-542/acs/ac-${n}`;
+
+// The four cases dec-3 settled on: the three states the document PERSISTS, plus
+// the absence of any state. Derived from the real `GroundingState` union rather
+// than restated, so a state added to the model shows up here instead of being
+// silently untested. `not_applicable` is absent on purpose — it is transient to
+// an `assess_spec` call and never persisted, so the footer cannot know it.
+type GuardState = GroundingState | 'no_context';
+
+const ALL_STATES: readonly GuardState[] = [
+  'not_grounded',
+  'grounded',
+  'grounded_stale',
+  'no_context',
+];
+
+// The claim that must never appear about a Spec it is not true of.
+const NEGATIVE_CLAIM = /No code-grounding on this Spec/i;
+// The tell that the condition is written INTO the prose rather than evaluated.
+const PROSE_CONDITIONAL = /If unverified:/i;
+// The affirmative branch — prose that already exists in the server-only home
+// (`agent/phases/_base/code-grounding.md`, `## nudge:verified`) and is currently
+// unreachable from the footer.
+const AFFIRMATIVE_CLAIM = /Code-grounding affirmed/i;
+
+/**
+ * THE SEAM. Composes the nudge as it will be composed for `state`.
+ *
+ * t-2 landed the `grounding` dimension on `GuidanceTarget` / `ToNudgeInput`, so
+ * the state is now passed through — this helper is wired end to end.
+ *
+ * The assertions below nevertheless stay RED until t-3, and for a reason worth
+ * being precise about: `scaffold-data.ts` still registers ONE code-grounding
+ * block with `target: {}`, and an untargeted block matches every state by
+ * design (the back-compat guarantee ac-5 pins). So the projection now CAN
+ * discriminate and the data still does not ask it to. t-3 splits the block.
+ *
+ * `no_context` is the absence of a state, never a value of `GroundingState` —
+ * conflating the two is the defect itself, so the type does not permit it.
+ */
+function composeFor(state: GuardState, tool: string, phase: Phase): string {
+  return toNudge({
+    dataset: BASE_SCAFFOLD,
+    tool: state === 'no_context' ? undefined : tool,
+    phase: state === 'no_context' ? undefined : phase,
+    grounding: state === 'no_context' ? undefined : state,
+  });
+}
+
+describe('spec-542 — no composed nudge contradicts its subject', () => {
+  // ── The self-check (ac-11) ──────────────────────────────────────────────
+  // A guard that quietly composes an empty string would satisfy every negative
+  // assertion below while checking nothing at all. That failure mode is silent
+  // and looks exactly like success, so it is asserted before anything else.
+  it('the guard composes a REAL nudge, not an empty string', () => {
+    tagAc(AC(11));
+
+    const out = composeFor('grounded', 'get_doc', 'specify');
+    expect(out.length).toBeGreaterThan(500);
+    // A different global block, to prove the whole projection ran rather than
+    // one lucky substring surviving.
+    expect(out).toMatch(/Reference elements by their handle/);
+  });
+
+  // ── Placement (ac-10) ───────────────────────────────────────────────────
+  // The guard asserts its OWN location, so a later move into the server suite
+  // fails here rather than quietly costing every run a database. `toNudge` is a
+  // pure projection in this package and this package's vitest provisions no DB;
+  // the server suite's globalSetup does. Placement is part of the choice.
+  it('lives in @memex/shared, the package whose suite needs no database', () => {
+    tagAc(AC(10));
+
+    expect(import.meta.url).toMatch(/\/packages\/shared\//);
+    // And it composes with nothing but the dataset — no server import, no client,
+    // no fixture. If this file ever needs one, it is in the wrong package.
+    expect(typeof toNudge).toBe('function');
+  });
+
+  // ── Negative-first assertions (ac-9, and the scope claim ac-2) ──────────
+  // The defect was never a MISSING string; it was a PRESENT and wrong one. So
+  // the load-bearing assertions are the negatives.
+  //
+  // These carry ac-2 as well: "no response asserts something untrue about the
+  // Spec it describes" is the scope commitment, and this is where it is proven.
+  // Tagging only the implementation AC would leave the promise made to the
+  // reader unverified while the mechanism read green.
+
+  it('a GROUNDED Spec is never told it has no code-grounding', () => {
+    tagAc(AC(9));
+    tagAc(AC(2));
+
+    const out = composeFor('grounded', 'get_doc', 'specify');
+    expect(out, 'a grounded Spec is being told the opposite').not.toMatch(NEGATIVE_CLAIM);
+  });
+
+  it('a STALE-grounded Spec is not presented as freshly grounded', () => {
+    tagAc(AC(9));
+    tagAc(AC(2));
+
+    const out = composeFor('grounded_stale', 'get_doc', 'specify');
+    // It must not claim the plain affirmative, and must not claim the flat
+    // negative either — a stale grounding is neither.
+    expect(out, 'a stale grounding is being reported as fresh').not.toMatch(AFFIRMATIVE_CLAIM);
+    expect(out, 'a stale grounding is being reported as absent').not.toMatch(NEGATIVE_CLAIM);
+  });
+
+  it('a read with NO Spec context makes no grounding claim at all', () => {
+    tagAc(AC(9));
+    tagAc(AC(2));
+
+    // ac-7's case, and the one today's code gets most clearly wrong: "nothing
+    // known" is rendered as "known to be ungrounded".
+    const out = composeFor('no_context', 'list_memexes', 'specify');
+    expect(out, 'a read that knows nothing is asserting a grounding state').not.toMatch(
+      NEGATIVE_CLAIM,
+    );
+  });
+
+  it('an UNGROUNDED Spec is not told it is grounded', () => {
+    tagAc(AC(9));
+    tagAc(AC(2));
+
+    const out = composeFor('not_grounded', 'get_doc', 'specify');
+    expect(out).not.toMatch(AFFIRMATIVE_CLAIM);
+  });
+
+  // ── The structural assertion: the states must actually differ ────────────
+  // This is the defect stated at its root. States producing one identical string
+  // is the whole bug, and it is the assertion that stays meaningful even if the
+  // exact wording of every branch changes later.
+  //
+  // ONLY the three same-context states are compared. An earlier version of this
+  // test swept all four including `no_context` and PASSED against the broken
+  // code — because `no_context` also drops `tool`/`phase`, so its output differs
+  // for a reason that has nothing to do with grounding. A green that cannot fail
+  // on this defect proves nothing (std-52), so the varying dimension is isolated:
+  // same tool, same phase, grounding state the only difference.
+  it('the three same-context grounding states do not compose the same text', () => {
+    tagAc(AC(9));
+    tagAc(AC(2));
+
+    const SAME_CONTEXT: readonly GuardState[] = [
+      'not_grounded',
+      'grounded',
+      'grounded_stale',
+    ];
+    const composed = SAME_CONTEXT.map((s) => composeFor(s, 'get_doc', 'specify'));
+    const distinct = new Set(composed);
+    expect(
+      distinct.size,
+      `all ${SAME_CONTEXT.length} grounding states composed byte-identical output at ` +
+        '(tool=get_doc, phase=specify) — the grounding claim is unconditional',
+    ).toBe(SAME_CONTEXT.length);
+  });
+
+  // ── The prose-conditional tell ──────────────────────────────────────────
+  // "If unverified:" is a condition written into the sentence instead of being
+  // evaluated by code. Its presence anywhere in a composed nudge means the
+  // reader is being asked to evaluate a branch the system should have resolved.
+  it('no composed nudge asks the READER to evaluate the condition', () => {
+    tagAc(AC(9));
+    tagAc(AC(2));
+
+    for (const state of ALL_STATES) {
+      const out = composeFor(state, 'get_doc', 'specify');
+      expect(out, `prose conditional survives in state=${state}`).not.toMatch(PROSE_CONDITIONAL);
+    }
+  });
+});

--- a/packages/shared/src/scaffold-data.toNudge.test.ts
+++ b/packages/shared/src/scaffold-data.toNudge.test.ts
@@ -89,7 +89,14 @@ describe('toNudge against BASE_SCAFFOLD — phase-agnostic fallback (ac-25)', ()
       (b) =>
         b.target.phase === undefined &&
         b.target.tool === undefined &&
-        b.target.transition === undefined,
+        b.target.transition === undefined &&
+        // spec-542: `grounding` is a narrowing dimension too, and this call
+        // passes no grounding state. A grounding-targeted block is therefore
+        // NOT global here and MUST be absent — asserting it must appear would
+        // demand the very claim spec-542 removed ("nothing known" rendered as
+        // "known to be ungrounded"). The predicate was written before the
+        // dimension existed; the test's intent is unchanged.
+        b.target.grounding === undefined,
     );
     expect(globalBlocks.length).toBeGreaterThan(0);
     for (const block of globalBlocks) {
@@ -250,7 +257,11 @@ describe('toNudge against BASE_SCAFFOLD — base-first + enabled-Org merge (ac-9
       (b) =>
         (b.target.phase === undefined || b.target.phase === 'build') &&
         b.target.tool === undefined &&
-        b.target.transition === undefined,
+        b.target.transition === undefined &&
+        // spec-542: as above — this call passes no grounding state, so a
+        // grounding-targeted block does not match the context and cannot be
+        // expected in the output.
+        b.target.grounding === undefined,
     );
     expect(matchingBaseBlocks.length).toBeGreaterThan(0);
 

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -612,11 +612,67 @@ const BASE_CODE_GROUNDING: PromptBlockNode = {
   kind: 'prompt_block',
   id: 'code-grounding',
   surface: 'shared_nudge',
+  // spec-542: the PROMPT half only. It used to carry the `nudge:not_verified`
+  // warning fused onto the end, and BASE_GUIDANCE registered the fused string
+  // with `target: {}` — so every Spec, grounded or not, was told it had no
+  // code-grounding. The condition lived INSIDE the sentence ('If unverified:')
+  // rather than being evaluated, which is why a grounded Spec and an ungrounded
+  // one emitted byte-identical text. The ask below is state-independent and
+  // stays globally targeted; the state-keyed siblings carry the claim.
   text:
-    'Is this Spec\'s scope code-touching (does any resolved decision name code shape — files, symbols, schema, routes)? If yes, have the resolved decisions been verified against current source? Call assess_spec again with `codeGrounding` set to one of: `not_applicable`, `verified`, or `not_verified`.\n\n' +
-    'If unverified: ⚠ No code-grounding on this Spec. If you\'re driving from a coding agent, walk the resolved decisions against current source before transitioning. Build transition is not blocked.',
+    'Is this Spec\'s scope code-touching (does any resolved decision name code shape — files, symbols, schema, routes)? If yes, have the resolved decisions been verified against current source? Call assess_spec again with `codeGrounding` set to one of: `not_applicable`, `verified`, or `not_verified`.',
   rationale:
-    'Code-grounding self-classification prompt for the doc-27 flow. Both agents face the same specify→build gate and should self-classify the same way. Mirrors the `prompt` + `nudge:not_verified` sections of `_base/code-grounding.md`.',
+    'Code-grounding self-classification prompt for the doc-27 flow. Both agents face the same specify→build gate and should self-classify the same way. Mirrors the `prompt` section of `_base/code-grounding.md`. spec-542 split the `nudge:*` sections out into per-state siblings.',
+};
+
+// spec-542 t-3 — the state-keyed halves. Prose is lifted VERBATIM from the
+// server-only home (`agent/phases/_base/code-grounding.md`), not paraphrased:
+// std-15 mandates the two homes and they are a hand-maintained copy (dec-3), so
+// a paraphrase would start a fresh divergence of exactly the kind that caused
+// this defect. The lift also drops the 'If unverified:' prefix for free — the
+// markdown home never had it; it appeared only once the halves were fused.
+//
+// WHY THERE IS NO `not_applicable` SIBLING, and why that is not this bug again:
+// `nudge:not_applicable` exists in the markdown home and is deliberately NOT
+// reachable from the footer. That classification is transient to an
+// `assess_spec` call (`CodeGrounding` in `services/phase-assessment.ts`) and is
+// never written to the document — the schema persists a boolean plus
+// timestamps. So the footer cannot know it, and DERIVING it (guessing whether a
+// resolved decision 'names code shape') was considered and rejected: a guess
+// rendered as a statement of fact is the defect class this Spec removes, and it
+// would be worse than the original because it would look authoritative.
+// An unreachable branch WITH a recorded reason is fine; an unreachable branch
+// with NO reason is what caused spec-542. (dec-3)
+const BASE_CODE_GROUNDING_NOT_GROUNDED: PromptBlockNode = {
+  kind: 'prompt_block',
+  id: 'code-grounding-not-grounded',
+  surface: 'shared_nudge',
+  text:
+    '⚠ No code-grounding on this Spec. If you\'re driving from a coding agent, walk the resolved decisions against current source before transitioning. Build transition is not blocked.',
+  rationale:
+    'The ungrounded branch — `nudge:not_verified` of `_base/code-grounding.md`, verbatim. Fires only when the document says the Spec is not grounded, never as the default for a state nobody knows (spec-542 ac-7).',
+};
+
+const BASE_CODE_GROUNDING_GROUNDED: PromptBlockNode = {
+  kind: 'prompt_block',
+  id: 'code-grounding-grounded',
+  surface: 'shared_nudge',
+  text: 'Code-grounding affirmed by agent.',
+  rationale:
+    'The grounded branch — `nudge:verified` of `_base/code-grounding.md`, verbatim. This prose already existed and was unreachable from the footer: spec-409 shipped the flag and the web badge, and the MCP read rendered neither (spec-542 ac-6).',
+};
+
+const BASE_CODE_GROUNDING_STALE: PromptBlockNode = {
+  kind: 'prompt_block',
+  id: 'code-grounding-stale',
+  surface: 'shared_nudge',
+  // The only branch with NEW words: the markdown home has no stale section,
+  // because assess_spec's three-way self-classification has no stale answer.
+  // Portable per std-22 — no paths, no language, no tooling.
+  text:
+    '⚠ This Spec was code-grounded, but decisions or acceptance criteria have changed since. Treat the grounding as out of date: re-check the changed ones against current source before relying on it.',
+  rationale:
+    'The stale branch (spec-542 dec-3 / ac-12). Absent from `_base/code-grounding.md` because staleness is DERIVED at read time rather than self-classified, so assess_spec has no answer for it. This is the case where re-verification is most warranted, and before spec-542 it read identically to a Spec grounded five minutes ago.',
 };
 
 const BASE_STANDARDS_PROTOCOL: PromptBlockNode = {
@@ -1429,7 +1485,47 @@ const BASE_GUIDANCE: GuidanceBlock[] = [
     enabled: true,
     order: 2,
     rationale:
-      'Code-grounding self-classification for the specify→build gate. Globally targeted because both agents face the same gate.',
+      'Code-grounding self-classification for the specify→build gate. Globally targeted because both agents face the same gate, and because the ASK is state-independent — only the claim below it depends on the state.',
+  },
+  // spec-542 — the claim itself, keyed by the state the document actually
+  // persists (dec-3). Exactly one of the three can match any given read, so
+  // they share `order: 2` with the ask they belong to without ever competing:
+  // the ask precedes them by array position under the stable sort ES2019
+  // guarantees, and there is a test pinning that order rather than trusting it.
+  //
+  // A read that resolves no Spec passes no state, and then NONE of these match
+  // — the response makes no grounding claim at all. That fallthrough is the
+  // point: before spec-542 this was one `target: {}` block, so 'nothing known'
+  // was rendered as 'known to be ungrounded' on every read, of every Spec.
+  {
+    kind: 'guidance_block',
+    source: 'base',
+    target: { grounding: 'not_grounded' },
+    text: BASE_CODE_GROUNDING_NOT_GROUNDED.text,
+    enabled: true,
+    order: 2,
+    rationale:
+      'The ungrounded claim. Now fires only when the document says so, instead of on every Spec (spec-542 ac-6).',
+  },
+  {
+    kind: 'guidance_block',
+    source: 'base',
+    target: { grounding: 'grounded' },
+    text: BASE_CODE_GROUNDING_GROUNDED.text,
+    enabled: true,
+    order: 2,
+    rationale:
+      'The grounded claim. Prose that shipped with spec-409 and had no way to reach the MCP reader until now (spec-542 ac-6).',
+  },
+  {
+    kind: 'guidance_block',
+    source: 'base',
+    target: { grounding: 'grounded_stale' },
+    text: BASE_CODE_GROUNDING_STALE.text,
+    enabled: true,
+    order: 2,
+    rationale:
+      'The stale claim — grounded, but decisions or ACs moved since. The branch dec-1 never considered and the product already computed (spec-542 ac-12).',
   },
   {
     kind: 'guidance_block',
@@ -1966,6 +2062,11 @@ const PROMPT_BLOCKS: PromptBlockNode[] = [
   BASE_ABOUT_BRIEF,
   BASE_MUTATION_PROTOCOL,
   BASE_CODE_GROUNDING,
+  // spec-542: the state-keyed halves. `shared_nudge` like their parent, so
+  // `toPromptBlocks` filters them out and they sit in no phase's promptBlockIds.
+  BASE_CODE_GROUNDING_NOT_GROUNDED,
+  BASE_CODE_GROUNDING_GROUNDED,
+  BASE_CODE_GROUNDING_STALE,
   BASE_STANDARDS_PROTOCOL,
   // spec-106 t-2: lens-shape block (shared_nudge — rides the nudge footer).
   SPEC_SHAPE_LENSES,
@@ -2543,6 +2644,48 @@ Walk me through this Spec's CANDIDATE decisions — choices an agent extracted t
 //     ours.
 //   * No noun for the document. "Spec" is our vocabulary, and the flag lives on
 //     the shared documents table, so the copy stays neutral about what it is on.
+/**
+ * spec-542 (ac-1) — the code-grounding HEADER line, for the MCP read.
+ *
+ * Lives here, not in `formatting/formatters.ts`, because agent-facing prose has
+ * one home (std-15) and that file is not on the drift guard's allowlist. The
+ * formatter pushes these as single lines, the way the spec-535 sensitivity
+ * block does.
+ *
+ * Rendered in EVERY state, never signalled by absence — the rule
+ * `Response shape:` states for itself (spec-538 ac-13): a line that appears
+ * only in one state forces the reader to infer the others from silence. Here
+ * that inference is "absence means ungrounded", which is the spec-542 defect
+ * one step quieter.
+ *
+ * WHO is the denormalised `groundedByName` (std-32), stamped at write so a later
+ * rename cannot rewrite history. Each variant has an unattributed twin: dropping
+ * the line when the name is missing would lose the STATE too — and the state is
+ * the part the reader needs — but nobody may be named as if they were somebody.
+ *
+ * Portable per std-22: no paths, no language, no tooling. No apostrophes either,
+ * deliberately — this file is single-quoted TypeScript and an unescaped one
+ * fails the build with a symptom that looks like a stale measurement.
+ */
+export const CODE_GROUNDING_HEADER_PROSE = {
+  /** No agent has verified this Spec against source. */
+  none: 'Code-grounding: none — the resolved decisions have not been checked against current source.',
+  /** Grounded and fresh. */
+  verified: (by: string | null, ago: string): string =>
+    by
+      ? `Code-grounding: verified by ${by} (${ago}).`
+      : `Code-grounding: verified (${ago}), no name recorded.`,
+  /**
+   * Grounded, but a decision or acceptance criterion changed since. The branch
+   * dec-1 did not foresee, and the one where re-checking matters most: before
+   * spec-542 it read identically to a Spec grounded five minutes ago.
+   */
+  stale: (by: string | null, ago: string): string =>
+    by
+      ? `Code-grounding: verified by ${by} (${ago}), but decisions or acceptance criteria changed since — treat it as out of date.`
+      : `Code-grounding: verified (${ago}), no name recorded, but decisions or acceptance criteria changed since — treat it as out of date.`,
+};
+
 export const SENSITIVE_WARNING_PROSE = {
   /** Top and bottom rule — what makes it a block rather than another header line. */
   rule: '⚠ ─────────────────────────────────────────────────────────────',

--- a/packages/shared/src/scaffold-grounding.ts
+++ b/packages/shared/src/scaffold-grounding.ts
@@ -52,7 +52,11 @@ function sameTarget(a: GuidanceTarget, b: GuidanceTarget): boolean {
     a.phase === b.phase &&
     a.tool === b.tool &&
     a.transition === b.transition &&
-    a.button === b.button
+    a.button === b.button &&
+    // spec-542: included so two blocks differing ONLY by grounding are not
+    // treated as the same target. Without it the duplicate check would see the
+    // per-state siblings as one target wearing three texts.
+    a.grounding === b.grounding
   );
 }
 
@@ -61,7 +65,10 @@ function isUntargeted(t: GuidanceTarget): boolean {
     t.phase === undefined &&
     t.tool === undefined &&
     t.transition === undefined &&
-    t.button === undefined
+    t.button === undefined &&
+    // spec-542: a grounding-only target DOES narrow — it fires in one state
+    // rather than on every response — so it is not "untargeted".
+    t.grounding === undefined
   );
 }
 

--- a/packages/shared/src/scaffold-model.spec-542-grounding-target.test.ts
+++ b/packages/shared/src/scaffold-model.spec-542-grounding-target.test.ts
@@ -1,0 +1,125 @@
+// spec-542 t-2 (ac-5, ac-7) — the `grounding` selection dimension on
+// GuidanceTarget, exercised against SYNTHETIC datasets.
+//
+// Deliberately synthetic, matching the split scaffold-model.test.ts already
+// draws: this file tests the MECHANISM (does the projection discriminate on
+// grounding?), while scaffold-data.spec-542-grounding-claim.test.ts tests the
+// real BASE_SCAFFOLD data (does the shipped footer still lie?). t-2 delivers the
+// mechanism; t-3 rewires the data. Mixing the two would leave this file red for
+// a reason it does not own.
+//
+// The whole design rests on one line in `matchesNudgeTarget` written in the same
+// style as its `phase` clause, which yields BOTH required behaviours at once:
+//   - target.grounding undefined            → matches every state (back-compat)
+//   - target.grounding set, context unknown → does NOT match (ac-7)
+
+import { describe, it, expect } from 'vitest';
+import { tagAc } from '@memex-ai-ac/vitest';
+import {
+  toNudge,
+  type GroundingState,
+  type GuidanceBlock,
+  type ScaffoldDataset,
+} from './scaffold-model.js';
+
+const AC = (n: number) =>
+  `mindset-prod/memex-building-itself/specs/spec-542/acs/ac-${n}`;
+
+const ALL_STATES: readonly GroundingState[] = ['not_grounded', 'grounded', 'grounded_stale'];
+
+function block(text: string, target: GuidanceBlock['target'], order = 0): GuidanceBlock {
+  return { kind: 'guidance_block', source: 'base', target, text, enabled: true, order };
+}
+
+/** A dataset carrying only `baseGuidance` — the rest is empty, since toNudge
+ *  reads nothing else. */
+function datasetOf(...blocks: GuidanceBlock[]): ScaffoldDataset {
+  return {
+    phases: [],
+    promptBlocks: [],
+    tools: [],
+    transitions: [],
+    baseGuidance: blocks,
+    promptButtons: [],
+  } as unknown as ScaffoldDataset;
+}
+
+describe('spec-542 — grounding as a nudge-target dimension (ac-5)', () => {
+  it('a grounding-targeted block fires ONLY in its own state', () => {
+    tagAc(AC(5));
+
+    const dataset = datasetOf(
+      block('YOU ARE GROUNDED', { grounding: 'grounded' }),
+      block('YOU ARE NOT GROUNDED', { grounding: 'not_grounded' }),
+      block('YOUR GROUNDING IS STALE', { grounding: 'grounded_stale' }),
+    );
+
+    expect(toNudge({ dataset, grounding: 'grounded' })).toBe('YOU ARE GROUNDED');
+    expect(toNudge({ dataset, grounding: 'not_grounded' })).toBe('YOU ARE NOT GROUNDED');
+    expect(toNudge({ dataset, grounding: 'grounded_stale' })).toBe('YOUR GROUNDING IS STALE');
+  });
+
+  it('a block with NO grounding on its target still matches every state', () => {
+    tagAc(AC(5));
+
+    // The back-compatibility guarantee. The three other global blocks in the
+    // real scaffold (about-spec, mutation-protocol, standards-protocol) rely on
+    // this: adding a dimension must not narrow blocks that never opted into it.
+    const dataset = datasetOf(block('ALWAYS', {}));
+
+    for (const grounding of ALL_STATES) {
+      expect(toNudge({ dataset, grounding }), `state=${grounding}`).toBe('ALWAYS');
+    }
+    // …including when the state is unknown.
+    expect(toNudge({ dataset })).toBe('ALWAYS');
+  });
+
+  it('grounding composes with the existing dimensions rather than replacing them', () => {
+    tagAc(AC(5));
+
+    // A block carrying BOTH must satisfy both. This is the assertion that fails
+    // if the new clause is written as an early `return true` instead of an early
+    // `return false` — a shape that would let a grounding match override a
+    // phase mismatch.
+    const dataset = datasetOf(
+      block('BUILD AND GROUNDED', { phase: 'build', grounding: 'grounded' }),
+    );
+
+    expect(toNudge({ dataset, phase: 'build', grounding: 'grounded' })).toBe(
+      'BUILD AND GROUNDED',
+    );
+    expect(toNudge({ dataset, phase: 'specify', grounding: 'grounded' })).toBe('');
+    expect(toNudge({ dataset, phase: 'build', grounding: 'not_grounded' })).toBe('');
+  });
+});
+
+describe('spec-542 — an unknown grounding state claims nothing (ac-7)', () => {
+  it('no grounding-targeted block fires when the state is absent', () => {
+    tagAc(AC(7));
+
+    // The bug in miniature. "Nothing known" must not resolve to "known to be
+    // ungrounded" — so a call with no grounding state selects NONE of the three,
+    // not the not_grounded one. Mirrors how `phase` already behaves per b-68 D-7.
+    const dataset = datasetOf(
+      block('YOU ARE GROUNDED', { grounding: 'grounded' }),
+      block('YOU ARE NOT GROUNDED', { grounding: 'not_grounded' }),
+      block('YOUR GROUNDING IS STALE', { grounding: 'grounded_stale' }),
+    );
+
+    expect(toNudge({ dataset })).toBe('');
+    expect(toNudge({ dataset, grounding: undefined })).toBe('');
+  });
+
+  it('an unknown state still receives grounding-agnostic guidance', () => {
+    tagAc(AC(7));
+
+    // The fallthrough must drop the grounding CLAIM without dropping everything
+    // else — a read that knows nothing about grounding is still a read.
+    const dataset = datasetOf(
+      block('GENERAL GUIDANCE', {}, 0),
+      block('YOU ARE NOT GROUNDED', { grounding: 'not_grounded' }, 1),
+    );
+
+    expect(toNudge({ dataset })).toBe('GENERAL GUIDANCE');
+  });
+});

--- a/packages/shared/src/scaffold-model.ts
+++ b/packages/shared/src/scaffold-model.ts
@@ -171,12 +171,39 @@ export type GuidanceSource = 'base' | 'org';
 
 export type GuidanceEmphasis = 'do' | 'dont';
 
+/**
+ * A Spec's code-grounding state, as it is KNOWABLE at read time (spec-542 dec-3).
+ *
+ * Three values, because three is what the document persists: `grounded_in_code`
+ * is a boolean and staleness is derived from `grounded_at` against decision/AC
+ * `updated_at`. There is deliberately no `not_applicable` — that classification
+ * is transient to an `assess_spec` call and is never written to the document, so
+ * a footer cannot know it. Deriving it by guessing whether a decision "names
+ * code shape" was considered and rejected: a guess rendered as a statement of
+ * fact is the defect class spec-542 exists to remove.
+ *
+ * The fourth state — nothing known — is the ABSENCE of this value, never a
+ * member of this union. "Nothing known" must not resolve to "known to be
+ * ungrounded"; that conflation IS the spec-542 defect.
+ */
+export type GroundingState = 'not_grounded' | 'grounded' | 'grounded_stale';
+
 export interface GuidanceTarget {
   phase?: Phase;
   tool?: string;
   transition?: Transition;
   /** Append guidance to a specific Prompt Button (spec-103 D-7). */
   button?: string;
+  /**
+   * Fire only when the Spec is in this grounding state (spec-542 dec-1).
+   *
+   * BASE-only today: the org-addition API surface (`routes/scaffold.ts`,
+   * `routes/personal-scaffold.ts`, `services/scaffold-additions.ts`) validates
+   * the other four dimensions and does not accept this one, so an Org cannot
+   * scope an addition by grounding. That is deliberate, not an oversight —
+   * widening it means deciding what an Org may assert about grounding.
+   */
+  grounding?: GroundingState;
 }
 
 export type ScaffoldNode =
@@ -247,6 +274,13 @@ export interface ToNudgeInput {
    *  (e.g. `list_memexes`) — falls through to phase-agnostic content per
    *  b-68 D-7. */
   phase?: Phase;
+  /** The Spec's code-grounding state at call time (spec-542). Undefined for
+   *  tools that resolve no Spec (e.g. `list_memexes`) — falls through to
+   *  grounding-agnostic content exactly as `phase` does, which means NO
+   *  grounding-targeted block fires and the response makes no grounding claim
+   *  at all. Passing `not_grounded` here to stand in for "unknown" would
+   *  reinstate the defect. */
+  grounding?: GroundingState;
   /** Org additions already filtered to `source: 'org'` + the principal's Org. */
   orgBlocks?: readonly GuidanceBlock[];
 }
@@ -343,8 +377,9 @@ export function toToolDefinition(tool: ToolNode): ToolDefinition {
  *  `order`. `target.transition !== undefined` blocks are excluded — those
  *  ride `toRubric`. */
 export function toNudge(input: ToNudgeInput): string {
-  const { dataset, tool, phase, orgBlocks } = input;
-  const matches = (block: GuidanceBlock): boolean => matchesNudgeTarget(block.target, { tool, phase });
+  const { dataset, tool, phase, grounding, orgBlocks } = input;
+  const matches = (block: GuidanceBlock): boolean =>
+    matchesNudgeTarget(block.target, { tool, phase, grounding });
 
   const base = filterAndSort(dataset.baseGuidance, (b) => b.source === 'base' && matches(b));
   const org = filterAndSort(orgBlocks ?? [], (b) => b.source === 'org' && b.enabled && matches(b));
@@ -471,12 +506,20 @@ export function toInitPromptRef(tool: ToolNode): InitPromptRefEntry {
  */
 function matchesNudgeTarget(
   target: GuidanceTarget,
-  context: { tool?: string; phase?: Phase },
+  context: { tool?: string; phase?: Phase; grounding?: GroundingState },
 ): boolean {
   if (target.transition !== undefined) return false;
   if (target.button !== undefined) return false;
   if (target.phase !== undefined && target.phase !== context.phase) return false;
   if (target.tool !== undefined && target.tool !== context.tool) return false;
+  // spec-542: written in the same shape as the two clauses above, which is what
+  // makes it correct in both directions from one line — an untargeted block
+  // still matches every state (back-compat for the other global blocks), and a
+  // grounding-targeted block does NOT match when the state is unknown, so a
+  // read that knows nothing asserts nothing. Note this must stay an early
+  // `return false` and never become an early `return true`: as a positive match
+  // it would let grounding override a phase or tool mismatch.
+  if (target.grounding !== undefined && target.grounding !== context.grounding) return false;
   return true;
 }
 

--- a/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
+++ b/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
@@ -14,6 +14,11 @@
 //          calls to support one, and is withheld with a stated reason where it
 //          does not. Both sides come from real traffic at two volumes, so the
 //          threshold is exercised end to end rather than mocked.
+//   ac-28 — and the column itself is only drawn because one row earns it. The
+//          all-thin case (no column at all) is a component-tier test: it needs
+//          a payload where every row is below the floor, which would mean
+//          seeding no operation above it — and then the mixed case, which is
+//          the one a real Memex reaches, would go uncovered here.
 //
 // SEEDING IS REAL TRAFFIC, not fixture rows. The journey drives actual MCP
 // tool calls at `/mcp` (the same shape journey-20 uses), so `mcp_tool_calls`
@@ -46,6 +51,7 @@ const ACS = [
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-3",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-23",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-24",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-28",
 ];
 
 const DEV_MCP_BEARER = "mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION";
@@ -146,10 +152,19 @@ test("the cost card reports real MCP traffic, per operation, with a median and a
   ).toBeVisible();
   await expect(page.getByRole("columnheader", { name: /p90/i })).toBeVisible();
 
-  // dec-10, both sides, from real traffic (ac-23 / ac-24):
-  //   the 10-call row earns its p90, and the 1-call row is told it cannot.
-  // The withheld cell's reason is spoken-only, so it is found by text, not
-  // sight — exactly how a screen-reader user meets it.
+  // dec-10, both sides, from real traffic (ac-23 / ac-24 / ac-28):
+  //   the 10-call row earns its p90 — which is also what puts the header above
+  //   on screen at all, since ac-28 drops the whole column when no row does —
+  //   and the 1-call row is told it cannot. The withheld cell's reason is
+  //   spoken-only, so it is found by text rather than by sight, which is
+  //   exactly how a screen-reader user meets it.
+  //
+  // ⚠ THE COUNT ENCODES THE SEEDING. `toHaveCount(1)` holds because exactly ONE
+  // seeded operation sits below the floor. Seed a third tool thinly and this
+  // fails on the count rather than on anything meaningful — so change the
+  // number here in the same edit, or assert a range. Deliberately exact rather
+  // than `>= 1`: a range would also pass if the qualifying row were withheld
+  // too, which is the regression worth catching.
   await expect(page.getByText(/too few calls for a p90/i)).toHaveCount(1);
   await expect(page.getByText("list_tasks").first()).toBeVisible();
 

--- a/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
+++ b/packages/ui/e2e/journey-73-spec-552-cost-panel.spec.ts
@@ -10,6 +10,10 @@
 //          per operation, with a median and a p90 rather than one average.
 //   ac-3 — the figures are computed, not authored: nothing is seeded into the
 //          card, and the numbers appear only because tool calls happened.
+//   ac-23/ac-24 — a per-operation p90 appears only where the row has enough
+//          calls to support one, and is withheld with a stated reason where it
+//          does not. Both sides come from real traffic at two volumes, so the
+//          threshold is exercised end to end rather than mocked.
 //
 // SEEDING IS REAL TRAFFIC, not fixture rows. The journey drives actual MCP
 // tool calls at `/mcp` (the same shape journey-20 uses), so `mcp_tool_calls`
@@ -40,6 +44,8 @@ const ACS = [
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-1",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-2",
   "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-3",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-23",
+  "mindset-prod/memex-building-itself/specs/spec-552/acs/ac-24",
 ];
 
 const DEV_MCP_BEARER = "mxt_DEV_LOCAL_ONLY_NEVER_PRODUCTION";
@@ -98,12 +104,26 @@ test("the cost card reports real MCP traffic, per operation, with a median and a
   });
   const specRef = `${tenant.namespaceSlug}/${tenant.memexSlug}/specs/${spec.handle}`;
 
-  // ── 2. REAL traffic. Four calls clears MIN_CALLS_FOR_FIGURES (3) with room,
-  //      and get_doc responses carry the platform footer — which is what makes
-  //      the guidance share on screen a measurement rather than a constant.
-  for (let i = 0; i < 4; i += 1) {
+  // ── 2. REAL traffic, ACROSS THE P90 FLOOR (dec-10) ────────────────────────
+  //      Two operations at different volumes, so one row earns a p90 and the
+  //      other is withheld — the threshold proved on the production path, not
+  //      simulated from a fixture.
+  //
+  //      Ten get_doc calls clear MIN_CALLS_FOR_P90; get_doc responses also
+  //      carry the platform footer, which is what makes the guidance share on
+  //      screen a measurement rather than a constant.
+  //      ONE list_tasks call sits below the floor.
+  //      Eleven calls together clear MIN_CALLS_FOR_FIGURES (3) with room.
+  //
+  //      The literal 10 is deliberate here, and it is NOT the duplication
+  //      ac-25 forbids: an e2e file cannot import a React module, and a
+  //      mismatch with the constant reds this run loudly. What ac-25 protects
+  //      against is a test that stays GREEN on the wrong side of the
+  //      threshold, which is a unit-test hazard, not this one.
+  for (let i = 0; i < 10; i += 1) {
     await mcpToolCall(request, "get_doc", { ref: specRef });
   }
+  await mcpToolCall(request, "list_tasks", { ref: specRef });
 
   // ── 3. The card, on the page a member actually visits ─────────────────────
   await page.goto(`/${tenant.namespaceSlug}/${tenant.memexSlug}/insights`);
@@ -117,9 +137,21 @@ test("the cost card reports real MCP traffic, per operation, with a median and a
   // Per-operation rows, and the operation named is the one we really called.
   await expect(page.getByText("get_doc").first()).toBeVisible();
 
-  // Median AND p90 — never one number standing in for both (ac-2).
-  await expect(page.getByText("Median", { exact: false }).first()).toBeVisible();
-  await expect(page.getByText("p90", { exact: false }).first()).toBeVisible();
+  // Median AND p90 — never one number standing in for both (ac-2). Asserted on
+  // the column HEADERS by role: `getByText("p90").first()` matched the header
+  // and would have stayed green with every value cell withheld — green for the
+  // wrong reason, which is the failure this whole Spec keeps meeting.
+  await expect(
+    page.getByRole("columnheader", { name: /median/i })
+  ).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: /p90/i })).toBeVisible();
+
+  // dec-10, both sides, from real traffic (ac-23 / ac-24):
+  //   the 10-call row earns its p90, and the 1-call row is told it cannot.
+  // The withheld cell's reason is spoken-only, so it is found by text, not
+  // sight — exactly how a screen-reader user meets it.
+  await expect(page.getByText(/too few calls for a p90/i)).toHaveCount(1);
+  await expect(page.getByText("list_tasks").first()).toBeVisible();
 
   // Token figures are marked as estimates, and the characters behind them are
   // on the row so a reader can recompute.

--- a/packages/ui/src/components/insights/CostPanelCard.test.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.test.tsx
@@ -312,6 +312,60 @@ describe('CostPanelCard — dec-10: a row too thin for a percentile', () => {
     render(<CostPanelCard data={acrossTheFloor()} />);
     // A bare <td> announces nothing to a screen reader, and "missing" and
     // "deliberately withheld" are the same experience. The reason is text.
+    const reason = screen.getByText(/too few calls/i);
+    expect(reason).toBeTruthy();
+
+    // The string being in the DOM is NOT the claim — testing-library ignores
+    // CSS, so `getByText` would find it inside an aria-hidden subtree just as
+    // happily. What ac-27 promises is that a screen reader REACHES it, so
+    // assert the two halves carry opposite visibility: the reason is spoken and
+    // the dash is not. Without this the test passes on markup no reader hears.
+    expect(reason.closest('[aria-hidden="true"]')).toBeNull();
+    const dash = screen.getByText('—');
+    expect(dash.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('draws no p90 column at all when NO row clears the floor', () => {
+    tagAc(AC(28));
+    // The state a young Memex actually lives in: enough total calls for the
+    // panel to show figures, no single operation near the floor. This is the
+    // dogfood card as measured on prod 2026-09-09 — twelve operations, the
+    // busiest at n=2 — where a p90 header would have stood over twelve em
+    // dashes for weeks.
+    const allThin: CostPanelResponse = {
+      available: true,
+      windowDays: 30,
+      totals: { calls: 3, totalChars: 30_000, guidanceChars: 9_000 },
+      operations: [1, 1, 1].map((calls, i) => ({
+        tool: `thin_tool_${i}`,
+        verb: null,
+        calls,
+        medianChars: 10_000,
+        p90Chars: 10_000,
+        guidanceChars: 3_000,
+        totalChars: 10_000,
+      })),
+    };
+    render(<CostPanelCard data={allThin} />);
+
+    // The table is drawn — this is not the not-enough-activity state.
+    expect(screen.getByRole('columnheader', { name: /median/i })).toBeTruthy();
+    expect(screen.getByText('thin_tool_0')).toBeTruthy();
+
+    // But no p90 header, and no withheld-cell dashes either: an absent column
+    // needs no per-row apology.
+    expect(screen.queryByRole('columnheader', { name: /p90/i })).toBeNull();
+    expect(screen.queryByText(/too few calls/i)).toBeNull();
+  });
+
+  it('brings the column back as soon as one row earns it', () => {
+    tagAc(AC(28));
+    // The other direction, because a gate that never opens is the same bug as
+    // one that never closes. `acrossTheFloor` has exactly one qualifying row.
+    render(<CostPanelCard data={acrossTheFloor()} />);
+    expect(screen.getByRole('columnheader', { name: /p90/i })).toBeTruthy();
+    // And the thin row beside it is withheld rather than dropped from view.
+    expect(screen.getByText('update_doc')).toBeTruthy();
     expect(screen.getByText(/too few calls/i)).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/insights/CostPanelCard.test.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.test.tsx
@@ -18,7 +18,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tagAc } from '@memex-ai-ac/vitest';
-import { CostPanelCard } from './CostPanelCard';
+import { CostPanelCard, MIN_CALLS_FOR_FIGURES, MIN_CALLS_FOR_P90 } from './CostPanelCard';
+import { estimateTokens } from './tokenEstimate';
 import type { CostPanelResponse } from '../../api/insights';
 
 const AC = (n: number) =>
@@ -181,8 +182,12 @@ describe('CostPanelCard — ac-2: median and p90, never a bare mean', () => {
   it('shows both median and p90 per operation', () => {
     tagAc(AC(2));
     render(<CostPanelCard data={populated()} />);
-    expect(screen.getByText(/median/i)).toBeTruthy();
-    expect(screen.getByText(/p90/i)).toBeTruthy();
+    // Headers by role. A text query here passed only because this fixture's
+    // rows both clear MIN_CALLS_FOR_P90; dropping one below it would have made
+    // the withheld cell's spoken reason a second /p90/i match and reddened
+    // this test for a reason that has nothing to do with ac-2 (dec-10).
+    expect(screen.getByRole('columnheader', { name: /median/i })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: /p90/i })).toBeTruthy();
   });
 
   it('never labels a figure as an average or a mean', () => {
@@ -200,5 +205,113 @@ describe('CostPanelCard — ac-2: median and p90, never a bare mean', () => {
     // add_comment is 96,000 of 101,100 characters — 95% guidance. That is the
     // half that is ours to cut, so it belongs in the reader's line of sight.
     expect(screen.getByText(/95%/)).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dec-10 (t-7) — the P90 floor.
+//
+// Observed on prod 2026-09-09: ten of twelve rows carried n=1, and every one
+// still printed a MEDIAN and a P90. At n=1 those are the same observation under
+// two headers; at n=2 the p90 is `percentile_cont` interpolating 90% of the way
+// between the only two calls seen. Below n=10 no observation actually sits in
+// the top decile, so the cell claims a tail it has not observed.
+//
+// THE FIXTURE IS DERIVED FROM THE CONSTANT, NOT FROM 10 (ac-25). A test that
+// hardcoded 9 would, the day someone raises the floor to 30, silently start
+// asserting the ABOVE-floor case twice and prove nothing about suppression —
+// green, for the wrong reason. Reading the constant re-aims it instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The card's own arithmetic, so the expectation cannot drift from it. */
+const approx = (chars: number): string =>
+  `≈ ${estimateTokens(chars).toLocaleString('en-US')}`;
+
+/**
+ * One payload, both sides of the floor. Deliberately ONE fixture rather than
+ * two: a regression that blanks EVERY p90 must fail, and it would pass a
+ * suppression-only test (ac-24 is the other half of ac-23).
+ */
+function acrossTheFloor(): CostPanelResponse {
+  return {
+    available: true,
+    windowDays: 30,
+    totals: { calls: 2 * MIN_CALLS_FOR_P90 - 1, totalChars: 300_000, guidanceChars: 90_000 },
+    operations: [
+      {
+        // AT the floor — the p90 renders.
+        tool: 'get_doc',
+        verb: null,
+        calls: MIN_CALLS_FOR_P90,
+        medianChars: 2_000,
+        p90Chars: 888_888,
+        guidanceChars: 60_000,
+        totalChars: 200_000,
+      },
+      {
+        // ONE BELOW the floor — the p90 is withheld, the median is not.
+        tool: 'update_doc',
+        verb: null,
+        calls: MIN_CALLS_FOR_P90 - 1,
+        medianChars: 1_000,
+        p90Chars: 999_999,
+        guidanceChars: 30_000,
+        totalChars: 100_000,
+      },
+    ],
+  };
+}
+
+describe('CostPanelCard — dec-10: a row too thin for a percentile', () => {
+  it('withholds the p90 on a row below the floor while still showing its median', () => {
+    tagAc(AC(23));
+    render(<CostPanelCard data={acrossTheFloor()} />);
+
+    // The thin row is present and its median — meaningful at any n, because it
+    // IS the value — still renders with its exact character count beside it.
+    expect(screen.getByText('update_doc')).toBeTruthy();
+    expect(screen.getByText(approx(1_000))).toBeTruthy();
+    expect(screen.getByText('1,000 ch')).toBeTruthy();
+
+    // But its p90 figure is nowhere on the card. 999,999 characters is a value
+    // no other cell in this fixture can produce, so this cannot pass by
+    // coincidence.
+    expect(screen.queryByText(approx(999_999))).toBeNull();
+  });
+
+  it('still renders the p90 on a row at the floor — a threshold, not a removal', () => {
+    tagAc(AC(24));
+    render(<CostPanelCard data={acrossTheFloor()} />);
+
+    expect(screen.getByText(approx(888_888))).toBeTruthy();
+    // And the column itself survives: ac-2 committed to a median AND a p90.
+    // By ROLE, not by text: the withheld cell's spoken reason also contains
+    // "p90", so a text query matches two nodes and throws. The claim was
+    // always about the HEADER anyway.
+    expect(screen.getByRole('columnheader', { name: /p90/i })).toBeTruthy();
+  });
+
+  it('derives the floor from the exported constant rather than a literal', () => {
+    tagAc(AC(25));
+    // The constant is what the card reads, so the card and this test cannot
+    // disagree about where the threshold is. Asserted as a property of the
+    // fixture: exactly one row sits below it and one at it.
+    const { operations } = acrossTheFloor() as Extract<
+      CostPanelResponse,
+      { available: true }
+    >;
+    expect(operations.filter((o) => o.calls < MIN_CALLS_FOR_P90)).toHaveLength(1);
+    expect(operations.filter((o) => o.calls >= MIN_CALLS_FOR_P90)).toHaveLength(1);
+    // A floor at or below the panel's own gate would be inert: every row that
+    // reaches the table would clear it, and nothing would ever be suppressed.
+    expect(MIN_CALLS_FOR_P90).toBeGreaterThan(MIN_CALLS_FOR_FIGURES);
+  });
+
+  it('says why the cell is empty rather than leaving a silent blank', () => {
+    tagAc(AC(27));
+    render(<CostPanelCard data={acrossTheFloor()} />);
+    // A bare <td> announces nothing to a screen reader, and "missing" and
+    // "deliberately withheld" are the same experience. The reason is text.
+    expect(screen.getByText(/too few calls/i)).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/insights/CostPanelCard.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.tsx
@@ -65,6 +65,24 @@ export const MIN_CALLS_FOR_FIGURES = 3;
  */
 export const MIN_CALLS_FOR_P90 = 10;
 
+/**
+ * Does ANY row have enough calls to carry a p90? If not, the column is not
+ * drawn at all — no header, no cells (dec-10, owner's call 2026-09-09).
+ *
+ * Withholding a cell is right; leaving a header standing over nothing but em
+ * dashes for its whole height is not. A young Memex has every row below the
+ * floor, so that is the state it would live in for weeks — and the first thing
+ * a reader does with an empty column is wonder what broke. The column comes
+ * back on its own the day one operation reaches the floor.
+ *
+ * This does not weaken ac-2's median-AND-p90 commitment: the p90 is computed,
+ * returned by the API for every row, and shown wherever it can mean something.
+ * What is gated is drawing a header for a statistic nothing on screen has.
+ */
+function anyRowEarnsP90(operations: readonly CostPanelOperation[]): boolean {
+  return operations.some((op) => op.calls >= MIN_CALLS_FOR_P90);
+}
+
 function pct(part: number, whole: number): number {
   if (whole <= 0) return 0;
   return Math.round((part / whole) * 100);
@@ -83,9 +101,11 @@ interface RowProps {
   op: CostPanelOperation;
   guidanceHue: string;
   track: string;
+  /** Whether the table is drawing a p90 column at all (see anyRowEarnsP90). */
+  showP90: boolean;
 }
 
-function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement {
+function OperationRow({ op, guidanceHue, track, showP90 }: RowProps): React.ReactElement {
   const share = pct(op.guidanceChars, op.totalChars);
   // The high-guidance rows are the actionable ones — those are ours to cut, and
   // spec-510 is the work that cuts them. Emphasis puts them in the eye-line.
@@ -103,23 +123,29 @@ function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement 
         {/* The measured number, beside the derived one (ac-13). */}
         <span className="ml-2 text-[11px] text-muted">{fmt(op.medianChars)} ch</span>
       </td>
-      <td className="py-2 text-right font-mono tabular-nums text-secondary">
-        {op.calls >= MIN_CALLS_FOR_P90 ? (
-          approxTokens(op.p90Chars)
-        ) : (
-          <>
-            {/* An em dash reads as "deliberately nothing" where a blank reads
-                as broken. The WHY is the call count already on this row, so
-                nothing new is asserted — but a sighted reader gets it from the
-                Calls column and a screen reader gets nothing, hence the
-                spoken-only reason beside it (dec-10, ac-27). */}
-            <span aria-hidden="true" className="text-muted">
-              &mdash;
-            </span>
-            <span className="sr-only">Too few calls for a p90</span>
-          </>
-        )}
-      </td>
+      {showP90 && (
+        <td className="py-2 text-right font-mono tabular-nums text-secondary">
+          {op.calls >= MIN_CALLS_FOR_P90 ? (
+            approxTokens(op.p90Chars)
+          ) : (
+            <>
+              {/* An em dash reads as "deliberately nothing" where a blank reads
+                  as broken. The WHY is the call count already on this row, so
+                  nothing new is asserted — but a sighted reader gets it from the
+                  Calls column and a screen reader gets nothing, hence the
+                  spoken-only reason beside it (dec-10, ac-27).
+
+                  The dash is aria-hidden and the reason is not: a reader who
+                  can see the dash needs no sentence, and a reader who cannot
+                  needs the sentence and not a dash announced as "em dash". */}
+              <span aria-hidden="true" className="text-muted">
+                &mdash;
+              </span>
+              <span className="sr-only">Too few calls for a p90</span>
+            </>
+          )}
+        </td>
+      )}
       <td className="py-2 pl-4">
         <span className="flex items-center justify-end gap-2">
           <span
@@ -158,6 +184,7 @@ export function CostPanelCard({ data }: { data: CostPanelResponse }): React.Reac
   const { windowDays, totals, operations } = data;
   const guidanceShare = pct(totals.guidanceChars, totals.totalChars);
   const answerShare = 100 - guidanceShare;
+  const showP90 = anyRowEarnsP90(operations);
 
   return (
     <div className="p-5 bg-panel border border-edge rounded-lg">
@@ -254,7 +281,9 @@ export function CostPanelCard({ data }: { data: CostPanelResponse }): React.Reac
                   <th className="text-left pb-2 border-b border-edge">Operation</th>
                   <th className="text-right pb-2 border-b border-edge">Calls</th>
                   <th className="text-right pb-2 border-b border-edge">Median</th>
-                  <th className="text-right pb-2 border-b border-edge">p90</th>
+                  {showP90 && (
+                    <th className="text-right pb-2 border-b border-edge">p90</th>
+                  )}
                   <th className="text-right pb-2 pl-4 border-b border-edge">
                     Guidance
                   </th>
@@ -267,6 +296,7 @@ export function CostPanelCard({ data }: { data: CostPanelResponse }): React.Reac
                     op={op}
                     guidanceHue={guidanceHue}
                     track={palette.verification.untested}
+                    showP90={showP90}
                   />
                 ))}
               </tbody>

--- a/packages/ui/src/components/insights/CostPanelCard.tsx
+++ b/packages/ui/src/components/insights/CostPanelCard.tsx
@@ -8,6 +8,12 @@
 //   the median and 11,700 at p90 — a factor of seven on one operation. A single
 //   number per row tells most readers something false about their own usage.
 //
+//   ...BUT ONLY WHERE A P90 MEANS SOMETHING (dec-10, ac-23/ac-24). The first
+//   real prod read showed ten of twelve rows at n=1, each printing a median and
+//   a p90 that were the same observation under two headers. Below
+//   MIN_CALLS_FOR_P90 the cell is withheld, because a column header a reader
+//   has to discount per row is a header that has stopped working.
+//
 //   EVERY FIGURE COMES FROM THE RESPONSE (ac-10), the window included. A
 //   literal here is a number that stops being true with nothing detecting it —
 //   which is the whole argument dec-3 settled.
@@ -40,6 +46,24 @@ import { useChartPalette } from './theme';
  * card measures; the rule is the page's.
  */
 export const MIN_CALLS_FOR_FIGURES = 3;
+
+/**
+ * Below this many calls on ONE OPERATION, that row's p90 is withheld (dec-10).
+ *
+ * Not a rounder version of the constant above — a different claim. The panel
+ * gate asks "does this Memex have enough traffic to show figures at all?"; this
+ * asks "does this ROW have enough calls for a 90th percentile to be a statement
+ * about variability?" Ten is where the answer turns: below it no observation
+ * actually falls in the top decile, so `percentile_cont` is interpolating
+ * between the last two values whatever the data does. A p90 there is arithmetic
+ * wearing a statistic's label.
+ *
+ * A plain constant, deliberately. spec-458 dec-1 made its honesty floor
+ * env-tunable; the sibling threshold in this very file is a constant, and
+ * consistency with the file a reader is looking at beats consistency with
+ * another Spec's deployment surface.
+ */
+export const MIN_CALLS_FOR_P90 = 10;
 
 function pct(part: number, whole: number): number {
   if (whole <= 0) return 0;
@@ -80,7 +104,21 @@ function OperationRow({ op, guidanceHue, track }: RowProps): React.ReactElement 
         <span className="ml-2 text-[11px] text-muted">{fmt(op.medianChars)} ch</span>
       </td>
       <td className="py-2 text-right font-mono tabular-nums text-secondary">
-        {approxTokens(op.p90Chars)}
+        {op.calls >= MIN_CALLS_FOR_P90 ? (
+          approxTokens(op.p90Chars)
+        ) : (
+          <>
+            {/* An em dash reads as "deliberately nothing" where a blank reads
+                as broken. The WHY is the call count already on this row, so
+                nothing new is asserted — but a sighted reader gets it from the
+                Calls column and a screen reader gets nothing, hence the
+                spoken-only reason beside it (dec-10, ac-27). */}
+            <span aria-hidden="true" className="text-muted">
+              &mdash;
+            </span>
+            <span className="sr-only">Too few calls for a p90</span>
+          </>
+        )}
       </td>
       <td className="py-2 pl-4">
         <span className="flex items-center justify-end gap-2">

--- a/packages/ui/src/components/scaffold/composition.ts
+++ b/packages/ui/src/components/scaffold/composition.ts
@@ -17,6 +17,7 @@ import {
   toRubric,
   type GuidanceBlock,
   type GuidanceEmphasis,
+  type GroundingState,
   type Phase,
   type ScaffoldDataset,
   type Transition,
@@ -61,17 +62,27 @@ function baseSegment(block: GuidanceBlock): ComposedSegment {
 }
 
 /** Mirror of `matchesNudgeTarget` (scaffold-model.ts) — a target matches a
- *  (tool, phase) context when every present dimension equals the context; an
- *  absent dimension is a wildcard. transition/button targets ride other
- *  channels and never match a nudge. */
+ *  (tool, phase, grounding) context when every present dimension equals the
+ *  context; an absent dimension is a wildcard. transition/button targets ride
+ *  other channels and never match a nudge.
+ *
+ *  spec-542: `grounding` was added to the original and this mirror went stale,
+ *  which the ac-8 fidelity guard caught — this surface composed all three
+ *  mutually exclusive grounding claims at once while `toNudge` composed none.
+ *  That is what a stale mirror looks like, so the clause is kept in the SAME
+ *  SHAPE and SAME POSITION as the two above it rather than special-cased: this
+ *  surface passes no grounding state (it renders the Scaffold, not a live doc
+ *  read), so every grounding-targeted block correctly drops out — and it does
+ *  so by the same rule the server uses, not by a rule that happens to agree. */
 function matchesNudge(
   target: GuidanceBlock['target'],
-  ctx: { tool?: string; phase?: Phase },
+  ctx: { tool?: string; phase?: Phase; grounding?: GroundingState },
 ): boolean {
   if (target.transition !== undefined) return false;
   if (target.button !== undefined) return false;
   if (target.phase !== undefined && target.phase !== ctx.phase) return false;
   if (target.tool !== undefined && target.tool !== ctx.tool) return false;
+  if (target.grounding !== undefined && target.grounding !== ctx.grounding) return false;
   return true;
 }
 

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -254,9 +254,13 @@ fi
 #                               the one that bounds what a queued request actually costs
 #                               (a parsed body, 1.1–1.5× its wire bytes; c-18). Default
 #                               20000, deliberately unreachable at today's ceiling of 2
-#                               (2 × 500 events max), so it cannot refuse before t-10 has
-#                               measured. Read the value to set from the heartbeat's
-#                               `inFlightEvents`, not from a guess.
+#                               (2 × 500 events max). It is NOT waiting on a measurement:
+#                               dec-8 declined enforcement, so the gate stays in shadow and
+#                               this term never refuses. The default IS the declaration, on
+#                               purpose. It becomes a live knob only if dec-8 re-opens (its
+#                               tripwire is spec-533 making batches bigger), and then the
+#                               value is read from the heartbeat's `inFlightEvents` against
+#                               c-18's heap figures, never from a guess.
 #
 # The CEILING is deliberately absent: ac-12 requires it computed from the resolved pool,
 # so it follows DB_POOL_MAX. A hand-set ceiling is a number someone raises during a busy


### PR DESCRIPTION
Release promotion. **Merging this PR IS the decision to ship** — the prod deploy runs unattended on merge to `main` (`deploy.yml`'s own header states this; the prod environment's required-reviewer gate was removed 2026-06-05).

**Merge as a merge commit, not a squash.** std-21 / cl-50: GitHub's PR surface cannot fast-forward, so the release lands as a merge commit and the content invariant is `git log develop..main --no-merges` being empty — not SHA-identity. A squash here would break that invariant.

## What ships — 5 commits across 3 Specs

| Spec | change | surface |
|---|---|---|
| **spec-542** | an agent reading a Spec over MCP can now tell whether it is code-grounded, and by whom and when; the footer stops asserting the negative on every Spec | MCP read (header + guidance footer), shared Scaffold, one UI mirror |
| **spec-525** | the emission gate's mode check could skip in silence; shadow is now a decision rather than a stage | `services/admission/emission-gate.ts` + a regression test + a smoke test |
| **spec-552** | the cost panel's p90 column is dropped entirely while no row can fill it | Insights `CostPanelCard` + its test + e2e journey-73 |

```
63822ab1 fix(spec-542): an agent reading a Spec over MCP can tell whether it is code-grounded (#699)
47dfe6f9 test(spec-525): ac-29 had no test — assert the mode guard cannot be re-gated (#698)
d582dea2 fix(spec-525): the gate's mode check could skip in silence, and shadow is now a decision rather than a stage (#697)
b95469f0 fix(spec-552): drop the p90 column entirely while no row can fill it
6723fc33 fix(spec-552): withhold a per-operation p90 where the row has too few calls to support one
```

## Blast radius — checked, not assumed

- **No migrations.** `git diff origin/main...origin/develop --name-only` matches nothing under `drizzle/`, no `.sql`, no migration file. The prod deploy's migration step has nothing to apply.
- **`scripts/deploy-config.sh` is in the diff and is comment-only.** It restates that spec-525 dec-8 declined enforcement, so the emission gate stays in shadow and its in-flight term never refuses. No deploy behaviour changes.
- **spec-525's gate ships in shadow mode** — it does not refuse traffic.
- **User-visible change:** only spec-552's — the p90 column disappears from the Insights cost panel, which per its own commit was rendering a header over nothing but em dashes (twelve operations, the busiest at n=2, every cell suppressed).
- **spec-542 changes no web surface at all.** spec-409 already shipped the flag and the badge; only the MCP read was blind.

## Verification already on this content

- `develop` CI green on `63822ab1`: 23 checks, all 3 `e2e` shards passing
- **int is already deployed from this exact content** and its post-deploy smoke passed: `✓ Smoke passed (ENV=int)`, 38 smoke tests — the std-17 gate before prod
- spec-542 locally: server 6748 / 0 · shared 831 / 4 (4 pre-existing `tool-manifest` summary-length reds, untouched by any of these commits) · ui 2422 / 0 with the coverage gate · `make typecheck`, `ui build`, `lint` all exit 0

## What this release does NOT close

**spec-542 ac-3 stays open until after this merge**, by nature: it asks that the reported Spec (`mindset-prod/memex-backstage/specs/spec-19`) read correctly against the **deployed** system, and that Spec is prod data — it does not exist on int, so int could never assert it. The pre-fix baseline was captured from live prod before this promotion and is recorded on spec-542 t-6, because a post-fix read alone proves the line is present and can never prove it was once absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
