### PR TITLE
docs(spec-564): a superseded migration says so, instead of reading as the definition

### DIFF
--- a/packages/server/drizzle/0089_activity_view.sql
+++ b/packages/server/drizzle/0089_activity_view.sql
@@ -1,3 +1,13 @@
+-- ⚠ SUPERSEDED — this file's definition of activity_view is no longer the live one.
+--    Migrations that define it, in order:
+--      grep -lE 'CREATE (OR REPLACE )?VIEW activity_view' drizzle/*.sql | sort
+--    ⚠ the last one may REPLAY the definition dynamically without carrying its text
+--      (0142 does exactly that) — a later file is not necessarily a readable one.
+--    Only authority on the live body (needs DB):
+--      pg_get_viewdef('activity_view'::regclass, true)
+--    Why this marker exists: spec-564. It was written because spec-563 was authored
+--    against this file's body and blamed a defect 0109/0111 had already fixed.
+--
 -- spec-122 t-6 (dec-1) — the activity VIEW. One read-only SQL view that UNION ALLs
 -- every kind of activity source into ONE uniform shape, so a single query returns
 -- every activity without a second materialised ledger. The activity-contract

--- a/packages/server/drizzle/0109_activity_view_tenant_scope.sql
+++ b/packages/server/drizzle/0109_activity_view_tenant_scope.sql
@@ -1,3 +1,13 @@
+-- ⚠ SUPERSEDED — this file's definition of activity_view is no longer the live one.
+--    Migrations that define it, in order:
+--      grep -lE 'CREATE (OR REPLACE )?VIEW activity_view' drizzle/*.sql | sort
+--    ⚠ the last one may REPLAY the definition dynamically without carrying its text
+--      (0142 does exactly that) — a later file is not necessarily a readable one.
+--    Only authority on the live body (needs DB):
+--      pg_get_viewdef('activity_view'::regclass, true)
+--    Why this marker exists: spec-564. It was written because spec-563 was authored
+--    against this file's body and blamed a defect 0109/0111 had already fixed.
+--
 -- spec-396 — SECURITY: close the cross-org activity bleed in activity_view.
 --
 -- THE LEAK (fixed here): the test_events arm of activity_view (migration 0089)

--- a/packages/server/drizzle/0111_test_events_retention_and_memex_id.sql
+++ b/packages/server/drizzle/0111_test_events_retention_and_memex_id.sql
@@ -1,3 +1,13 @@
+-- ⚠ SUPERSEDED — this file's definition of activity_view is no longer the live one.
+--    Migrations that define it, in order:
+--      grep -lE 'CREATE (OR REPLACE )?VIEW activity_view' drizzle/*.sql | sort
+--    ⚠ the last one may REPLAY the definition dynamically without carrying its text
+--      (0142 does exactly that) — a later file is not necessarily a readable one.
+--    Only authority on the live body (needs DB):
+--      pg_get_viewdef('activity_view'::regclass, true)
+--    Why this marker exists: spec-564. It was written because spec-563 was authored
+--    against this file's body and blamed a defect 0109/0111 had already fixed.
+--
 -- spec-398 — bounded retention + durable tenancy for test_events.
 --
 -- Three things, one atomic migration (the hand-runner wraps the file in a single


### PR DESCRIPTION
## Why

`drizzle/0089_activity_view.sql` opens with a confident, well-written header describing `activity_view` — its arms, its uniform projection, the Spec and task that produced it. It reads as the definition.

It is not. Four migrations define that view — `0089`, `0109`, `0111`, `0142` — and `0089` is the one that is wrong. `0109` (spec-396) closed a cross-org leak in the `test_events` arm; `0111` (spec-398) recreated it reading `te.memex_id` directly; `0142` replayed it under partitioning. **`0089` points nowhere forward.**

On 2026-09-11 that cost a Spec. spec-563 was authored blaming a defect `0109`/`0111` had already fixed, because its author read `0089` and treated the migration that *created* the view as the view's definition. Two of its five acceptance criteria described shipped work. It was caught in review — only because a second reader went to `pg_get_viewdef` instead of the file.

A reader cannot look up what they do not suspect. So the marker goes where they already are: the top of the file they opened.

## What changed

A comment header on the three superseded migrations. **`0142` carries no marker — it is the current definition.** No SQL changed; every added line is a comment.

```
-- ⚠ SUPERSEDED — this file's definition of activity_view is no longer the live one.
--    Migrations that define it, in order:
--      grep -lE 'CREATE (OR REPLACE )?VIEW activity_view' drizzle/*.sql | sort
--    ⚠ the last one may REPLAY the definition dynamically without carrying its text
--      (0142 does exactly that) — a later file is not necessarily a readable one.
--    Only authority on the live body (needs DB):
--      pg_get_viewdef('activity_view'::regclass, true)
--    Why this marker exists: spec-564. …
```

Per spec-564 dec-1 (option C) the marker names the **object** and how to find its definition, never the migrations that superseded it. A list of migration numbers would have to be maintained across every earlier file at each new supersession, and a marker that can go stale is a smaller instance of the defect being fixed [per std-50 cl-1].

## Two corrections found by testing the text before writing it

- **`grep -l` does not emit in path order** — here it returned `0089, 0111, 0142, 0109`, so `| tail -1` named `0109`, three migrations too early. Needs `| sort`.
- **`0142` captures the live body** (`SELECT pg_get_viewdef(…) INTO view_def`), drops the view, and replays it via `EXECUTE format(…)`. It is the last definer and carries **no readable text**. The marker says so rather than promising the chain can be read offline.

## Safety

Editing an already-applied migration is safe here, verified rather than assumed: `scripts/apply-hand-migrations.mjs` records applied files in `manual_migrations` with `filename text PRIMARY KEY` — no hash, no checksum. A comment change re-runs nothing. Were the applier content-addressed this approach would be unavailable.

## What this does NOT do

**Nothing yet adds a marker at the next supersession.** That guard is spec-564 `ac-2`/`ac-3` and belongs in `build`. Until it lands, these three headers are a snapshot — which is exactly the failure mode the Spec names, and the reason it does not stop here.

## Test plan

- [x] `make check` — offline guard battery green
- [x] `apply-hand-migrations-batch.regression.test.ts` — 5/5, `No hand-written migrations to apply`
- [x] Every added line is a comment (0 non-comment lines in each marker block)
- [x] `0142` unmarked (0 occurrences of `SUPERSEDED`)
- [x] `.husky/pre-push` — lint + typecheck + server unit tests green
- [ ] CI required checks on `develop`

## Follow-ups (not in this PR)

- [ ] spec-564 `ac-2`/`ac-3` — the twin guard that keeps the marker appearing
- [ ] std-50 scope amendment proposed as `std-50/comments/c-1`, awaiting the standard owner
- [ ] spec-563's mechanism section was corrected in the Memex after this finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
