### PR TITLE
fix(spec-542): the new write-path smoke shipped without std-17's guard rail

### DIFF
--- a/packages/server/src/__smoke__/grounding-header.spec-542.smoke.test.ts
+++ b/packages/server/src/__smoke__/grounding-header.spec-542.smoke.test.ts
@@ -69,7 +69,7 @@
 // which is the strongest form of red-capability available for a smoke, since
 // the input is genuine production output rather than a mutation of the source.
 
-import { describe, it, expect, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { tagAc } from "@memex-ai-ac/vitest";
 import {
   SMOKE_BASE_URL,
@@ -114,6 +114,24 @@ const createdDocRefs: string[] = [];
 describe.skipIf(!SMOKE_MCP_TOKEN)(
   `spec-542 grounding header smoke @ ${SMOKE_BASE_URL} (ENV=${SMOKE_ENV || "?"})`,
   () => {
+    beforeAll(() => {
+      // std-17 cl-35 guard rail (spec-70 dec-2): refuse to run authed WRITE
+      // journeys against anything that does not read as a throwaway namespace,
+      // so a misconfigured token can never mutate real data on shared int/prod.
+      // Mirrors authed.smoke.test.ts and tags-curation.smoke.test.ts verbatim.
+      //
+      // This file writes twice — `create_doc` and `ground_spec` — so it needs
+      // the rail as much as they do, and it shipped in #702 without one. The
+      // rail is per-file by design: a new write-path smoke inherits nothing and
+      // has to carry its own, which is exactly how this one was missed.
+      if (!/smoke/i.test(SMOKE_NAMESPACE)) {
+        throw new Error(
+          `Refusing to run authed smoke writes against namespace "${SMOKE_NAMESPACE}" — ` +
+            `it must be an obvious throwaway (contain "smoke"). Set SMOKE_NAMESPACE.`,
+        );
+      }
+    });
+
     afterAll(async () => {
       for (const ref of createdDocRefs.splice(0)) {
         await callMcpTool("update_doc", { ref, status: "done" }).catch(() => {});


### PR DESCRIPTION
Follow-up to #702, closing a **std-17 cl-35** compliance gap in the file that PR added.

## The gap

std-17 requires the authed smoke tier to refuse any namespace that does not read as an obvious throwaway, so a misconfigured token can never mutate real data on shared int/prod. Both existing write-path smokes carry that rail:

- `authed.smoke.test.ts:105`
- `tags-curation.smoke.test.ts:53`

`grounding-header.spec-542.smoke.test.ts` shipped in #702 **without** it — and it writes twice, `create_doc` and `ground_spec`.

## How it was found, which is the part worth recording

Re-reading std-17 against the diff **after** marking t-6 complete — later than it should have been. The completion nag surfaced the standard, the standard named the clause, and the clause was not met.

The reason it was missed is structural and worth naming: **the rail is per-file by design.** A new write-path smoke inherits nothing, so "the siblings have it" gives no protection at all. Anyone adding the next write-path smoke will hit the same trap.

## Scope

No behaviour change on a correct configuration — the rail only fires on the misconfiguration it exists to catch. `SMOKE_NAMESPACE` defaults to `zzz-smoke/main`, which passes.

## Verification

- [x] `tsc --noEmit` exit 0
- [x] `pnpm lint` exit 0
- [x] `make build` exit 0 — std-17 cl-21 is explicit that a green vitest is **not** proof the deploy will build, so the build gate was run rather than assumed
- [x] ac-3 is already verified from #702's int deploy (2 emissions at 08:44:18Z); this changes nothing about that

🤖 Generated with [Claude Code](https://claude.com/claude-code)