### PR TITLE
spec-424 t-3: the in-app agent stops asking for grounding it cannot do, and points instead

### DIFF
--- a/packages/server/src/agent/spec-424-inapp-grounding-cta.test.ts
+++ b/packages/server/src/agent/spec-424-inapp-grounding-cta.test.ts
@@ -1,0 +1,178 @@
+// spec-424 t-3 (ac-12; scope ac-6) — the in-app agent's honest grounding handoff.
+//
+// dec-4: the in-app agent CANNOT ground. `ground_spec` is hard-gated to
+// `channel='mcp'`, and the agent cannot read the repo either. std-34 says no
+// human-facing surface may instruct an MCP-only step, so the agent must POINT,
+// never INSTRUCT — and it must not stay silent, because a Spec drifting
+// ungrounded through specify is the failure this whole Spec exists to prevent.
+//
+// ── WHY THE SEAM IS buildSystemBlocks, NOT toPromptBlocks ─────────────────
+// ac-12 asks what the IN-APP SURFACE emits. A `toPromptBlocks(BASE_SCAFFOLD,
+// 'specify')` assertion would prove the block is registered and prove nothing
+// about whether it reaches the agent — the block could be projected and then
+// dropped by the composition, which is precisely the class of gap spec-424 was
+// written about (spec-409's prose existed and never got delivered). So this
+// asserts the COMPOSED system prompt the primary Spec agent actually receives.
+//
+// ── WHAT THIS TEST PINNED THAT THE TASK DID NOT KNOW ──────────────────────
+// t-3's description says "nothing emits a grounding CTA on the in-app surface".
+// True, but the real gap is wider and has TWO independent causes, both read at
+// source on this branch:
+//
+//   1. The `code-grounding` prose is `surface: 'shared_nudge'`, so it rides the
+//      nudge/rubric channels only and never enters the React system prompt.
+//   2. `SHARED_HANDOFF_GUIDANCE` — the canonical map that contains "Asked to
+//      TOUCH CODE → the coding agent over MCP" — is appended ONLY for
+//      `scopedMode` of standards/issues/skills (`system-prompt.ts`), and the
+//      primary Spec agent is `isPrimaryAgent = !scaffoldMode && !driftMode &&
+//      !scopedMode`, which excludes it by construction.
+//
+// So the agent a user talks to ON A SPEC PAGE has no path to "this needs the
+// coding agent" — for grounding or for anything else. This Spec closes the
+// grounding case only, which is what dec-4 scoped. The general case (the primary
+// agent carrying no handoff map at all) is registered as a separate todo Issue
+// rather than fixed in passing: adding all five canonical handoffs to the
+// most-used agent in the product is a behaviour change spec-424 does not own.
+//
+// ── WHY IT POINTS AT THE BUTTON RATHER THAN COMPOSING ITS OWN PROMPT ──────
+// std-38 cl-4's affordance is `render_handoff` (an ad-hoc copyable prompt). This
+// CTA points at the `plan-handoff` Prompt Button instead, and that is not a
+// conflict: the button IS the maintained grounding instruction. Having the agent
+// compose its own would create a second copy of prose that already has an owner
+// (spec-33/dec-4). dec-4 chose the DRY path.
+//
+// ── std-28 ────────────────────────────────────────────────────────────────
+// No Playwright journey. This adds agent prose to a system prompt; it renders no
+// new element, and the Prompt Button it names already exists on the Spec page.
+// There is no new user-facing flow to drive. Recorded here because the AC asks
+// for the call to be made explicitly, and "prose only, and here is why" is the
+// answer rather than an omission.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { BASE_SCAFFOLD } from "@memex/shared";
+import { buildSystemBlocks } from "./system-prompt.js";
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-424/acs/ac-${n}`;
+
+/** The primary Spec agent: no scaffold mode, no drift mode, no scoped mode. */
+const primaryPrompt = (phase: "draft" | "specify" | "build" | "verify" | "done") =>
+  buildSystemBlocks("Doc context.", phase)
+    .map((b) => b.text)
+    .join("\n\n");
+
+/** The button dec-4 points at — named, so the user knows where to click. */
+const NAMES_THE_BUTTON = /plan-handoff|handoff prompt|Specify handoff/i;
+/** It has to say WHERE the work happens, or "handoff" is meaningless. */
+const NAMES_THE_CODING_AGENT = /coding agent/i;
+/**
+ * std-34's negative. The in-app agent must not name the tool it cannot call —
+ * the button's own prose owns that instruction, and repeating it here would both
+ * instruct an impossible step and duplicate an owned string.
+ */
+const THE_MCP_ONLY_TOOL = /ground_spec/;
+
+describe("spec-424 ac-12 — the in-app agent points at the grounding handoff, never instructs it", () => {
+  it("the composed primary-agent prompt for specify carries the handoff and names the button", () => {
+    tagAc(AC(12));
+    tagAc(AC(6));
+
+    const specify = primaryPrompt("specify");
+
+    // ── Delivery is asserted by the block's OWN text reaching the composed
+    // prompt, not by a keyword. A first draft of this test matched /coding
+    // agent/ against the whole prompt and passed BEFORE the block existed — the
+    // phrase occurs in the unrelated Skills block. A keyword assertion over a
+    // large composed prompt is a coin flip; this pins the actual delivery.
+    const node = BASE_SCAFFOLD.promptBlocks.find((n) => n.id === "grounding-handoff");
+    expect(node, "the grounding-handoff block is not in the Scaffold model").toBeDefined();
+    expect(
+      specify,
+      "the grounding handoff block never reaches the composed in-app prompt — registered but not delivered, which is the exact gap this Spec exists to close",
+    ).toContain(node!.text);
+
+    // ── Content: it has to say WHERE the work happens and WHERE to click.
+    expect(node!.text, "the handoff does not name the coding agent").toMatch(
+      NAMES_THE_CODING_AGENT,
+    );
+    expect(
+      node!.text,
+      "the handoff does not name the Prompt Button, so the user is told to hand off but not where to click",
+    ).toMatch(NAMES_THE_BUTTON);
+
+    // ── It must land where the impossible instruction lands. The in-app agent
+    // is ALREADY told to "ground code-touching decisions against current
+    // source" — shared phase guidance, correct for the MCP agent, impossible
+    // here. The handoff is what makes that instruction actionable instead of a
+    // dead end, so it has to be present in the same phase.
+    expect(
+      specify,
+      "the specify prompt no longer carries the grounding instruction — if it moved, this handoff may now be orphaned",
+    ).toMatch(/[Gg]round code-touching decisions against current source/);
+
+    // ── std-34, the load-bearing negative. The in-app agent cannot call this
+    // tool; naming it would instruct a step it cannot fulfil.
+    expect(
+      specify,
+      "the in-app prompt names ground_spec — std-34 forbids instructing an MCP-only step here",
+    ).not.toMatch(THE_MCP_ONLY_TOOL);
+  });
+
+  it("the copy is Scaffold data, not inline, and is portable", () => {
+    tagAc(AC(12));
+
+    // std-15 / std-38 cl-8: in-app agent prose lives in the scaffold model. This
+    // is NOT the cl-68 footer carve-out — that applies to the composed MCP
+    // footer (t-1), not to a React system-prompt block.
+    const node = BASE_SCAFFOLD.promptBlocks.find((n) => n.id === "grounding-handoff");
+    expect(node, "the grounding-handoff block is not in the Scaffold model").toBeDefined();
+    expect(node!.surface, "the block must be react_only — it is in-app agent prose").toBe(
+      "react_only",
+    );
+
+    // std-22: the copy reaches agents working on arbitrary codebases.
+    const text = node!.text;
+    expect(text, "the copy hardcodes a path or directory (std-22)").not.toMatch(
+      /packages\/|src\/|\.ts\b/,
+    );
+    expect(text, "the copy names a framework or package manager (std-22)").not.toMatch(
+      /vitest|jest|pnpm|npm |yarn|playwright/i,
+    );
+    expect(text, "the copy cites a Standard by handle (std-22)").not.toMatch(/\bstd-\d+/i);
+
+    // std-15: it must not ALSO be inline in the server. One home.
+    const src = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "system-prompt.ts"),
+      "utf8",
+    );
+    expect(
+      src,
+      "the CTA prose was inlined in system-prompt.ts instead of living in the Scaffold (std-15)",
+    ).not.toMatch(NAMES_THE_BUTTON);
+  });
+
+  it("the ground_spec channel gate is untouched and still points at a coding agent with the repo open", () => {
+    tagAc(AC(12));
+
+    // dec-4 changes PROMPTING only. The structural refusal that makes the honest
+    // CTA necessary in the first place must still be there: if this gate were
+    // relaxed, the CTA would be lying about the boundary rather than describing
+    // it. Read at source rather than assumed.
+    const lifecycle = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "handlers", "lifecycle.ts"),
+      "utf8",
+    );
+    expect(lifecycle, "ground_spec left the lifecycle handler").toMatch(/name:\s*"ground_spec"/);
+    expect(
+      lifecycle,
+      "the channel='mcp' gate on ground_spec is gone — the in-app CTA now describes a boundary that does not exist",
+    ).toMatch(/channel\s*[!=]==?\s*["']mcp["']/);
+    expect(
+      lifecycle,
+      "the rejection no longer tells the caller where the work belongs",
+    ).toMatch(/coding agent/i);
+  });
+});

--- a/packages/server/src/services/spec-424-grounding-push.integration.test.ts
+++ b/packages/server/src/services/spec-424-grounding-push.integration.test.ts
@@ -63,7 +63,7 @@ import {
   users,
 } from "../db/schema.js";
 import { createMcpServer } from "../mcp/tools.js";
-import { toolManifest } from "@memex/shared";
+import { toolManifest, BASE_SCAFFOLD } from "@memex/shared";
 import { createDocDraft } from "./documents.js";
 
 const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-424/acs/ac-${n}`;
@@ -378,17 +378,26 @@ describe("spec-424 — the resolve_decision footer delivers the ground_spec call
     // …and NOT routed through the Scaffold. cl-68 is a carve-out FROM cl-20,
     // so putting it in scaffold-data.ts would fight the carve-out and both
     // guards, and is the mistake an earlier draft of dec-1 made.
-    const scaffoldSrc = readFileSync(
-      resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "shared", "src", "scaffold-data.ts"),
-      "utf8",
-    );
-    const scaffoldGroundSpec = (scaffoldSrc.match(/ground_spec/g) ?? []).length;
+    //
+    // Asserted against DELIVERED PROSE, not the raw file. An earlier version of
+    // this guard counted `ground_spec` occurrences in scaffold-data.ts and
+    // capped them at 2 — and spec-424's own t-3 reddened it by naming the tool
+    // in a block's `rationale`, which is Inspect-only metadata no agent ever
+    // reads. The claim is about what the Scaffold DELIVERS, so that is what is
+    // inspected: prompt-block and guidance text. Prompt BUTTONS are excluded on
+    // purpose — `plan-handoff` names the tool by design; it is the human-copied
+    // surface that owns the instruction, which is exactly why the footer line
+    // and the in-app CTA must not restate it.
+    const deliveredProse = [
+      ...BASE_SCAFFOLD.promptBlocks.map((b) => b.text),
+      ...BASE_SCAFFOLD.baseGuidance.map((g) => g.text),
+    ];
+    const offenders = deliveredProse.filter((t) => /ground_spec/.test(t));
     expect(
-      scaffoldGroundSpec,
-      "ground_spec now appears in scaffold-data.ts more than its two pre-existing homes " +
-        "(the tool-description map and the plan-handoff button) — this Spec's line was routed " +
-        "through the Scaffold instead of the cl-68 seat",
-    ).toBeLessThanOrEqual(2);
+      offenders,
+      "the grounding call was routed through Scaffold-delivered prose instead of the cl-68 seat — " +
+        "the Prompt Button is the one surface allowed to name it",
+    ).toEqual([]);
 
     // The nugget it extends is still intact and still first.
     const spec = await specWithDecisions("Push Seat", 1);

--- a/packages/shared/src/scaffold-data.ts
+++ b/packages/shared/src/scaffold-data.ts
@@ -1047,7 +1047,7 @@ const PHASE_PLAN: PhaseNode = {
     ],
     blocked: ['create_task', 'execution_plans'],
   },
-  promptBlockIds: [...REACT_ONLY_BLOCK_IDS, 'create-from-doc'],
+  promptBlockIds: [...REACT_ONLY_BLOCK_IDS, 'create-from-doc', 'grounding-handoff'],
   rationale:
     'Specify is team-visible narrative shaping + decision resolution. Same allowance as draft (per `phaseAllowanceLine`): full section + decision surface, tasks blocked.',
 };
@@ -2041,6 +2041,38 @@ const BASE_GUIDANCE: GuidanceBlock[] = [
 // Composed dataset.
 // ──────────────────────────────────────────────────────────────────────────
 
+// spec-424 t-3 (dec-4, std-34, std-38 cl-4) — the in-app agent's honest grounding
+// handoff. The React agent is ALREADY told, by the shared specify phase guidance,
+// to "ground code-touching decisions against current source before resolving".
+// That instruction is correct for the MCP agent and IMPOSSIBLE here: this agent
+// cannot open the repository, and recording the result is gated to the MCP
+// channel. Before this block the surface was not silent about grounding — it was
+// asking for something it could not do, with nowhere to send the user.
+//
+// So this does not repeat the ask; it makes the existing one actionable. It
+// points at the `plan-handoff` Prompt Button (label 'Specify handoff'), which
+// already carries the full grounding instructions including the tool call, so
+// the tool is deliberately NOT named here: naming it would instruct an MCP-only
+// step (std-34) and duplicate prose that already has one owner (spec-33/dec-4).
+//
+// std-38 cl-4's affordance for an ad-hoc refusal is `render_handoff`. Pointing at
+// the button instead is the DRY choice, not a departure: the button IS the
+// maintained grounding prose, and an agent-composed prompt would be a second copy.
+//
+// react_only, and registered on the specify phase only — the phase where
+// decisions resolve and grounding still changes the outcome. Portable per std-22.
+const BASE_GROUNDING_HANDOFF: PromptBlockNode = {
+  kind: 'prompt_block',
+  id: 'grounding-handoff',
+  surface: 'react_only',
+  text:
+    '## Grounding a code-touching Spec — you point at it, you do not do it\n' +
+    'When this Spec\'s decisions name code — files, symbols, schema, routes — someone has to check them against the real source before they harden into tasks. That someone is not you: you cannot open the repository, and recording the result is a coding-agent action you have no way to perform. Never claim a Spec is grounded, and never imply you are about to go and read the code.\n\n' +
+    'What to do instead, when decisions are being resolved on a code-touching Spec: say plainly that the grounding belongs in a coding agent with the repository open, and point the user at the **Specify handoff** prompt on this Spec — it already carries the full instructions, so do not restate them or compose your own version. Then carry on with the work that IS yours: shaping the narrative and driving the decisions to resolution.',
+  rationale:
+    'spec-424 t-3 (dec-4): the in-app grounding handoff. The React agent inherits the specify phase guidance telling it to ground decisions against current source (spec-123 dec-8 brought the shared_nudge phase guidance to this surface), but the recording call is channel=mcp only and the agent cannot read a repo — so without this block the surface instructs an impossible step with no destination, which is what std-34 forbids. It POINTS at the plan-handoff Prompt Button (std-23, the existing primitive, no net-new chip) rather than composing its own prompt, because that button is the single owner of the grounding instruction (spec-33/dec-4) and a second copy is the duplication this Spec lists as a constraint. Deliberately does not name the grounding tool: that is the MCP-only step std-34 keeps off human-facing surfaces. Registered on the specify phase only. Portable per std-22 — no paths, no framework or tooling names, no Standard handles.',
+};
+
 const PROMPT_BLOCKS: PromptBlockNode[] = [
   // React-only cross-phase blocks.
   BASE_ROLE,
@@ -2049,6 +2081,8 @@ const PROMPT_BLOCKS: PromptBlockNode[] = [
   BASE_CONTEXT_AWARENESS,
   // spec-176 t-1: create-from-doc guidance — active in specify/build/verify.
   BASE_CREATE_FROM_DOC,
+  // spec-424 t-3 (dec-4): the in-app grounding handoff — specify phase only.
+  BASE_GROUNDING_HANDOFF,
   // Conditionally-injected react_only blocks (not in any phase's promptBlockIds;
   // appended by buildSystemBlocks per-request — readOnly: spec-111 t-9 / dec-2;
   // review: spec-126 dec-4 when the resolved role is reviewer).


### PR DESCRIPTION
Closes **spec-424**'s last two ACs (ac-12, ac-6). Follows #704 (t-1 + t-2, merged).

## The gap was not silence — it was an impossible instruction

t-3 was written as *"nothing emits a grounding CTA on the in-app surface today"*. True, and it understates the problem.

Read at source: the React agent **already** inherits the specify phase guidance telling it to *"ground code-touching decisions against current source"* and to *"read the relevant source"* (spec-123 dec-8 brought the `shared_nudge` phase guidance to this surface). It can do neither — it cannot open a repository, and the recording call is gated to `channel='mcp'`.

So the surface was asking the agent for something impossible, with nowhere to send the user. That is exactly what std-34 forbids.

## What changed

One `react_only` `PromptBlockNode` (`grounding-handoff`) in `scaffold-data.ts`, registered on the **specify** phase only:

> **Grounding a code-touching Spec — you point at it, you do not do it**
> […] That someone is not you: you cannot open the repository, and recording the result is a coding-agent action you have no way to perform. Never claim a Spec is grounded […] point the user at the **Specify handoff** prompt on this Spec — it already carries the full instructions, so do not restate them.

**The shared phase guidance is deliberately not edited.** It is correct for the MCP agent; rewriting it to suit this surface would break the other one. The new block makes the existing ask actionable rather than repeating it.

**It never names the tool.** Two reasons that agree: naming an MCP-only step on a human-facing surface is what std-34 rules out, and the `plan-handoff` button is the single owner of that instruction (spec-33/dec-4), so restating it would be a second copy. std-38 cl-4's affordance for an ad-hoc refusal is `render_handoff`; pointing at the button instead is the DRY choice, not a departure — an agent-composed prompt would duplicate maintained prose.

## Two test-quality problems this found, both mine

**1. A guard from #704 was too coarse.** t-1's ac-9 guard counted `ground_spec` occurrences in `scaffold-data.ts` and capped them at 2. This block's `rationale` pushed it to 3 — and a rationale is Inspect-only metadata **no agent ever reads**, so the guard was asserting something wider than its claim. It now inspects *delivered* prose (`promptBlocks[].text` + `baseGuidance[].text`) and excludes Prompt Buttons, which name the tool by design.

Red-capability was **re-proven after the rewrite** by injecting the tool name into delivered prose and watching it fail. A rewritten guard whose failure path is unverified proves nothing.

**2. My first assertion was a false positive.** It matched `/coding agent/` against the composed prompt and **passed before the block existed** — that phrase occurs in the unrelated Skills block. A keyword search over a multi-thousand-word prompt is a coin flip. Delivery is now pinned by the block's own text reaching the composed prompt.

## Test seam

Asserted against the **composed system prompt** (`buildSystemBlocks`), not `toPromptBlocks`. A projection assertion would prove the block is registered and say nothing about whether it reaches the agent — which is the exact class of gap this entire Spec exists to close (spec-409's prose existed and was never delivered).

## Out of scope, registered not fixed — issue-1

**The primary Spec agent receives no cross-agent handoff map at all.** `SHARED_HANDOFF_GUIDANCE` — which carries all five canonical handoffs including *"touch code → the coding agent over MCP"* — is appended only for `scopedMode` of standards/issues/skills, and `isPrimaryAgent = !scaffoldMode && !driftMode && !scopedMode` excludes those by construction.

So the most-used in-app agent in the product cannot hand off **any** out-of-scope request, not just grounding. The server-side `MODE_TOOLS` gate still blocks the action (std-38 cl-6), so this is a UX gap rather than a hole.

Not fixed here: the shared block opens *"You are scoped to ONE function"*, which is false of the primary agent, and adding five behavioural instructions to that surface deserves its own decision. Filed as `issue-1` on spec-424 with a suggested shape.

## Standards

- **std-34** — points, never instructs; the tool name is asserted absent from the composed in-app prompt.
- **std-15 / std-38 cl-8** — copy is Scaffold data, never inline. Asserted that it is not *also* inline in `system-prompt.ts`. This is **not** the cl-68 carve-out t-1 used: that covers the composed MCP footer, not a React system-prompt block.
- **std-23** — the existing `plan-handoff` primitive is reused; no net-new chip.
- **std-22** — no paths, framework names or Standard handles in the copy; asserted.
- **std-28 — no journey.** Agent prose into a system prompt; no new rendered element, and the button it names already exists on the page. The AC asked for the call to be made explicitly, and this is the answer rather than an omission.
- The `ground_spec` channel gate is asserted **untouched** — if it were relaxed, this CTA would describe a boundary that no longer exists.

## Testing

| | |
|---|---|
| Full server suite | **731 files / 6736 tests, 0 failed** |
| UI scaffold + Inspect | 85/85 |
| `@memex/shared` | 831 passed (see caveat) |
| `tsc` shared + server | exit 0 |
| `make check` | green |

Driven red → green: both new tests failed on the missing block before it existed.

**Pre-existing red, not caused here:** 4 failures in `@memex/shared`'s `tool-manifest.test.ts` (summary-length on `list_docs`, `supersede_spec`, `propose_standard_change`, `accept_standard_change`). Red on `develop` already; `tool-manifest.ts` is untouched by this branch.

## Acceptance criteria

With this, **14/14 verified**. spec-424 stays in `build` — moving it on is not this PR's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
