### PR TITLE
fix(spec-558): selecting an Issue body no longer closes the card

### DIFF
--- a/packages/ui/e2e/journey-74-spec-558-issue-card-zones.spec.ts
+++ b/packages/ui/e2e/journey-74-spec-558-issue-card-zones.spec.ts
@@ -1,0 +1,351 @@
+// Journey 74 — spec-558: an Issue card you can read out of [per std-28].
+//
+// spec-164 dec-4 made the WHOLE Issue card a click-to-toggle accordion. A
+// drag-select inside the expanded body still produces a `click` on the card —
+// the browser fires it on the nearest common ancestor of the mousedown and
+// mouseup targets — so the gesture for reading the body was the gesture that
+// closed it, and the text was gone before it could be copied (issue-4).
+//
+// spec-558 dec-1 splits the card in two: a title strip that responds to clicks
+// and a content zone that responds to nothing. This journey is the tier that
+// can prove it, because it is the only one that produces a real
+// mousedown→drag→mouseup→click sequence at all — jsdom never does.
+//
+// THE TRAP THIS JOURNEY IS SHAPED AROUND. Two very different things both end
+// with "the expanded region is gone": the bug (a real selection, and the click
+// collapses the card) and a geometry miss (no selection ever started, so the
+// click is an ordinary toggle). After the mouseup they are indistinguishable —
+// the collapse unmounts the selected nodes, so the selection reads empty either
+// way. Measured while specifying: starting the drag 4px into the paragraph
+// lands in its left padding and selects NOTHING, while 6px selects the line.
+// A first attempt at this journey went red for exactly that wrong reason and
+// "proved" a bug it had not exercised. So the selection is read MID-DRAG,
+// before the mouseup, and asserted BEFORE the symptom (ac-4).
+//
+// Seeding is HTTP-only over the env-gated `__test__` surface, navigation is
+// path-based [per std-2 / std-28].
+
+import {
+  test,
+  expect,
+  tenantPath,
+  seedIssue,
+  emitAcEvents,
+} from "./helpers/index.js";
+import { seedOrgTenant, seedSpec } from "./helpers/retained.js";
+
+const SPEC558 = "mindset-prod/memex-building-itself/specs/spec-558";
+
+const ACS_BY_TEST: Record<string, string[]> = {
+  "selecting text inside an expanded Issue card leaves it open": [
+    `${SPEC558}/acs/ac-1`,
+    `${SPEC558}/acs/ac-4`,
+  ],
+  "the content zone is inert — a click on the body does nothing": [
+    `${SPEC558}/acs/ac-3`,
+  ],
+  "one click on the title strip opens, one click closes": [
+    `${SPEC558}/acs/ac-2`,
+  ],
+  "the two zones read as two zones in both themes, and only the strip reacts to hover":
+    [
+      `${SPEC558}/acs/ac-5`,
+      `${SPEC558}/acs/ac-8`,
+      `${SPEC558}/acs/ac-9`,
+    ],
+};
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === "skipped") return;
+  const refs = ACS_BY_TEST[testInfo.title];
+  if (!refs) return;
+  await emitAcEvents(
+    refs,
+    testInfo.status === "passed" ? "pass" : "fail",
+    `packages/ui/e2e/journey-74-spec-558-issue-card-zones.spec.ts::${testInfo.title}`,
+    testInfo.duration,
+  );
+});
+
+// Long enough that a horizontal drag across the first line has plenty of
+// glyphs to bite into.
+const BODY =
+  "The quick brown fox jumps over the lazy dog, and then keeps going for a " +
+  "good while longer so that a drag across this first line has plenty of " +
+  "glyphs to bite into.";
+
+/** Seed a Spec carrying one bodied Issue, open its Issues panel, return it. */
+async function openIssuePanel(page, resources, slug: string) {
+  const tenant = await seedOrgTenant({ slug: resources.slug(slug) });
+  const spec = await seedSpec({
+    memexId: tenant.memexId,
+    title: "Issue Card Zones Spec",
+    purpose: "Exercise reading an expanded Issue card.",
+  });
+  await seedIssue({
+    memexId: tenant.memexId,
+    docId: spec.docId,
+    type: "bug",
+    title: "An issue whose body you want to copy",
+    body: BODY,
+  });
+
+  await page.goto(
+    tenantPath(tenant.namespaceSlug, tenant.memexSlug, `/specs/${spec.handle}`),
+  );
+  await page.locator('[data-tab="verify"]').click();
+  // spec-282: Issues live under the unified "Agent Tasks & Issues" sub-tab.
+  await page
+    .getByRole("button", { name: /Agent Tasks?( \(\d+\))? & Issues?/ })
+    .click();
+  const panel = page.getByTestId("issue-panel");
+  await expect(panel).toBeVisible({ timeout: 15_000 });
+  return panel;
+}
+
+/**
+ * Drag-select across the first rendered line of `target` and return what was
+ * selected WHILE THE BUTTON WAS STILL DOWN. See the header note: reading it
+ * after the mouseup cannot distinguish the bug from a geometry miss.
+ *
+ * Pass the TEXT's own element, never a padded container: the content zone
+ * carries `px-3 py-2.5`, so a gesture measured from its box starts inside the
+ * padding and selects nothing. The guard below caught precisely that when the
+ * zone gained its padding — which is the whole reason it is a separate
+ * assertion. `+6`px, not `+4`: four pixels still lands left of the first
+ * glyph and selects nothing (measured).
+ */
+async function dragSelectMidDrag(page, target): Promise<string> {
+  const box = (await target.boundingBox())!;
+  const y = box.y + 8;
+  await page.mouse.move(box.x + 6, y);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width * 0.75, y, { steps: 12 });
+  const selected = await page.evaluate(() =>
+    (window.getSelection()?.toString() ?? "").trim(),
+  );
+  await page.mouse.up();
+  return selected;
+}
+
+test("selecting text inside an expanded Issue card leaves it open", async ({
+  page,
+  resources,
+}) => {
+  const panel = await openIssuePanel(page, resources, "j74a");
+  const card = panel.getByTestId("issue-card").first();
+
+  await card.click();
+  const content = card.getByTestId("issue-expanded");
+  await expect(content).toBeVisible();
+  await expect(content).toContainText("quick brown fox");
+
+  // The rendered body paragraph, not the padded zone around it.
+  const selected = await dragSelectMidDrag(page, content.locator("p").first());
+
+  // Geometry guard FIRST — prove a real selection existed, so the assertion
+  // below can only fail for the reason this journey exists (ac-4).
+  expect(
+    selected.length,
+    "a non-empty text selection should have landed inside the card",
+  ).toBeGreaterThan(0);
+
+  // The reported symptom: the read gesture is not a collapse gesture (ac-1).
+  await expect(content).toBeVisible();
+  await expect(card).toHaveAttribute("data-expanded", "true");
+});
+
+test("the content zone is inert — a click on the body does nothing", async ({
+  page,
+  resources,
+}) => {
+  const panel = await openIssuePanel(page, resources, "j74b");
+  const card = panel.getByTestId("issue-card").first();
+
+  await card.click();
+  const content = card.getByTestId("issue-expanded");
+  await expect(content).toBeVisible();
+
+  // A plain click in the middle of the body, and a double-click too: neither
+  // is a toggle, because the content zone carries no handler at all (ac-3).
+  await content.click({ position: { x: 40, y: 8 } });
+  await expect(content).toBeVisible();
+
+  await content.dblclick({ position: { x: 40, y: 8 } });
+  await expect(content).toBeVisible();
+  await expect(card).toHaveAttribute("data-expanded", "true");
+});
+
+test("one click on the title strip opens, one click closes", async ({
+  page,
+  resources,
+}) => {
+  const panel = await openIssuePanel(page, resources, "j74c");
+  const card = panel.getByTestId("issue-card").first();
+  // NOTE: this test is the guard for ac-2, not part of the reproduction. On an
+  // unfixed card `issue-strip` does not exist yet, so it fails as a missing
+  // locator rather than as the symptom — the two tests above are the ones that
+  // mutation-check the fix [per std-45 cl-3].
+  const strip = card.getByTestId("issue-strip");
+  await expect(strip).toBeVisible();
+
+  await strip.click();
+  await expect(card.getByTestId("issue-expanded")).toBeVisible();
+
+  // The same gesture closes it — nothing about closing is harder than opening.
+  await strip.click();
+  await expect(card.getByTestId("issue-expanded")).not.toBeVisible();
+});
+
+/**
+ * Resolved background of an element, as an [r,g,b] triple.
+ *
+ * Refuses a transparent background rather than returning one. `getComputedStyle`
+ * reports an element with no fill of its own as `rgba(0, 0, 0, 0)`, which parses
+ * to black — and black is darker than every token that ships, so a "the content
+ * is lighter than the strip" assertion would pass against a zone that has no
+ * fill at all. That is not hypothetical: this journey passed both themes that
+ * way before the strip was given its own `bg-surface`, comparing a real colour
+ * against a transparent one read as black. Each zone must own its fill, and
+ * this guard is what makes that unfakeable [per std-45 cl-4].
+ */
+async function bgOf(locator): Promise<[number, number, number]> {
+  const css = await locator.evaluate(
+    (el: Element) => getComputedStyle(el).backgroundColor,
+  );
+  const m = css.match(/rgba?\(([^)]+)\)/);
+  expect(m, `expected an rgb() background, got "${css}"`).not.toBeNull();
+  const parts = m![1].split(",").map((n) => parseFloat(n));
+  const [r, g, b] = parts;
+  const alpha = parts.length > 3 ? parts[3] : 1;
+  expect(
+    alpha,
+    `this element has no background of its own (${css}) — it is showing an ancestor's fill through, and a comparison against it measures nothing`,
+  ).toBeGreaterThan(0);
+  return [r, g, b];
+}
+
+const luminance = ([r, g, b]: [number, number, number]) =>
+  0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+test("the two zones read as two zones in both themes, and only the strip reacts to hover", async ({
+  page,
+  resources,
+}) => {
+  const panel = await openIssuePanel(page, resources, "j74d");
+  const card = panel.getByTestId("issue-card").first();
+  const strip = card.getByTestId("issue-strip");
+  const content = card.getByTestId("issue-expanded");
+
+  // The theme lives in localStorage('memex-theme') and ThemeContext toggles a
+  // .dark / .light class on <html>; set it and reload to switch, as journey-26
+  // does. BOTH themes are asserted, because a one-theme check is exactly what
+  // would let this ship half-broken — and half-broken is the normal outcome
+  // here, since the emphasis tokens run in opposite directions in the two
+  // themes (ac-5).
+  for (const theme of ["light", "dark"] as const) {
+    await page.evaluate((t) => localStorage.setItem("memex-theme", t), theme);
+    await page.reload();
+    await page
+      .getByRole("button", { name: /Agent Tasks?( \(\d+\))? & Issues?/ })
+      .click();
+    await expect(strip).toBeVisible({ timeout: 15_000 });
+    await strip.click();
+    await expect(content).toBeVisible();
+
+    // Measure AT REST — ac-5 states the rule at rest, deliberately.
+    //
+    // The click leaves the pointer on the strip, and so does a real user's, so
+    // this is not a test artifact: it is the state the rule excludes. Measured
+    // in the dark theme with the pointer resting on the strip — strip
+    // rgb(40,44,52) against content rgb(33,37,43) — the strip is the LIGHTER
+    // of the two and the "content recedes" reading inverts. It cannot be
+    // fixed by choosing a different hover token: `bg-surface` (#1b1e24) is
+    // already the darkest token that ships, so any hover can only lighten.
+    // Accepted rather than worked around — the element under the pointer
+    // should be the emphasised one — and ac-5 now says "at rest" because that
+    // is the boundary the rule actually holds at.
+    await page.mouse.move(2, 2);
+
+    const stripBg = await bgOf(strip);
+    const contentBg = await bgOf(content);
+
+    // Two zones, not one fill (ac-5) …
+    expect(
+      contentBg,
+      `${theme}: the content zone must not share the strip's fill`,
+    ).not.toEqual(stripBg);
+    // … and the CONTENT is the half that recedes, in both themes. That is the
+    // direction dec-1 chose instead of a darker strip, because no shipped
+    // token is darker than the card in the light theme (ac-8).
+    expect(
+      luminance(contentBg),
+      `${theme}: the content zone should recede (be lighter) — strip ${stripBg}, content ${contentBg}`,
+    ).toBeGreaterThan(luminance(stripBg));
+  }
+
+  // ac-9: the hover promise follows the click target. Hovering the content
+  // zone must change nothing — while the whole card carried
+  // `hover:bg-card-hover`, hovering lit up the one region that no longer
+  // responds to a click, which teaches the user the wrong thing.
+  const contentIdle = await bgOf(content);
+  const stripIdle = await bgOf(strip);
+  await content.hover({ position: { x: 40, y: 8 } });
+
+  // Let the hover STATE settle before reading, and read once.
+  //
+  // Every assertion below claims a value STAYED put, and that is the one shape
+  // polling cannot express: `expect.poll(...).toBe(idle)` succeeds on its first
+  // read, which lands before the 150ms `transition-colors` has moved anything.
+  // Measured — with the hover group deliberately put back on the card (the
+  // defect this asserts against), a polled version of these checks passed all
+  // four tests. A poll proves a value BECOMES something; a settle-then-read
+  // proves it stayed.
+  await page.waitForTimeout(400);
+
+  expect(
+    await bgOf(content),
+    "hovering the content zone changed its own fill",
+  ).toEqual(contentIdle);
+  expect(
+    await bgOf(strip),
+    "hovering the content zone lit up the title strip",
+  ).toEqual(stripIdle);
+
+  // The focus icon is the card's OTHER hover cue, and it is not a background —
+  // a fill-only check misses it completely. It used to hang off a hover group
+  // on the card, so pointing at the inert content zone made a button appear up
+  // in the strip. Asserted on computed opacity, not toBeVisible(): Playwright
+  // counts an `opacity: 0` element as visible, so the obvious assertion here
+  // would pass either way and prove nothing.
+  const focusOpacity = () =>
+    card
+      .getByTestId("issue-focus")
+      .evaluate((el: Element) => getComputedStyle(el).opacity);
+
+  // Read once, after the settle above — for the same reason, and this is the
+  // assertion that actually pins the defect: the hover group used to sit on the
+  // card, so pointing at the inert content zone faded this button in up in the
+  // strip.
+  expect(
+    await focusOpacity(),
+    "hovering the content zone revealed the strip's focus icon",
+  ).toBe("0");
+
+  // And the vacuity guard [per std-45 cl-4]: the cue must be PRESENT on the
+  // strip, not merely absent from the content. Without this, a card that had
+  // lost its hover treatment altogether would satisfy every assertion above.
+  // Polled, not read once: the zones carry `transition-colors`, so the fill
+  // reached ~150ms after the pointer arrives, not on the same tick.
+  await strip.hover();
+  await expect
+    .poll(async () => (await bgOf(strip)).join(","), {
+      message: "the title strip should light up under the pointer",
+    })
+    .not.toBe(stripIdle.join(","));
+  await expect
+    .poll(focusOpacity, {
+      message: "the focus icon should appear when the strip is hovered",
+    })
+    .toBe("1");
+});

--- a/packages/ui/src/components/IssuePanel.spec-484.test.tsx
+++ b/packages/ui/src/components/IssuePanel.spec-484.test.tsx
@@ -75,7 +75,8 @@ describe('spec-484: IssuePanel body markdown', () => {
     tagAc(AC(13));
     render(<IssuePanel docId="doc-1" />);
     const card = await screen.findByTestId('issue-card');
-    fireEvent.click(card);
+    // spec-558 dec-1: the title strip is the click target now, not the card.
+    fireEvent.click(within(card).getByTestId('issue-strip'));
     const expanded = within(card).getByTestId('issue-expanded');
     expect(expanded.querySelector('li')).not.toBeNull();
     expect(expanded.querySelector('strong')?.textContent).toBe('Safari');

--- a/packages/ui/src/components/IssuePanel.spec-558.test.tsx
+++ b/packages/ui/src/components/IssuePanel.spec-558.test.tsx
@@ -1,0 +1,169 @@
+// spec-558 t-3 / dec-1 — the Issue card is TWO zones: a title strip that takes
+// clicks and a content zone that takes none.
+//
+//   • ac-6 — the content zone is a SIBLING of the title strip, not a descendant
+//     of it. Until they are siblings neither the fill nor the click behaviour
+//     can differ, so the structural relationship is the claim, not the mere
+//     presence of both elements.
+//   • ac-7 — no code path in IssuePanel reads a selection. The fix is
+//     structural; a guard reappearing here would mean the click target came
+//     back.
+//   • ac-2 / ac-3 — the strip toggles both ways; the content zone answers
+//     nothing.
+//
+// WHAT THIS TIER CANNOT PROVE, deliberately. jsdom never produces a
+// mousedown→drag→mouseup→click sequence, so "selecting text leaves the card
+// open" (ac-1) lives in journey-74 and only there. A test here that stubbed
+// `window.getSelection` would assert a guard this Spec specifically does NOT
+// have — it would pass against an implementation that reintroduced the bug.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { IssuePanel } from './IssuePanel';
+import type { Issue } from '../api/types';
+import { tagAc } from '@memex-ai-ac/vitest';
+
+const AC = (n: number) => `mindset-prod/memex-building-itself/specs/spec-558/acs/ac-${n}`;
+
+const mockFetchIssues = vi.fn();
+const mockAddContextChip = vi.fn();
+
+vi.mock('./ChatContext', () => ({
+  useChat: () => ({ addContextChip: mockAddContextChip }),
+}));
+vi.mock('../hooks/useDocChangeStream', () => ({
+  useDocChangeStream: () => {},
+}));
+vi.mock('../api/client', () => ({
+  fetchIssues: (...a: unknown[]) => mockFetchIssues(...a),
+  createIssueApi: vi.fn(),
+  updateIssueStatusApi: vi.fn(),
+  convertIssueToTaskApi: vi.fn(),
+}));
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'iss-1',
+    docId: 'doc-1',
+    seq: 1,
+    title: 'An issue whose body you want to copy',
+    body: 'The quick brown fox jumps over the lazy dog.',
+    type: 'bug',
+    severity: null,
+    status: 'open',
+    source: 'human',
+    satisfyingTaskId: null,
+    promotedDocId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Issue;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchIssues.mockResolvedValue([makeIssue()]);
+});
+
+/** Render, open the card via its strip, and hand back the three elements. */
+async function openCard() {
+  render(<IssuePanel docId="doc-1" />);
+  const card = await screen.findByTestId('issue-card');
+  const strip = within(card).getByTestId('issue-strip');
+  fireEvent.click(strip);
+  const content = within(card).getByTestId('issue-expanded');
+  return { card, strip, content };
+}
+
+describe('spec-558: the Issue card is two zones', () => {
+  it('ac-6: the content zone is a SIBLING of the title strip, not nested inside it', async () => {
+    tagAc(AC(6));
+    const { card, strip, content } = await openCard();
+
+    // The claim is the relationship, so assert it from both directions rather
+    // than merely finding both elements on the page.
+    expect(strip.contains(content)).toBe(false);
+    expect(content.parentElement).toBe(card);
+    expect(strip.parentElement).toBe(card);
+  });
+
+  it('ac-3: the content zone answers no click, and no ancestor toggles on its behalf', async () => {
+    tagAc(AC(3));
+    const { card, content } = await openCard();
+
+    fireEvent.click(content);
+    expect(within(card).queryByTestId('issue-expanded')).not.toBeNull();
+
+    // A double-click is two clicks: if anything above were listening, the card
+    // would flicker shut. It also stands in for the word-select gesture, which
+    // is the one a reader uses to copy a single term.
+    fireEvent.doubleClick(content);
+    expect(within(card).queryByTestId('issue-expanded')).not.toBeNull();
+
+    // And the content zone must not reach the chat store either — the card
+    // wrapper used to own a handler, so this is the same absence, checked on
+    // the other consumer.
+    expect(mockAddContextChip).not.toHaveBeenCalled();
+  });
+
+  it('ac-2: one click on the strip opens, the same click closes', async () => {
+    tagAc(AC(2));
+    render(<IssuePanel docId="doc-1" />);
+    const card = await screen.findByTestId('issue-card');
+    const strip = within(card).getByTestId('issue-strip');
+
+    expect(within(card).queryByTestId('issue-expanded')).toBeNull();
+    fireEvent.click(strip);
+    expect(within(card).queryByTestId('issue-expanded')).not.toBeNull();
+    expect(strip).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(strip);
+    expect(within(card).queryByTestId('issue-expanded')).toBeNull();
+    expect(strip).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('ac-9: the hover cue lives on the strip, so the inert zone promises nothing', async () => {
+    tagAc(AC(9));
+    const { card, strip, content } = await openCard();
+
+    // The hover group and the pointer cursor belong to the click target. On the
+    // card they meant the inert content zone still faded in the focus icon and
+    // still showed a pointer — a promise the zone cannot keep.
+    expect(strip.className).toContain('group/issue');
+    expect(strip.className).toContain('cursor-pointer');
+    expect(strip.className).toContain('hover:bg-card-hover');
+
+    expect(card.className).not.toContain('group/issue');
+    expect(card.className).not.toContain('cursor-pointer');
+    expect(card.className).not.toContain('hover:');
+    expect(content.className).not.toContain('cursor-pointer');
+    expect(content.className).not.toContain('hover:');
+  });
+
+  it('ac-7: no code path in IssuePanel reads a text selection', () => {
+    tagAc(AC(7));
+    // A claim about the SHAPE of the module, so the honest evidence is the
+    // source itself — there is no runtime state to observe, which is the whole
+    // point of the design. dec-1 rejected three guard-shaped options in favour
+    // of removing the click target; a selection API reappearing in this file
+    // would mean the target came back.
+    const source = readFileSync(join(__dirname, 'IssuePanel.tsx'), 'utf8');
+
+    // Comments legitimately discuss selections, so strip them before scanning
+    // — otherwise this test would pin the prose rather than the code.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+
+    for (const api of ['getSelection', 'intersectsNode', 'commonAncestorContainer', 'createRange']) {
+      expect(code, `IssuePanel should not reach for ${api}`).not.toContain(api);
+    }
+
+    // Vacuity guard: prove the scrub left real code behind, so a regex that
+    // accidentally emptied the file could never make this pass [per std-45 cl-4].
+    expect(code).toContain('toggleExpanded');
+    expect(code).toContain('issue-strip');
+  });
+});

--- a/packages/ui/src/components/IssuePanel.test.tsx
+++ b/packages/ui/src/components/IssuePanel.test.tsx
@@ -245,19 +245,25 @@ describe('IssuePanel — inline expansion (spec-164)', () => {
     expect(cards).toHaveLength(2);
     expect(screen.queryByTestId('issue-expanded')).not.toBeInTheDocument();
 
-    await user.click(cards[0]);
-    expect(cards[0]).toHaveAttribute('aria-expanded', 'true');
+    // spec-558 dec-1 re-cut the click target: the TITLE STRIP toggles, the
+    // card does not. The accordion contract this test pins is unchanged —
+    // one click opens, the same click closes, several stay open — only the
+    // element carrying it moved, so the gestures now go to the strip.
+    const strips = cards.map((c) => within(c).getByTestId('issue-strip'));
+
+    await user.click(strips[0]);
+    expect(strips[0]).toHaveAttribute('aria-expanded', 'true');
     const expanded = screen.getByTestId('issue-expanded');
     expect(expanded).toHaveTextContent('line three — long enough to be clamped when collapsed.');
     expect(expanded).toHaveTextContent('issue-1');
 
     // Second card opens alongside the first.
-    await user.click(cards[1]);
+    await user.click(strips[1]);
     expect(screen.getAllByTestId('issue-expanded')).toHaveLength(2);
 
     // Clicking the first again collapses only it.
-    await user.click(cards[0]);
-    expect(cards[0]).toHaveAttribute('aria-expanded', 'false');
+    await user.click(strips[0]);
+    expect(strips[0]).toHaveAttribute('aria-expanded', 'false');
     expect(screen.getAllByTestId('issue-expanded')).toHaveLength(1);
   });
 
@@ -280,7 +286,10 @@ describe('IssuePanel — inline expansion (spec-164)', () => {
 
     render(<IssuePanel docId="doc-1" highlightIssueHandle="issue-5" />);
     const card = await screen.findByTestId('issue-card');
-    await waitFor(() => expect(card).toHaveAttribute('aria-expanded', 'true'));
+    // spec-558 dec-1: `aria-expanded` moved onto the title strip, which is the
+    // control now — the card is a container and announces nothing.
+    const strip = within(card).getByTestId('issue-strip');
+    await waitFor(() => expect(strip).toHaveAttribute('aria-expanded', 'true'));
     expect(screen.getByTestId('issue-expanded')).toHaveTextContent('full detail');
   });
 });

--- a/packages/ui/src/components/IssuePanel.tsx
+++ b/packages/ui/src/components/IssuePanel.tsx
@@ -7,10 +7,14 @@
 // same doc-change bus every other panel uses, so a create/update/delete from
 // any source (React UI, MCP, the agent, REST) re-renders the list (ac-2).
 //
-// Card interaction (spec-164 dec-4): clicking a card toggles an INLINE
-// expansion — full body + metadata in place, click again to collapse, several
-// cards may be open at once (the spec-96 dec-16 accordion pattern). The
-// click-to-focus chip (c-1) now fires ONLY from the dedicated hover icon:
+// Card interaction (spec-164 dec-4, re-cut by spec-558 dec-1): a card is TWO
+// zones. Clicking the TITLE STRIP toggles an inline expansion — full body +
+// metadata, one click to open, the same click to close, several cards open at
+// once (the spec-96 dec-16 accordion pattern). The CONTENT ZONE takes no
+// clicks at all, so the body can be selected and copied: when the whole card
+// was the toggle, a drag-select inside it ended with a `click` on the card and
+// closed what the user was reading (issue-4). The
+// click-to-focus chip (c-1) fires ONLY from the dedicated hover icon:
 // it drops a MINIMAL {type:'issue', id, label:'issue-N — title'} ContextChip
 // into the shared chat store — the agent fetches detail via get_issue.
 //
@@ -357,12 +361,35 @@ export function IssuePanel({
             data-issue-type={issue.type}
             data-issue-status={issue.status}
             data-expanded={isExpanded || undefined}
-            aria-expanded={isExpanded}
-            onClick={() => toggleExpanded(issue.id)}
-            className={`group/issue px-3 py-2.5 rounded-md border cursor-pointer transition-colors bg-surface/50 hover:bg-card-hover ${
+            className={`rounded-md border overflow-hidden transition-colors ${
               highlightedId === issue.id ? 'ring-2 ring-accent border-accent' : 'border-edge-subtle'
             }`}
           >
+            {/* spec-558 dec-1: the card is TWO zones, and only this one takes
+                clicks. The whole card used to be the toggle (spec-164 dec-4),
+                so a drag-select in the body ended with a `click` on the card —
+                the common ancestor of the mousedown and mouseup targets — and
+                reading the body collapsed it before it could be copied
+                (issue-4). No selection guard replaces it: the content zone
+                below simply has no handler, so there is no state to read and
+                nothing to read wrongly.
+
+                This stays a `div`, not a `<button>`: it contains issue-focus,
+                Resolve/Convert and the ⋯ menu, and interactive content cannot
+                nest inside a button. Their stopPropagation calls are still
+                load-bearing — this zone still toggles.
+
+                `group/issue` lives on THIS zone rather than on the card (ac-9).
+                On the card, hovering the inert content zone revealed the focus
+                icon up in the strip — a hover cue fired by the one region that
+                no longer answers a pointer. A background-only test never
+                catches that, so the group had to move with the handler. */}
+            <div
+              data-testid="issue-strip"
+              aria-expanded={isExpanded}
+              onClick={() => toggleExpanded(issue.id)}
+              className="group/issue px-3 py-2.5 bg-surface cursor-pointer transition-colors hover:bg-card-hover"
+            >
             <div className="flex items-start gap-3">
               <span className="flex-none text-xs font-mono text-muted pt-0.5">
                 issue-{issue.seq}
@@ -394,22 +421,6 @@ export function IssuePanel({
                 </div>
                 {issue.body && !isExpanded && (
                   <p className="text-xs text-muted mt-1 line-clamp-2">{issue.body}</p>
-                )}
-                {isExpanded && (
-                  // spec-164 dec-4: the inline expansion — full body (no
-                  // clamp) + the metadata line. Read in place; click the
-                  // card again to collapse.
-                  <div data-testid="issue-expanded" className="mt-2 space-y-2">
-                    {issue.body && (
-                      <MarkdownText inline={false} className="text-xs text-body">{issue.body}</MarkdownText>
-                    )}
-                    <p className="text-[11px] text-muted">
-                      issue-{issue.seq} · {TYPE_LABEL[issue.type]} ·{' '}
-                      {STATUS_LABEL[issue.status]}
-                      {issue.severity ? <> · severity {issue.severity}</> : null} · raised{' '}
-                      {new Date(issue.createdAt).toLocaleDateString()}
-                    </p>
-                  </div>
                 )}
               </div>
               {/* spec-182 dec-4: dispositions are editor calls — canEdit on top
@@ -452,6 +463,37 @@ export function IssuePanel({
                 </div>
               )}
             </div>
+            </div>
+
+            {/* spec-558 dec-1: the content zone — a pure reading surface, a
+                SIBLING of the strip rather than nested inside it (which is
+                where it used to live, in the strip's flex-1 column, sharing
+                one fill and one handler). No onClick here, and no clickable
+                ancestor: selecting, clicking or double-clicking this text
+                cannot do anything.
+
+                `bg-page` rather than a darker strip: measured against what
+                ships, no token is DARKER than the card in the light theme —
+                surface, card-hover and selected are all slate-50 — so the
+                contrast is made by letting the content recede instead. That
+                direction holds in both themes (white vs slate-50 in light,
+                #21252b vs #1b1e24 in dark) [per std-49]. */}
+            {isExpanded && (
+              <div
+                data-testid="issue-expanded"
+                className="px-3 py-2.5 space-y-2 bg-page border-t border-edge-subtle"
+              >
+                {issue.body && (
+                  <MarkdownText inline={false} className="text-xs text-body">{issue.body}</MarkdownText>
+                )}
+                <p className="text-[11px] text-muted">
+                  issue-{issue.seq} · {TYPE_LABEL[issue.type]} ·{' '}
+                  {STATUS_LABEL[issue.status]}
+                  {issue.severity ? <> · severity {issue.severity}</> : null} · raised{' '}
+                  {new Date(issue.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+            )}
           </div>
           );
         })}


### PR DESCRIPTION
Closes the defect behind **[spec-558](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-558)**: opening an Issue and trying to select its body closed the card before the text could be copied.

## What was wrong

spec-164 dec-4 made the whole Issue card a click-to-toggle accordion. A drag-select inside the expanded body still fires a `click` on the card — the browser dispatches it on the nearest common ancestor of the mousedown and mouseup targets — so the gesture for *reading* the body was the gesture that *closed* it.

## The fix — two zones, not a guard

spec-558 dec-1 rejected three guard-shaped options (read `getSelection()` and bail; test range containment; measure pointer travel) in favour of removing the click target from the read surface entirely:

- the **title strip** takes clicks; it carries `onClick`, `aria-expanded`, `cursor-pointer`, `hover:bg-card-hover` and the `group/issue` hover group
- the **content zone** takes none — no handler, no clickable ancestor, so there is no selection state to read and none to read wrongly
- the expanded region moves **out** of the title row's `flex-1` column to become its sibling; until they are siblings neither the fill nor the behaviour can differ

Fills come from shipped tokens only [per std-49]: the strip keeps `bg-surface`, the content recedes to `bg-page`. Measured — nothing ships darker than the card in the light theme (`surface`, `card-hover` and `selected` are all slate-50) — so the contrast is made by letting the content recede, which holds in **both** themes.

The strip stays a `div`, not a `<button>`: it contains the focus icon, Convert/Resolve and the ⋯ menu, and interactive content cannot nest inside a button. Keyboard operability is explicitly out of scope (dec-1).

## Test plan

- [x] **`journey-74-spec-558-issue-card-zones.spec.ts`** (new, std-28) — 4 tests. Drives the real mouse gesture; the only tier that produces mousedown→drag→mouseup→click at all.
- [x] **`IssuePanel.spec-558.test.tsx`** (new) — 5 tests: sibling structure, inertness, symmetric toggle, hover ownership, and a source scan proving no selection API remains.
- [x] **Red before green, on the record.** The journey was written and run against the unfixed card first: red on the symptom (post-drag `issue-expanded` gone; body click collapsing it), then green against the fix.
- [x] **Mutation-checked both tiers** [per std-45 cl-3] — fix removed → red on the symptom by name; content re-nested + `getSelection()` reintroduced → three component tests red, each on its own claim.
- [x] Full `@memex/ui` unit suite — **358 files, 2427 tests, 0 failures**
- [x] `make check` · `pnpm --filter @memex/ui build` (tsc + vite) · `tsc -b` — all clean
- [x] **spec-558 ACs: 9/9 verified, 100% covered**

### Two findings worth a reviewer's eye

**A test was passing for the wrong reason.** The strip had no fill of its own (it showed the wrapper's `bg-surface/50` through), so `getComputedStyle` reported `rgba(0,0,0,0)` — parsed as black, darker than every shipped token — and the "content is lighter than the strip" assertions passed in both themes against a transparent zone. The fill moved onto the strip and the helper now refuses a zero-alpha background outright.

**A vacuity guard that was itself vacuous.** `expect.poll(...).toBe(x)` succeeds on its *first* read, which lands before the 150 ms `transition-colors` moves anything — so the first mutation check passed **green** with the defect reintroduced. Polling can assert a value *becomes* something, never that it *stays* something. Replaced with settle-then-read; the re-run went red on the symptom by name.

### Three tests from other Specs were repaired, none renamed

`IssuePanel.test.tsx` (spec-164's accordion + deep-link cases) and `IssuePanel.spec-484.test.tsx` (markdown rendering) drove the card and read `aria-expanded` from it. They now drive `issue-strip`. **No test was renamed**, so their `tagAc` identifiers — and spec-164's and spec-484's evidence — stay intact rather than being stranded.

### Local full e2e: 14 pre-existing failures, proven unrelated

`make e2e-cold` (full suite) locally: **150 passed, 14 failed**. journey-74 passes. The 14 are the SSE / reactivity / streaming cluster (journeys 8, 12, 15, 16 ×7, 47, 55 ×2, 56) — none touches the Issue panel.

A/B'd rather than assumed: the branch was detached to `18c56907` (`origin/develop`, this branch's parent, without this commit) and the same subset re-run — **the same 14 failed there too**. Environmental to this machine, not introduced here. CI runs the suite cold on a clean host and is the arbiter.

## Scope deliberately left open

`DecisionPanel.tsx:654` and `TaskPanel.tsx:144` carry the identical unguarded whole-card `onClick` (selecting text on those cards drops a context chip into the chat). Scoped out by the Spec's owner: a chip on a stray click is plausibly intended behaviour, so changing it is a product call, not a bug fix.

Full session record, including the accepted dark-theme hover inversion: the [QA report](https://memex.ai/mindset-prod/memex-building-itself/specs/spec-558) on spec-558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
