### PR TITLE
fix(spec-563): the activity footer's spec filter reaches test_events

### DIFF
--- a/packages/server/drizzle/0146_spec563_activity_footer_spec_filter_index.sql
+++ b/packages/server/drizzle/0146_spec563_activity_footer_spec_filter_index.sql
@@ -1,0 +1,112 @@
+-- spec-563 t-2 (dec-1) — the activity footer's SPEC filter gets an index to stand on.
+--
+-- THE DEFECT. `listActivityView(memexId, { specRef })` reads activity_view with two
+-- predicates. `memex_id` pushes down — it is a base column on test_events, indexed since
+-- spec-398's 0111. `spec_ref` does NOT: for the test_events arm `spec_ref` IS
+-- `spec_doc.id`, and the only link back to the table is
+--
+--     substring(te.subject_ref from 'specs/([^/]+)/') = spec_doc.handle
+--
+-- with nothing indexed on that expression. So Postgres builds a hash join whose PROBE SIDE
+-- is the tenant's entire test_events history, then discards everything that is not the
+-- requested Spec. Measured on prod 2026-09-11 for mindset-four: 4 155 275 rows read to
+-- return 0 rows, 9 343 ms of a 9 347 ms query — for a Spec that owns no test events at all.
+-- The worst case in pg_stat_statements is 109 734 ms (the same plan, cold cache).
+--
+-- ⚠ WHAT THIS IS *NOT* FIXING. Earlier drafts of spec-563 blamed the TENANT filter. That
+-- was true of 0089 and has not been true since 0109/0111 — `te.memex_id` is a base column
+-- and is indexed. The sequential scan visible in the prod plan serves that tenant filter
+-- and is a defensible choice (the largest tenant owns ~73 % of the loaded partitions).
+-- Nothing here touches it. See spec-564's SUPERSEDED markers.
+--
+-- ── WHY dec-1 CHOSE AN INDEX OVER A COLUMN ──────────────────────────────────────────────
+--
+-- A stored generated column or a write-path `spec_doc_id` would be a cleaner end state.
+-- Both REWRITE or re-plumb a table taking ~31 events/s from a client with a 5 s timeout
+-- that NEVER retries (std-48) — a blocked write there is DISCARDED, not delayed. 0111 did
+-- exactly that shape and deadlocked a prod deploy (40P01, std-39 cl-9). An index touches
+-- neither the table's rows nor the write path, and `DROP INDEX` undoes it in one
+-- statement. Both alternatives remain available if this proves insufficient; the reverse
+-- would not have been true.
+--
+-- ── THE EXPRESSION IS COPIED FROM THE LIVE CATALOGUE ────────────────────────────────────
+--
+-- `pg_get_viewdef('activity_view'::regclass, true)` emits
+-- `"substring"(te.subject_ref, 'specs/([^/]+)/'::text)`. An expression index is matched
+-- STRUCTURALLY: if the view's spelling and this one ever diverge, the index is silently
+-- never chosen — no error, no log line, no failing migration, just the old plan and the
+-- old latency. The durable guard against that is the regression test
+-- (services/activity-view-spec-filter.spec-563.integration.test.ts, spec-563 ac-8), which
+-- asserts the ROW COUNT entering the arm. The assertion at the foot of this file guards
+-- only THIS deploy — it cannot see a divergence introduced afterwards.
+--
+-- ── RELATIONSHIP TO out-of-band/0145 ────────────────────────────────────────────────────
+--
+-- 0145 builds this index CONCURRENTLY, partition by partition, so production never pays
+-- for the build in a blocking window. It is an OPTIMISATION, not a prerequisite: this file
+-- is self-sufficient. Every fresh database (per-worker test DBs, the e2e cold-template
+-- build, a new dev machine) applies migrations through a runner whose readdirSync never
+-- sees out-of-band/, and depending on a prep file made `pnpm db:migrate` fail everywhere
+-- except prod once already (0142's header). On prod the index already exists and IF NOT
+-- EXISTS skips it; on a fresh database the table is empty and the build is instant.
+--
+-- ⚠ IF NOT EXISTS MATCHES ON THE NAME ALONE. 0142 records the near-miss: the name was
+-- already taken by a renamed legacy index, the statement silently created NOTHING, and a
+-- scrolled-past NOTICE was the only evidence. Here the collision is intended (0145 creates
+-- the same name on purpose) — so the skip is correct, and the risk moves to skipping over
+-- the WRONG index. §2 turns that from a silent success into a failed deploy.
+
+-- ── 1. The index ────────────────────────────────────────────────────────────────────────
+-- On the partitioned PARENT, so it reaches every existing partition and every partition
+-- test-event-retention.ts mints on its 60-day horizon. That propagation is the point
+-- (0142's header records what a missing forward index costs) and it is also the cost:
+-- one more tuple per insert on every partition, permanently [per std-39 cl-7].
+CREATE INDEX IF NOT EXISTS test_events_memex_spec_handle_created_idx
+  ON test_events (memex_id, substring(subject_ref, 'specs/([^/]+)/'), created_at);
+--> statement-breakpoint
+
+-- ── 2. Assert what §1 left behind — never trust a skip ──────────────────────────────────
+DO $$
+DECLARE
+  idx_oid    oid;
+  idx_valid  boolean;
+  idx_def    text;
+  view_def   text;
+BEGIN
+  SELECT c.oid, i.indisvalid, pg_get_indexdef(c.oid)
+    INTO idx_oid, idx_valid, idx_def
+    FROM pg_class c
+    JOIN pg_index i ON i.indexrelid = c.oid
+   WHERE c.relname = 'test_events_memex_spec_handle_created_idx';
+
+  IF idx_oid IS NULL THEN
+    RAISE EXCEPTION
+      'spec-563: test_events_memex_spec_handle_created_idx does not exist after CREATE INDEX. '
+      'The statement was skipped or failed silently.';
+  END IF;
+
+  -- An interrupted 0145 leaves the parent index INVALID (not every partition attached).
+  -- The planner ignores an invalid index, so the deploy would "succeed" and change nothing.
+  IF NOT idx_valid THEN
+    RAISE EXCEPTION
+      'spec-563: test_events_memex_spec_handle_created_idx exists but is INVALID — a '
+      'partition build from out-of-band/0145 failed or is unattached. The planner will '
+      'ignore it. Re-run 0145 and confirm indisvalid before deploying.';
+  END IF;
+
+  -- IF NOT EXISTS matched on the name; confirm the name holds the index we meant.
+  IF idx_def NOT LIKE '%memex_id%' OR idx_def NOT LIKE '%specs/([^/]+)/%' THEN
+    RAISE EXCEPTION
+      'spec-563: the index name is taken by something else: %', idx_def;
+  END IF;
+
+  -- The coupling this whole change rests on. Guards this deploy only — a divergence
+  -- introduced later is caught by the regression test, not here.
+  SELECT pg_get_viewdef('activity_view'::regclass, true) INTO view_def;
+  IF view_def NOT LIKE '%specs/([^/]+)/%' THEN
+    RAISE EXCEPTION
+      'spec-563: activity_view no longer contains the substring pattern this index is '
+      'built on. The index would never be chosen. Re-derive the expression from '
+      'pg_get_viewdef and rebuild.';
+  END IF;
+END $$;

--- a/packages/server/drizzle/0147_spec563_doc_sections_memex_id.sql
+++ b/packages/server/drizzle/0147_spec563_doc_sections_memex_id.sql
@@ -1,0 +1,131 @@
+-- spec-563 t-4 (ac-3) — doc_sections carries its own memex_id.
+--
+-- THE SURVIVING INSTANCE. spec-563 set out to fix "the tenant recovered through a join
+-- instead of read from the table". For test_events that had already been repaired by
+-- spec-396/spec-398 and the Spec was wrong about it. For doc_sections it is still true, and
+-- this is the only arm where it is:
+--
+--     ( SELECT pd.memex_id FROM documents pd WHERE pd.id = s.doc_id) AS memex_id
+--       FROM doc_sections s
+--
+-- Every other activity-bearing table — acs, tasks, decisions, doc_comments, test_events,
+-- activity_log — carries `memex_id uuid NOT NULL` as a first-class column [std-32: load-
+-- bearing fields are columns, not derivations]. doc_sections is the odd one out, and
+-- schema.ts said so in a comment rather than fixing it.
+--
+-- ⚠ THIS IS A CONSISTENCY REPAIR, NOT A PERFORMANCE FIX — and that was MEASURED, not
+-- assumed. The worry on the task was that home-specs.ts reads activity_view WITHOUT a spec
+-- filter, so the correlated subplan would run once per section across the whole Memex.
+-- EXPLAIN says otherwise:
+--
+--     Index Scan using doc_sections_actor_created_at_idx on doc_sections s
+--       Index Cond: (s.actor_user_id = $0)
+--       Filter: (... AND (SubPlan 3) = $1)
+--
+-- `actor_user_id` is an INDEX CONDITION, so the subplan only ever runs on rows that
+-- already survived it — bounded by one user's sections, not the Memex's. Sizing this as a
+-- latency fix would have been the same error this Spec exists to correct, one table over.
+--
+-- NO NEW INDEX. The footer read reaches doc_sections by doc_id and home-specs by
+-- actor_user_id; both already have one, and after this change `memex_id` is a cheap column
+-- check rather than a subquery. Adding an index "for the tenancy filter" would cost a tuple
+-- per insert forever to serve no measured reader [std-39]. If one is needed later, a
+-- measurement will say so.
+
+-- ── 1. The column ───────────────────────────────────────────────────────────────────────
+ALTER TABLE doc_sections ADD COLUMN IF NOT EXISTS memex_id uuid;
+--> statement-breakpoint
+
+UPDATE doc_sections s
+   SET memex_id = d.memex_id
+  FROM documents d
+ WHERE d.id = s.doc_id
+   AND s.memex_id IS NULL;
+--> statement-breakpoint
+
+-- An orphan section would block SET NOT NULL. doc_id references documents, so there should
+-- be none — which is exactly why a surprise here is a finding and not something to paper
+-- over with a DELETE. Fail loudly and let a human look.
+DO $$
+DECLARE orphans bigint;
+BEGIN
+  SELECT count(*) INTO orphans FROM doc_sections WHERE memex_id IS NULL;
+  IF orphans > 0 THEN
+    RAISE EXCEPTION
+      'spec-563: % doc_sections rows have no resolvable document. Investigate before '
+      'forcing NOT NULL — deleting them here would destroy activity history silently.',
+      orphans;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+ALTER TABLE doc_sections ALTER COLUMN memex_id SET NOT NULL;
+--> statement-breakpoint
+
+-- ── 2. The view arm reads the column ────────────────────────────────────────────────────
+--
+-- ⚠ CAPTURED AND PATCHED, NOT RESTATED. activity_view is defined across six migrations and
+-- 0142 recreates it dynamically from pg_get_viewdef WITHOUT carrying its text — so "the
+-- last migration that defines it" is not a readable source [spec-564]. Retyping the whole
+-- body here would silently revert anything live that this file's author did not know about.
+-- Instead: read the live definition, patch the one arm by regex, and REFUSE to proceed if
+-- the patch did not apply. A silent no-op is the failure mode being designed against.
+DO $$
+DECLARE
+  old_def text;
+  new_def text;
+BEGIN
+  SELECT pg_get_viewdef('activity_view'::regclass, true) INTO old_def;
+
+  new_def := regexp_replace(
+    old_def,
+    '\(\s*SELECT\s+pd\.memex_id\s+FROM\s+documents\s+pd\s+WHERE\s+pd\.id\s*=\s*s\.doc_id\s*\)',
+    's.memex_id',
+    'g');
+
+  IF new_def = old_def THEN
+    RAISE EXCEPTION
+      'spec-563: the doc_sections correlated subquery was not found in the live '
+      'activity_view definition. It may already be repaired, or rendered differently. '
+      'Read pg_get_viewdef(''activity_view''::regclass, true) and adjust this migration '
+      'rather than letting it succeed having changed nothing.';
+  END IF;
+
+  IF new_def NOT LIKE '%s.memex_id%' THEN
+    RAISE EXCEPTION 'spec-563: patched view definition does not read s.memex_id: %', new_def;
+  END IF;
+
+  -- DROP + CREATE rather than CREATE OR REPLACE: replace refuses any change to the output
+  -- column list, and while this change keeps it identical, the drop makes a mismatch a
+  -- loud error here instead of a subtle one later. security_invoker is re-stated because
+  -- it does NOT survive a drop — losing it would silently disable the RLS posture std-36
+  -- depends on.
+  DROP VIEW activity_view;
+  EXECUTE format('CREATE VIEW activity_view WITH (security_invoker = true) AS %s', new_def);
+END $$;
+--> statement-breakpoint
+
+-- ── 3. Assert the result, rather than trusting the block above ──────────────────────────
+DO $$
+DECLARE
+  def          text;
+  invoker      boolean;
+BEGIN
+  SELECT pg_get_viewdef('activity_view'::regclass, true) INTO def;
+
+  IF def LIKE '%FROM documents pd%' THEN
+    RAISE EXCEPTION 'spec-563: the doc_sections correlated subquery is still present: %', def;
+  END IF;
+
+  SELECT COALESCE((SELECT option_value::boolean
+                     FROM pg_options_to_table(c.reloptions)
+                    WHERE option_name = 'security_invoker'), false)
+    INTO invoker
+    FROM pg_class c WHERE c.oid = 'activity_view'::regclass;
+
+  IF NOT invoker THEN
+    RAISE EXCEPTION
+      'spec-563: activity_view lost security_invoker in the recreate. The runtime role '
+      'would read it as the owner and bypass RLS [std-36].';
+  END IF;
+END $$;

--- a/packages/server/drizzle/0148_spec563_doc_sections_tenant_fk.sql
+++ b/packages/server/drizzle/0148_spec563_doc_sections_tenant_fk.sql
@@ -1,0 +1,61 @@
+-- spec-563 t-4 — a section's tenant CANNOT disagree with its document's.
+--
+-- WHY THIS EXISTS, AND WHY IT IS A CONSTRAINT RATHER THAN A TEST.
+--
+-- 0147 denormalised documents.memex_id onto doc_sections. A denormalised column that CAN
+-- drift from its source is a tenancy bug with a delay fuse: nothing reads wrong, until one
+-- day a row is written with the wrong tenant and the activity view happily attributes it
+-- there. The backfill made every existing row agree; nothing was stopping the next write
+-- from disagreeing.
+--
+-- A test caught exactly that within an hour of 0147 landing — CI shard 2 went red with
+-- `expected 1 to be +0` on a cross-table mismatch count. That is the correct outcome and
+-- the wrong MECHANISM: the check ran late, in a suite, far from the insert that caused it,
+-- and only because some other test happened to share the database. A test that depends on
+-- global state to find a defect will also miss it whenever the ordering changes.
+--
+-- Postgres can enforce this at the write itself. A composite foreign key makes the
+-- impossible state unrepresentable rather than merely detected:
+--
+--     doc_sections (doc_id, memex_id) REFERENCES documents (id, memex_id)
+--
+-- Now a fixture or a handler that stamps the wrong tenant fails AT THE INSERT, naming the
+-- row, instead of surfacing three minutes later as an aggregate count in an unrelated
+-- shard. [std-32: tenancy is load-bearing; std-39: reason about the write path, not only
+-- the read.]
+
+-- ── 1. The referenced side needs a unique key on the exact pair ─────────────────────────
+-- `id` is already the primary key, so (id, memex_id) is unique by implication — but a
+-- foreign key requires a DECLARED unique constraint over precisely its target columns.
+-- This adds no meaningful storage beyond the index itself and no write ambiguity.
+ALTER TABLE documents
+  ADD CONSTRAINT documents_id_memex_id_key UNIQUE (id, memex_id);
+--> statement-breakpoint
+
+-- ── 2. Report any disagreement before trying to enforce it ──────────────────────────────
+-- 0147 backfilled from documents, so every pre-existing row agrees by construction. If
+-- that is somehow false, fail with the count rather than letting ADD CONSTRAINT emit a
+-- generic violation — the number is the diagnostic.
+DO $$
+DECLARE mismatched bigint;
+BEGIN
+  SELECT count(*) INTO mismatched
+    FROM doc_sections s JOIN documents d ON d.id = s.doc_id
+   WHERE s.memex_id <> d.memex_id;
+  IF mismatched > 0 THEN
+    RAISE EXCEPTION
+      'spec-563: % doc_sections rows disagree with their document''s memex_id. These are '
+      'mis-attributed sections, not noise — investigate which writer produced them before '
+      'correcting the rows, or the same writer will produce more.', mismatched;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- ── 3. The constraint ───────────────────────────────────────────────────────────────────
+-- ON DELETE CASCADE matches the existing doc_id foreign key: deleting a document already
+-- takes its sections. ON UPDATE CASCADE covers a document moving between Memexes — the
+-- sections follow rather than blocking the move or being orphaned into the old tenant.
+ALTER TABLE doc_sections
+  ADD CONSTRAINT doc_sections_doc_id_memex_id_fkey
+  FOREIGN KEY (doc_id, memex_id) REFERENCES documents (id, memex_id)
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/server/drizzle/out-of-band/0145_spec563_activity_footer_index_prep.sql
+++ b/packages/server/drizzle/out-of-band/0145_spec563_activity_footer_index_prep.sql
@@ -1,0 +1,100 @@
+-- spec-563 t-2 — OUT OF BAND. An OPTIMISATION for production, not a prerequisite.
+--
+-- ⚠ DELIBERATELY OUTSIDE THE MIGRATION RUNNER. apply-hand-migrations.mjs wraps every file
+-- in one transaction, and CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- Same posture as 0138 and 0141. The runner's readdirSync is non-recursive, so a file in
+-- out-of-band/ is never picked up automatically.
+--
+-- ⚠ 0146 DOES NOT DEPEND ON THIS FILE. It creates the same parent index itself, because
+-- every fresh database — each per-worker test DB, the e2e cold-template build, a new dev
+-- machine — applies migrations through a runner that never sees out-of-band/. Depending on
+-- a prep file made `pnpm db:migrate` fail everywhere except prod once already (0142's
+-- header records it). Running this first is what keeps PRODUCTION's build out of a
+-- blocking window; skipping it does not break anything.
+--
+-- WHAT IT BUILDS. An expression index that lets the activity footer's SPEC filter reach
+-- test_events:
+--
+--     (memex_id, substring(subject_ref, 'specs/([^/]+)/'), created_at)
+--
+-- Today `spec_ref` cannot push down — activity_view's test_events arm links back through
+-- `substring(te.subject_ref, …) = spec_doc.handle` with nothing indexed on that expression,
+-- so the hash join's probe side is the tenant's WHOLE history. Measured on prod
+-- 2026-09-11: 4 155 275 rows read to return 0, 9 343 ms of a 9 347 ms query.
+--
+-- ⚠ THE EXPRESSION IS COPIED FROM THE LIVE CATALOGUE, NOT FROM A MIGRATION FILE.
+-- `pg_get_viewdef('activity_view'::regclass, true)` on prod emits
+-- `"substring"(te.subject_ref, 'specs/([^/]+)/'::text)`. An index whose expression differs
+-- by so much as an argument form is simply never chosen — no error, no failing test, just
+-- the old plan back. That is precisely why spec-564 now stamps a SUPERSEDED marker on the
+-- migrations that define this view: reading one of them instead of the catalogue is the
+-- authoring error that produced spec-563's first, wrong mechanism.
+--
+-- ── WHY THIS IS NOT ONE STATEMENT ───────────────────────────────────────────────────────
+--
+-- test_events is PARTITIONED (0142). `CREATE INDEX CONCURRENTLY` is REFUSED on a
+-- partitioned parent:
+--     ERROR: cannot create index on partitioned table "test_events" concurrently
+-- So the build follows Postgres's documented three-step form:
+--   1. create the parent index ON ONLY — a catalogue entry, marked INVALID, no partition
+--      work, brief lock;
+--   2. build each partition's index CONCURRENTLY — no writes blocked anywhere;
+--   3. ATTACH each one. When the last partition is attached the parent index becomes
+--      VALID automatically.
+-- Until step 3 completes for EVERY partition the parent index stays invalid and the
+-- planner ignores it. An interrupted run is therefore safe but useless — re-run it.
+--
+-- RUN IT LIKE THIS (int first, then prod), with the deploy proxy up. \gexec is what makes
+-- the per-partition statements run one-per-transaction in psql's autocommit:
+--
+--     psql "$DB_URL" -f packages/server/drizzle/out-of-band/0145_spec563_activity_footer_index_prep.sql
+--
+-- THEN CONFIRM IT IS VALID before deploying 0146 — see the verification query at the end.
+-- A CONCURRENTLY build that fails leaves an INVALID index behind, which nothing will use
+-- and nothing will complain about. 0146 asserts this rather than trusting it.
+
+-- ── 1. The parent index, ON ONLY — invalid until every partition is attached ────────────
+CREATE INDEX IF NOT EXISTS test_events_memex_spec_handle_created_idx
+  ON ONLY test_events (memex_id, substring(subject_ref, 'specs/([^/]+)/'), created_at);
+
+-- ── 2. One CONCURRENT build per partition ───────────────────────────────────────────────
+SELECT format(
+         'CREATE INDEX CONCURRENTLY IF NOT EXISTS %I ON %I.%I (memex_id, substring(subject_ref, %L), created_at)',
+         left(c.relname, 39) || '_mx_spec_created_idx',
+         n.nspname, c.relname,
+         'specs/([^/]+)/')
+  FROM pg_inherits i
+  JOIN pg_class c     ON c.oid = i.inhrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE i.inhparent = 'test_events'::regclass
+ ORDER BY c.relname
+\gexec
+
+-- ── 3. Attach each partition index to the parent ────────────────────────────────────────
+-- ALTER INDEX … ATTACH PARTITION is a catalogue operation. It is skipped for any partition
+-- whose index is already attached, so re-running this file is safe.
+SELECT format(
+         'ALTER INDEX test_events_memex_spec_handle_created_idx ATTACH PARTITION %I.%I',
+         n.nspname, left(c.relname, 39) || '_mx_spec_created_idx')
+  FROM pg_inherits i
+  JOIN pg_class c     ON c.oid = i.inhrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE i.inhparent = 'test_events'::regclass
+ ORDER BY c.relname
+\gexec
+
+-- ── 4. VERIFY — do not skip this, and do not read a NOTICE as a result ──────────────────
+-- indisvalid must be true. If it is false, at least one partition's CONCURRENT build
+-- failed or is unattached; find it, drop its index, and run this file again:
+--
+--   DROP INDEX CONCURRENTLY <partition>_mx_spec_created_idx;
+--
+SELECT c.relname                                     AS index_name,
+       i.indisvalid                                  AS is_valid,
+       (SELECT count(*) FROM pg_inherits WHERE inhparent = 'test_events'::regclass) AS partitions,
+       (SELECT count(*) FROM pg_index pi
+          JOIN pg_inherits pii ON pii.inhrelid = pi.indexrelid
+         WHERE pii.inhparent = c.oid)                AS attached_indexes
+  FROM pg_index i
+  JOIN pg_class c ON c.oid = i.indexrelid
+ WHERE c.relname = 'test_events_memex_spec_handle_created_idx';

--- a/packages/server/src/__perf__/queries.perf.test.ts
+++ b/packages/server/src/__perf__/queries.perf.test.ts
@@ -41,6 +41,7 @@ describe("perf: list-docs at scale", () => {
     });
     const targetSections = insertedTarget.map((d) => ({
       docId: d.id,
+      memexId: targetMemexId,
       sectionType: "purpose",
       title: "Purpose",
       content: "scale test",

--- a/packages/server/src/agent/facet-clause-authoring.integration.test.ts
+++ b/packages/server/src/agent/facet-clause-authoring.integration.test.ts
@@ -59,7 +59,7 @@ beforeAll(async () => {
     .insert(documents)
     .values({ memexId, handle: "std-1", title: "A standard", docType: "standard", status: "draft" })
     .returning();
-  await db.insert(docSections).values({ docId: std.id, sectionType: "rule", content: "x", seq: 1, position: 1 });
+  await db.insert(docSections).values({ memexId, docId: std.id, sectionType: "rule", content: "x", seq: 1, position: 1 });
   sectionRef = `${nsSlug}/main/standards/std-1/sections/s-1`;
 });
 

--- a/packages/server/src/agent/facet-consume-handlers.integration.test.ts
+++ b/packages/server/src/agent/facet-consume-handlers.integration.test.ts
@@ -59,7 +59,7 @@ beforeAll(async () => {
     .returning();
   const [sec] = await db
     .insert(docSections)
-    .values({ docId: std.id, sectionType: "rule", content: "Unauthorized access returns 404.", seq: 1, position: 1 })
+    .values({ memexId, docId: std.id, sectionType: "rule", content: "Unauthorized access returns 404.", seq: 1, position: 1 })
     .returning();
   const [cl] = await db
     .insert(standardClauses)

--- a/packages/server/src/agent/facet-edit-handlers.spec-445.integration.test.ts
+++ b/packages/server/src/agent/facet-edit-handlers.spec-445.integration.test.ts
@@ -78,7 +78,7 @@ async function seedOrgMemex(sub: string, withVocab: boolean): Promise<{ memexId:
       fid.set(key, f.id);
     }
     const [std] = await db.insert(documents).values({ memexId: mx.id, handle: "std-1", title: "Auth guard standard", docType: "standard", status: "approved" }).returning();
-    const [sec] = await db.insert(docSections).values({ docId: std.id, sectionType: "rule", content: "Unauthorized access returns 404.", seq: 1, position: 1 }).returning();
+    const [sec] = await db.insert(docSections).values({ memexId: mx.id, docId: std.id, sectionType: "rule", content: "Unauthorized access returns 404.", seq: 1, position: 1 }).returning();
     const [cl] = await db.insert(standardClauses).values({ memexId: mx.id, docId: std.id, sectionId: sec.id, seq: 1, position: 1, body: "404 not 403" }).returning();
     await db.insert(standardClauseFacets).values({ memexId: mx.id, clauseId: cl.id, facetId: fid.get("xc-security")! });
   }

--- a/packages/server/src/agent/testability-clause-authoring.integration.test.ts
+++ b/packages/server/src/agent/testability-clause-authoring.integration.test.ts
@@ -76,7 +76,7 @@ beforeAll(async () => {
     .insert(documents)
     .values({ memexId, handle: "std-1", title: "A standard", docType: "standard", status: "draft" })
     .returning();
-  await db.insert(docSections).values({ docId: std.id, sectionType: "rule", content: "x", seq: 1, position: 1 });
+  await db.insert(docSections).values({ memexId, docId: std.id, sectionType: "rule", content: "x", seq: 1, position: 1 });
   sectionRef = `${nsSlug}/main/standards/std-1/sections/s-1`;
 });
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -280,6 +280,14 @@ export const docSections = pgTable(
     docId: uuid("doc_id")
       .notNull()
       .references(() => documents.id, { onDelete: "cascade" }),
+    // spec-563 (ac-3), migration 0147. Until then this table was the ONE
+    // activity-bearing arm whose tenant activity_view recovered through a correlated
+    // subquery against documents — every sibling (acs, tasks, decisions, doc_comments,
+    // test_events, activity_log) carries it as a column. std-32: a field a consumer must
+    // read to attribute or filter is load-bearing, and load-bearing fields are columns.
+    // Sections inherit account scope from their parent document, so this is denormalised
+    // from documents.memex_id and stamped at write by every caller.
+    memexId: uuid("memex_id").notNull(),
     sectionType: text("section_type").notNull(),
     title: text("title"),
     // spec-106 (ac-10): nullable free-text metadata describing the section's
@@ -354,10 +362,16 @@ export const docSections = pgTable(
       .on(table.docId, table.seq)
       .where(sql`status <> 'deleted'`),
     unique("doc_sections_doc_id_section_type_unique").on(table.docId, table.sectionType),
-    // spec-352 (0105) — Home activity_view feed. doc_sections has no memex_id
-    // (the view derives the tenant via a documents sub-select), so the Q-spark
-    // arm reduces to doc_id IN (...) AND created_at >= window. Q-mine filters by
-    // actor_user_id + window (partial: only attributable rows).
+    // spec-352 (0105) — Home activity_view feed. The Q-spark arm reduces to
+    // doc_id IN (...) AND created_at >= window. Q-mine filters by actor_user_id +
+    // window (partial: only attributable rows).
+    //
+    // ⚠ This comment used to read "doc_sections has no memex_id (the view derives the
+    // tenant via a documents sub-select)". That stopped being true at spec-563 / 0147.
+    // No index was added FOR the tenant column: both readers reach this table by doc_id
+    // or actor_user_id, which these indexes already serve, and memex_id is now a cheap
+    // column check rather than a subquery. An index serving no measured reader costs a
+    // tuple per insert forever [std-39].
     index("doc_sections_doc_created_at_idx").on(table.docId, table.createdAt),
     index("doc_sections_actor_created_at_idx")
       .on(table.actorUserId, table.createdAt)

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, uuid, timestamp, integer, unique, uniqueIndex, check, primaryKey, jsonb, boolean, index, customType, doublePrecision, date, type AnyPgColumn } from "drizzle-orm/pg-core";
+import { pgTable, text, uuid, timestamp, integer, unique, uniqueIndex, check, primaryKey, foreignKey, jsonb, boolean, index, customType, doublePrecision, date, type AnyPgColumn } from "drizzle-orm/pg-core";
 import { relations, type InferSelectModel, type InferInsertModel, sql } from "drizzle-orm";
 import type { CommentAction, CommentAudience } from "../types/roles.js";
 
@@ -216,6 +216,12 @@ export const documents = pgTable("documents", {
 }, (table) => [
   unique("documents_memex_id_handle_unique").on(table.memexId, table.handle),
   index("documents_memex_id_idx").on(table.memexId),
+  // spec-563 (0148): the target of doc_sections' composite tenancy FK. `id` is already
+  // the primary key so this pair is unique by implication — but a foreign key requires a
+  // DECLARED unique constraint over precisely its target columns. Exists to make
+  // "a section's tenant disagrees with its document's" unrepresentable rather than merely
+  // detectable after the fact.
+  unique("documents_id_memex_id_key").on(table.id, table.memexId),
   // spec-521 (ac-15) — serves the REVERSE supersession question the successor's
   // page asks ("what did I replace?") so the mirror line renders without a scan
   // of the Memex's documents. PARTIAL (WHERE NOT NULL) because the overwhelming
@@ -362,6 +368,21 @@ export const docSections = pgTable(
       .on(table.docId, table.seq)
       .where(sql`status <> 'deleted'`),
     unique("doc_sections_doc_id_section_type_unique").on(table.docId, table.sectionType),
+    // spec-563 (0148) — a section's tenant CANNOT disagree with its document's. memex_id
+    // here is denormalised from documents, and a denormalised column that can drift from
+    // its source is a tenancy bug with a delay fuse. A test that counted mismatches caught
+    // one within an hour of the column landing — the right outcome by the wrong mechanism,
+    // late and dependent on what else shared the database. This makes the bad state
+    // unrepresentable: a wrong tenant now fails AT THE INSERT, naming the row.
+    // ON UPDATE CASCADE so a document moving between Memexes takes its sections with it
+    // rather than blocking the move or stranding them in the old tenant.
+    foreignKey({
+      columns: [table.docId, table.memexId],
+      foreignColumns: [documents.id, documents.memexId],
+      name: "doc_sections_doc_id_memex_id_fkey",
+    })
+      .onDelete("cascade")
+      .onUpdate("cascade"),
     // spec-352 (0105) — Home activity_view feed. The Q-spark arm reduces to
     // doc_id IN (...) AND created_at >= window. Q-mine filters by actor_user_id +
     // window (partial: only attributable rows).

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1072,6 +1072,23 @@ export const testEvents = pgTable(
       table.memexId,
       table.createdAt,
     ),
+    // spec-563 dec-1 (ac-6): the tenant filter above was never the bottleneck. The SPEC
+    // filter is — activity_view's arm links back through
+    // `substring(subject_ref, 'specs/([^/]+)/') = documents.handle`, which nothing
+    // indexed, so the hash join's probe side was the tenant's WHOLE history (prod
+    // 2026-09-11: 4 155 275 rows read to return 0). Built by 0146, CONCURRENTLY in
+    // out-of-band/0145.
+    //
+    // ⚠ THE EXPRESSION MUST MATCH activity_view's SPELLING EXACTLY — expression indexes
+    // are matched structurally, and a divergence is silent: no error, no failing test,
+    // just the old plan back. Read it from `pg_get_viewdef('activity_view'::regclass,
+    // true)`, never from a migration file [spec-564]. The durable guard is
+    // services/activity-view-spec-filter.spec-563.integration.test.ts (ac-8).
+    index("test_events_memex_spec_handle_created_idx").on(
+      table.memexId,
+      sql`substring(${table.subjectRef}, 'specs/([^/]+)/')`,
+      table.createdAt,
+    ),
     check(
       "test_events_status_valid",
       sql`${table.status} IN ('pass', 'fail', 'error')`,

--- a/packages/server/src/db/seed-reviewer.ts
+++ b/packages/server/src/db/seed-reviewer.ts
@@ -184,7 +184,7 @@ async function main() {
 
     // 3 sections — Overview, Approach, Acceptance Criteria.
     await db.insert(docSections).values([
-      {
+      { memexId: orgMemex.id,
         docId: spec.id,
         sectionType: "overview",
         title: "Overview",
@@ -197,6 +197,7 @@ async function main() {
         position: 1,
       },
       {
+        memexId: orgMemex.id,
         docId: spec.id,
         sectionType: "approach",
         title: "Approach",
@@ -208,6 +209,7 @@ async function main() {
         position: 2,
       },
       {
+        memexId: orgMemex.id,
         docId: spec.id,
         sectionType: "acceptance",
         title: "Acceptance Criteria",
@@ -330,7 +332,7 @@ async function main() {
         createdByUserId: user.id,
       })
       .returning();
-    await db.insert(docSections).values({
+    await db.insert(docSections).values({ memexId: orgMemex.id,
       docId: std.id,
       sectionType: "rule",
       title: "Rule",
@@ -359,7 +361,7 @@ async function main() {
         createdByUserId: user.id,
       })
       .returning();
-    await db.insert(docSections).values({
+    await db.insert(docSections).values({ memexId: orgMemex.id,
       docId: plan.id,
       sectionType: "plan",
       title: "Plan",

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -62,7 +62,7 @@ async function seed() {
       .returning();
 
     await db.insert(docSections).values([
-      {
+      { memexId: memex.id,
         docId: doc.id,
         sectionType: "purpose",
         title: "Purpose",
@@ -71,6 +71,7 @@ async function seed() {
         position: 1,
       },
       {
+        memexId: memex.id,
         docId: doc.id,
         sectionType: "approach",
         title: "Approach",
@@ -79,6 +80,7 @@ async function seed() {
         position: 2,
       },
       {
+        memexId: memex.id,
         docId: doc.id,
         sectionType: "risks",
         title: "Risks",

--- a/packages/server/src/db/spec-181-plan-to-specify-migration.test.ts
+++ b/packages/server/src/db/spec-181-plan-to-specify-migration.test.ts
@@ -133,8 +133,8 @@ async function withPreMigrationFixture(
       const mkSection = async (sectionType: string, content: string) => {
         const seq = nextSeq++;
         const r = (await tx.execute(
-          sql`insert into doc_sections (doc_id, section_type, content, seq, position)
-              values (${docId}, ${sectionType}, ${content}, ${seq}, ${seq})
+          sql`insert into doc_sections (doc_id, memex_id, section_type, content, seq, position)
+              values (${docId}, ${memexId}, ${sectionType}, ${content}, ${seq}, ${seq})
               returning id`,
         )) as unknown as Row[];
         return r[0]!.id as string;

--- a/packages/server/src/mcp/ac-nag-sketch.test.ts
+++ b/packages/server/src/mcp/ac-nag-sketch.test.ts
@@ -106,6 +106,7 @@ function makeSpecDoc(overrides: Partial<Doc> = {}): Doc & { sections: DocSection
       {
         id: "s-uuid-1",
         docId: "spec-uuid-121",
+        memexId: "memex-building-itself",
         sectionType: "overview",
         title: "Overview",
         description: null,

--- a/packages/server/src/mcp/auth.integration.test.ts
+++ b/packages/server/src/mcp/auth.integration.test.ts
@@ -361,7 +361,7 @@ describe("resolveMemexFromEntity", () => {
       .returning();
     const [section] = await db
       .insert(docSections)
-      .values({ docId: doc.id, sectionType: "purpose", content: "x", seq: 1, position: 1 } as any)
+      .values({ memexId: a.id, docId: doc.id, sectionType: "purpose", content: "x", seq: 1, position: 1 })
       .returning();
 
     const got = await resolveMemexFromEntity(u.id, "section", section.id);
@@ -412,7 +412,7 @@ describe("resolveMemexFromEntity", () => {
       .returning();
     const [s] = await db
       .insert(docSections)
-      .values({ docId: doc.id, sectionType: "purpose", content: "x", seq: 1, position: 1 } as any)
+      .values({ memexId: a.id, docId: doc.id, sectionType: "purpose", content: "x", seq: 1, position: 1 })
       .returning();
     const [cmt] = await db
       .insert(docComments)

--- a/packages/server/src/mcp/footer-delimiter.spec-203.test.ts
+++ b/packages/server/src/mcp/footer-delimiter.spec-203.test.ts
@@ -51,6 +51,7 @@ function makeSpec(status: string): Doc & { sections: DocSection[] } {
       {
         id: "section-uuid-1",
         docId: "doc-uuid-1",
+        memexId: "test-account",
         sectionType: "overview",
         title: "Overview",
         description: null,

--- a/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-essence.spec-203.test.ts
@@ -64,6 +64,7 @@ function makeSpec(status: string): Doc & { sections: DocSection[] } {
       {
         id: "section-uuid-1",
         docId: "doc-uuid-1",
+        memexId: "test-account",
         sectionType: "overview",
         title: "Overview",
         description: null,

--- a/packages/server/src/mcp/formatters.handoff-fulldelivery.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.handoff-fulldelivery.spec-203.test.ts
@@ -54,6 +54,7 @@ function makeSpec(status: string): Doc & { sections: DocSection[] } {
       {
         id: "section-uuid-1",
         docId: "doc-uuid-1",
+        memexId: "test-account",
         sectionType: "overview",
         title: "Overview",
         description: null,

--- a/packages/server/src/mcp/formatters.injected-blocks.spec-203.test.ts
+++ b/packages/server/src/mcp/formatters.injected-blocks.spec-203.test.ts
@@ -53,6 +53,7 @@ function makeSpec(): Doc & { sections: DocSection[] } {
       {
         id: "section-uuid-1",
         docId: "doc-uuid-1",
+        memexId: "test-account",
         sectionType: "overview",
         title: "Overview",
         description: null,

--- a/packages/server/src/mcp/formatters.test.ts
+++ b/packages/server/src/mcp/formatters.test.ts
@@ -68,6 +68,7 @@ function makeSection(overrides: Partial<DocSection> = {}): DocSection {
   return {
     id: "section-uuid-1",
     docId: "doc-uuid-1",
+    memexId: "test-account",
     sectionType: "purpose",
     title: "Purpose",
     description: null,

--- a/packages/server/src/mcp/telemetry-session-gate.spec-563.integration.test.ts
+++ b/packages/server/src/mcp/telemetry-session-gate.spec-563.integration.test.ts
@@ -1,0 +1,145 @@
+// spec-563 t-5 (ac-12) — the tail watcher's blind spot, measured rather than inherited.
+//
+// dec-2 puts the watcher on `mcp_tool_calls`. That table is written inside
+// `if (sessionId)` (mcp/tools.ts), so the obvious worry is that calls arriving WITHOUT an
+// MCP session record nothing and are invisible to the signal.
+//
+// GROUNDING SAYS THE GATE NEVER CLOSES IN PRODUCTION. `app.ts` derives it as
+//
+//     const sessionId = incomingSession ?? randomUUID();
+//
+// so a client that sends no `Mcp-Session-Id` gets a server-minted one. `createMcpServer`
+// has exactly ONE production call site and it always passes that value; `undefined` is
+// reachable only from tests. `git log -S incomingSession` dates the line to the initial
+// commit, so the behaviour has not changed across the window issue-1 wants to read.
+//
+// ⚠ BUT A SOURCE READ IS A SHAPE ANSWER, AND THE AC ASKS A RUNTIME ONE. "The code cannot
+// reach undefined" and "no production call is missing a row" are different claims, and the
+// second is the one the watcher depends on. This test drives the REAL /mcp endpoint with
+// NO session header and asserts a row lands — the claim, exercised, not inspected.
+//
+// The remaining hole is a different one, and it is recorded on t-5 rather than hidden
+// here: `logToolCall` swallows its errors, and `mcp_tool_calls` has an FK to
+// `mcp_sessions`, whose upsert also swallows. A failed session upsert therefore drops
+// every tool-call row for that session, silently. Prod logs show ZERO `logToolCall failed`
+// lines in 7 days (search instrument verified capable), so it is not currently firing —
+// but it is unguarded, and no test can assert an absence that lives in a catch block.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { inArray, eq, and } from "drizzle-orm";
+import { db } from "../db/connection.js";
+import {
+  memexes,
+  namespaces,
+  orgs,
+  orgMemberships,
+  users,
+  mcpToolCalls,
+  mcpSessions,
+} from "../db/schema.js";
+import { mintMcpToken } from "../services/mcp-tokens.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-563/acs";
+
+// /mcp does not use sessionMiddleware, but the app mounts routes that do.
+const originalClientId = process.env.GOOGLE_CLIENT_ID;
+beforeAll(() => {
+  delete process.env.GOOGLE_CLIENT_ID;
+  vi.resetModules();
+});
+
+const created = { users: [] as string[], memexes: [] as string[] };
+
+let token: string;
+let userId: string;
+
+beforeAll(async () => {
+  const sub = `s563t5-${process.env.VITEST_WORKER_ID ?? "0"}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`.toLowerCase();
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${sub}@memex.ai`, name: "Gate probe" } as typeof users.$inferInsert)
+    .returning();
+  userId = u.id;
+  created.users.push(u.id);
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db
+    .insert(memexes)
+    .values({ name: sub, slug: "main", namespaceId: ns.id } as typeof memexes.$inferInsert)
+    .returning();
+  created.memexes.push(mx.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  // mintMcpToken returns { raw, row } — `raw` is the Bearer value. Destructuring it
+  // wrong produced a 401, which the vacuity guard caught as "the call failed" rather
+  // than letting an absent telemetry row read as a blind spot.
+  ({ raw: token } = await mintMcpToken(u.id, "spec-563 gate probe"));
+});
+
+afterAll(async () => {
+  if (originalClientId !== undefined) process.env.GOOGLE_CLIENT_ID = originalClientId;
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+describe("mcp telemetry: the session gate never closes on a real call [spec-563 t-5]", () => {
+  it("ac-12: a tool call carrying NO Mcp-Session-Id still records a row the watcher can see", async () => {
+    tagAc(`${AC}/ac-12`);
+
+    const { app } = await import("../app.js");
+
+    // Deliberately NO Mcp-Session-Id header — the case the blind spot is about.
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "list_memexes", arguments: {} },
+      }),
+    });
+
+    // Vacuity guard: if the call did not succeed, an absent telemetry row would prove
+    // nothing about the gate (std-45 cl-4).
+    expect(res.status).toBe(200);
+
+    // ⚠ POLL, do not read once. The telemetry write is fired as `void logToolCall(...)`
+    // in mcp/tools.ts — deliberately not awaited, so the tool path never waits on
+    // telemetry. A single read right after the response therefore races the insert and
+    // returned 0 rows on the first run of this test. Read once and this would have looked
+    // exactly like "the gate closed and the watcher is blind" — the finding the whole task
+    // is about, arrived at for entirely the wrong reason [std-37: poll for async writes].
+    const readRows = () =>
+      db
+        .select({ id: mcpToolCalls.id, sessionId: mcpToolCalls.sessionId, tool: mcpToolCalls.toolName })
+        .from(mcpToolCalls)
+        .where(and(eq(mcpToolCalls.userId, userId), eq(mcpToolCalls.toolName, "list_memexes")));
+
+    // THE CLAIM: the row lands even though the client sent no session.
+    await expect.poll(async () => (await readRows()).length, { timeout: 5000 }).toBeGreaterThan(0);
+
+    const rows = await readRows();
+
+    // And the session it was filed under is a real, server-minted one — not a placeholder
+    // or an empty string that would collapse every sessionless caller into one bucket and
+    // make per-session analysis quietly wrong.
+    const sessionIds = rows.map((r) => r.sessionId);
+    expect(sessionIds.every((s) => typeof s === "string" && s.length > 0)).toBe(true);
+
+    const sessions = await db
+      .select({ id: mcpSessions.sessionId })
+      .from(mcpSessions)
+      .where(inArray(mcpSessions.sessionId, sessionIds));
+    expect(sessions.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/routes/comments.test.ts
+++ b/packages/server/src/routes/comments.test.ts
@@ -56,6 +56,7 @@ describe("GET /api/comments/doc/:docId", () => {
           section: {
             id: "s1",
             docId: "d1",
+            memexId: "test-account",
             sectionType: "purpose",
             title: "Purpose",
             description: null,

--- a/packages/server/src/routes/internal-lifecycle.ts
+++ b/packages/server/src/routes/internal-lifecycle.ts
@@ -23,6 +23,7 @@ import { Hono } from "hono";
 import { timingSafeEqual } from "node:crypto";
 import { runActivationDrip } from "../services/email/activation-drip.js";
 import { runConnectPeoplePass } from "../services/email/connect-people.js";
+import { runLatencyTailWatch } from "../services/mcp-latency-watch.js";
 
 export const internalLifecycleRouter = new Hono();
 
@@ -85,4 +86,38 @@ internalLifecycleRouter.post("/lifecycle-tick", async (c) => {
 
   // Non-200 on any failure → Cloud Scheduler retries (idempotent-safe via per-pass dedup).
   return c.json(result, result.errors.length ? 500 : 200);
+});
+
+/**
+ * spec-563 t-6 (dec-2) — the MCP latency TAIL watch.
+ *
+ * A SEPARATE endpoint from the lifecycle tick above, on purpose. That one runs once a day
+ * because email drips are daily; this one reads a 60-minute window and wants its own,
+ * faster Cloud Scheduler job. Folding a latency watcher into a daily email pass would
+ * silently give it a 24-hour detection floor — long enough for the incident it exists to
+ * catch to come and go twice.
+ *
+ * Same shared-secret auth, same fail-closed-when-unset posture.
+ *
+ * ⚠ FAILURE MUST BE LOUD. A watcher that errors quietly is indistinguishable from one
+ * reporting health — the exact failure mode this replaces (spec-412's OTEL sensor has
+ * emitted nothing in both environments for months while still looking like a dependency).
+ * So a throw returns 500, which makes the Cloud Scheduler job itself go red and surfaces
+ * in a place someone already watches. Retrying is harmless: this is a pure read.
+ */
+internalLifecycleRouter.post("/latency-tick", async (c) => {
+  if (!authorized(c.req.header("authorization"))) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  try {
+    const { readings, breaches } = await runLatencyTailWatch();
+    // The response carries COUNTS, never the breach rows: this body lands in Cloud
+    // Scheduler logs, and mcp_tool_calls holds args_json and user_id [std-31].
+    return c.json({ readings, breaches: breaches.length }, 200);
+  } catch (err) {
+    return c.json(
+      { error: "latency-tick failed", detail: err instanceof Error ? err.message : String(err) },
+      500,
+    );
+  }
 });

--- a/packages/server/src/routes/internal-lifecycle.ts
+++ b/packages/server/src/routes/internal-lifecycle.ts
@@ -23,7 +23,6 @@ import { Hono } from "hono";
 import { timingSafeEqual } from "node:crypto";
 import { runActivationDrip } from "../services/email/activation-drip.js";
 import { runConnectPeoplePass } from "../services/email/connect-people.js";
-import { runLatencyTailWatch } from "../services/mcp-latency-watch.js";
 
 export const internalLifecycleRouter = new Hono();
 
@@ -86,38 +85,4 @@ internalLifecycleRouter.post("/lifecycle-tick", async (c) => {
 
   // Non-200 on any failure → Cloud Scheduler retries (idempotent-safe via per-pass dedup).
   return c.json(result, result.errors.length ? 500 : 200);
-});
-
-/**
- * spec-563 t-6 (dec-2) — the MCP latency TAIL watch.
- *
- * A SEPARATE endpoint from the lifecycle tick above, on purpose. That one runs once a day
- * because email drips are daily; this one reads a 60-minute window and wants its own,
- * faster Cloud Scheduler job. Folding a latency watcher into a daily email pass would
- * silently give it a 24-hour detection floor — long enough for the incident it exists to
- * catch to come and go twice.
- *
- * Same shared-secret auth, same fail-closed-when-unset posture.
- *
- * ⚠ FAILURE MUST BE LOUD. A watcher that errors quietly is indistinguishable from one
- * reporting health — the exact failure mode this replaces (spec-412's OTEL sensor has
- * emitted nothing in both environments for months while still looking like a dependency).
- * So a throw returns 500, which makes the Cloud Scheduler job itself go red and surfaces
- * in a place someone already watches. Retrying is harmless: this is a pure read.
- */
-internalLifecycleRouter.post("/latency-tick", async (c) => {
-  if (!authorized(c.req.header("authorization"))) {
-    return c.json({ error: "unauthorized" }, 401);
-  }
-  try {
-    const { readings, breaches } = await runLatencyTailWatch();
-    // The response carries COUNTS, never the breach rows: this body lands in Cloud
-    // Scheduler logs, and mcp_tool_calls holds args_json and user_id [std-31].
-    return c.json({ readings, breaches: breaches.length }, 200);
-  } catch (err) {
-    return c.json(
-      { error: "latency-tick failed", detail: err instanceof Error ? err.message : String(err) },
-      500,
-    );
-  }
 });

--- a/packages/server/src/services/activity-view-arm-tenancy.spec-563.integration.test.ts
+++ b/packages/server/src/services/activity-view-arm-tenancy.spec-563.integration.test.ts
@@ -19,12 +19,45 @@
 // Asserting against a file would test a fiction. This Spec's entire first draft was that
 // mistake.
 
-import { describe, it, expect } from "vitest";
-import { sql } from "drizzle-orm";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, sql } from "drizzle-orm";
 import { tagAc } from "@memex-ai-ac/vitest";
 import { db } from "../db/connection.js";
+import { users, namespaces, orgs, orgMemberships, memexes, documents } from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
 
 const AC = "mindset-prod/memex-building-itself/specs/spec-563/acs";
+
+// The FK probe needs a document of its own to aim at. std-37: per-worker-unique.
+let seededMemexId: string;
+let seededUserId: string;
+
+beforeAll(async () => {
+  const sub = `s563fk-${process.env.VITEST_WORKER_ID ?? "0"}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`.toLowerCase();
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${sub}@memex.ai`, name: "FK probe" } as typeof users.$inferInsert)
+    .returning();
+  seededUserId = u.id;
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` })
+    .returning();
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+  seededMemexId = mx.id;
+});
+
+afterAll(async () => {
+  if (seededMemexId)
+    await db.delete(documents).where(eq(documents.memexId, seededMemexId)).catch(() => {});
+  if (seededMemexId) await db.delete(memexes).where(eq(memexes.id, seededMemexId)).catch(() => {});
+  if (seededUserId) await db.delete(users).where(eq(users.id, seededUserId)).catch(() => {});
+});
 
 async function liveViewDef(): Promise<string> {
   const rows = (await db.execute(
@@ -79,19 +112,65 @@ describe("activity_view: no arm recovers its tenant [spec-563 t-4]", () => {
     }
   });
 
-  it("ac-3: doc_sections supplies its own tenant, and it agrees with the document's", async () => {
+  it("ac-3: a section whose tenant disagrees with its document's cannot be written", async () => {
     tagAc(`${AC}/ac-3`);
 
-    // The column is denormalised from documents.memex_id. A denormalised column that can
-    // disagree with its source is a tenancy bug waiting to happen, so assert the two never
-    // diverge across every row present.
+    // ⚠ THIS TEST USED TO COUNT MISMATCHES ACROSS THE WHOLE DATABASE, and that was wrong
+    // twice over. It went red in CI (`expected 1 to be +0`) while passing locally — not
+    // because CI is different, but because the assertion depended on what OTHER tests in
+    // the same shard had left behind [std-37: fixtures must be isolated]. A check that
+    // needs global state to find a defect will also miss it when the ordering changes.
+    //
+    // The invariant it was reaching for is real, so it moved to where invariants belong:
+    // a composite FK, doc_sections (doc_id, memex_id) → documents (id, memex_id), added by
+    // 0148. A wrong tenant now fails AT THE INSERT, naming the row, instead of surfacing
+    // minutes later as an aggregate in an unrelated shard.
+    //
+    // What is left here is the isolated proof that the constraint is live and does bite.
     const rows = (await db.execute(sql`
-      SELECT count(*)::int AS total,
-             count(*) FILTER (WHERE s.memex_id <> d.memex_id)::int AS mismatched
-        FROM doc_sections s
-        JOIN documents d ON d.id = s.doc_id
-    `)) as unknown as { total: number; mismatched: number }[];
+      SELECT conname FROM pg_constraint
+       WHERE conrelid = 'doc_sections'::regclass
+         AND conname = 'doc_sections_doc_id_memex_id_fkey'
+    `)) as unknown as { conname: string }[];
+    expect(rows.length).toBe(1);
 
-    expect(rows[0].mismatched).toBe(0);
+    // And that it is not decorative: writing a section under a tenant that is not its
+    // document's must be refused by the DATABASE, not merely discouraged by convention.
+    //
+    // ⚠ The first version of this read `FROM documents d LIMIT 1` with no fixture of its
+    // own. When the clone held no documents the INSERT…SELECT matched no rows, inserted
+    // nothing, threw nothing, and the assertion failed — which is the lucky version of
+    // that mistake. Had it been written as `.resolves` it would have passed forever
+    // against a constraint that does not exist. The test now seeds its own target and
+    // asserts it exists first [std-45 cl-4].
+    const doc = await createDocDraft(seededMemexId, "FK probe", "FK", "spec");
+    const docRows = (await db.execute(
+      sql`SELECT memex_id FROM documents WHERE id = ${doc.id}`,
+    )) as unknown as { memex_id: string }[];
+    expect(docRows.length).toBe(1);
+    expect(docRows[0].memex_id).toBe(seededMemexId);
+
+    // ⚠ Assert on the CAUSE, not the surface message. Drizzle wraps a driver error in a
+    // generic `Failed query: …`, so `.rejects.toThrow(/foreign key/)` fails even when the
+    // constraint fired correctly — the first version of this assertion did exactly that
+    // and would have been easy to misread as "the FK is not working".
+    let caught: unknown;
+    try {
+      await db.execute(sql`
+        INSERT INTO doc_sections (doc_id, memex_id, section_type, content, seq, position)
+        VALUES (${doc.id},
+                '00000000-0000-0000-0000-000000000001'::uuid,  -- deliberately not the doc's
+                'rule', 'x', 9999, 9999)
+      `);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught, "the write was ACCEPTED — the tenancy FK is not enforcing").toBeDefined();
+    const cause = (caught as { cause?: { code?: string; constraint_name?: string } }).cause;
+    // 23503 = foreign_key_violation. Asserting the SQLSTATE rather than prose keeps this
+    // independent of Postgres's message wording across versions and locales.
+    expect(cause?.code).toBe("23503");
+    expect(cause?.constraint_name).toBe("doc_sections_doc_id_memex_id_fkey");
   });
 });

--- a/packages/server/src/services/activity-view-arm-tenancy.spec-563.integration.test.ts
+++ b/packages/server/src/services/activity-view-arm-tenancy.spec-563.integration.test.ts
@@ -1,0 +1,97 @@
+// spec-563 t-4 (ac-3) — the pattern is fixed, not just the one arm.
+//
+// ac-3 asks that "every UNION arm is walked and states where its memex_id comes from". A
+// one-time walk recorded in prose rots the moment someone adds a ninth arm. This is the
+// walk expressed as a guard.
+//
+// THE INVARIANT, and why it is spelled this way. pg_get_viewdef renders a column that is
+// already named correctly as a BARE reference — `te.memex_id`, no alias. It only emits
+// `AS memex_id` when the value is an EXPRESSION that needs renaming: a correlated
+// subquery, a COALESCE, a join-recovered column. So:
+//
+//     the live definition contains `AS memex_id`  ⇔  some arm derives its tenant
+//
+// One assertion covers all eight arms and any arm added later, without naming them.
+//
+// ⚠ WHY THIS IS READ FROM THE CATALOGUE AND NOT FROM A MIGRATION FILE. activity_view is
+// defined across six migrations, and 0142 recreates it dynamically from pg_get_viewdef
+// without carrying its text — so no file in the repo is the view's definition [spec-564].
+// Asserting against a file would test a fiction. This Spec's entire first draft was that
+// mistake.
+
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-563/acs";
+
+async function liveViewDef(): Promise<string> {
+  const rows = (await db.execute(
+    sql`SELECT pg_get_viewdef('activity_view'::regclass, true) AS def`,
+  )) as unknown as { def: string }[];
+  return rows[0].def;
+}
+
+describe("activity_view: no arm recovers its tenant [spec-563 t-4]", () => {
+  it("ac-3: every UNION arm takes memex_id from a column, never from an expression", async () => {
+    tagAc(`${AC}/ac-3`);
+
+    const def = await liveViewDef();
+
+    // Vacuity guard — if the view were missing or empty, every assertion below would pass
+    // for the wrong reason (std-45 cl-4).
+    expect(def.length).toBeGreaterThan(500);
+    expect(def).toContain("UNION ALL");
+    expect((def.match(/UNION ALL/g) ?? []).length).toBe(7); // 8 arms
+
+    // The invariant. Before 0147 this failed on the doc_sections arm, whose tenant came
+    // from `( SELECT pd.memex_id FROM documents pd WHERE pd.id = s.doc_id) AS memex_id`.
+    expect(def).not.toMatch(/AS memex_id/);
+
+    // And the specific shape that was there, named so a reader of a future failure knows
+    // what it looked like rather than only that a regex tripped.
+    expect(def).not.toContain("FROM documents pd");
+  });
+
+  it("ac-3: the guard above can fail — a derived tenant is detectable", async () => {
+    tagAc(`${AC}/ac-3`);
+
+    // Proving the invariant is not vacuous: build a view that DOES derive its tenant and
+    // confirm the same assertion catches it. Without this, `not.toMatch` would pass just as
+    // happily against a rendering convention that never emits `AS memex_id` at all — and
+    // the guard would be decoration.
+    const probe = `spec563_derived_tenant_probe_${process.env.VITEST_WORKER_ID ?? "0"}`;
+    await db.execute(
+      sql.raw(`
+        CREATE OR REPLACE VIEW ${probe} AS
+        SELECT s.id,
+               (SELECT pd.memex_id FROM documents pd WHERE pd.id = s.doc_id) AS memex_id
+          FROM doc_sections s`),
+    );
+    try {
+      const rows = (await db.execute(
+        sql.raw(`SELECT pg_get_viewdef('${probe}'::regclass, true) AS def`),
+      )) as unknown as { def: string }[];
+      expect(rows[0].def).toMatch(/AS memex_id/);
+    } finally {
+      await db.execute(sql.raw(`DROP VIEW IF EXISTS ${probe}`));
+    }
+  });
+
+  it("ac-3: doc_sections supplies its own tenant, and it agrees with the document's", async () => {
+    tagAc(`${AC}/ac-3`);
+
+    // The column is denormalised from documents.memex_id. A denormalised column that can
+    // disagree with its source is a tenancy bug waiting to happen, so assert the two never
+    // diverge across every row present.
+    const rows = (await db.execute(sql`
+      SELECT count(*)::int AS total,
+             count(*) FILTER (WHERE s.memex_id <> d.memex_id)::int AS mismatched
+        FROM doc_sections s
+        JOIN documents d ON d.id = s.doc_id
+    `)) as unknown as { total: number; mismatched: number }[];
+
+    expect(rows[0].mismatched).toBe(0);
+  });
+});

--- a/packages/server/src/services/activity-view-spec-filter.spec-563.integration.test.ts
+++ b/packages/server/src/services/activity-view-spec-filter.spec-563.integration.test.ts
@@ -205,6 +205,10 @@ describe("activity footer: the spec filter must reach test_events [spec-563 t-1]
     // TOTAL_NOISE. The 10% bar is deliberately loose: it must not be satisfiable by a
     // marginal improvement, and it must not go red over a handful of rows the planner
     // touches while descending an index.
-    expect(rowsRead).toBeLessThan(TOTAL_NOISE * 0.1);
+    // MEASURED: 2000 before the index (the tenant's whole history), 0 after. The bound is
+    // an absolute 100 rather than the exact 0 we observe — an exact match would go red on
+    // a single row touched while descending an index, which is not the defect. It is far
+    // enough below TOTAL_NOISE that no partial regression can slip under it.
+    expect(rowsRead).toBeLessThan(100);
   });
 });

--- a/packages/server/src/services/activity-view-spec-filter.spec-563.integration.test.ts
+++ b/packages/server/src/services/activity-view-spec-filter.spec-563.integration.test.ts
@@ -1,0 +1,210 @@
+// spec-563 t-1 (dec-1) — the regression guard for the activity footer's SPEC filter.
+//
+// THE DEFECT. `listActivityView(memexId, { specRef })` reads activity_view with two
+// predicates. `memex_id` pushes down to test_events (it is a base column, indexed since
+// spec-398's 0111). `spec_ref` does NOT: for the test_events arm `spec_ref` IS
+// `spec_doc.id`, and the only link back to the table is
+//
+//     substring(te.subject_ref from 'specs/([^/]+)/') = spec_doc.handle
+//
+// with no index on that expression. So Postgres builds a hash join whose PROBE SIDE is
+// the tenant's entire test_events history and discards everything that is not the
+// requested Spec — measured on prod 2026-09-11 as 4 155 275 rows read to return 0, in
+// 9 343 ms of a 9 347 ms query, for a Spec that has no test events at all.
+//
+// WHAT THIS ASSERTS, AND WHY IT IS THE ROW COUNT. The number of test_events rows the plan
+// actually reads. NOT the scan type: the sequential scan visible on prod today serves the
+// TENANT filter and is a defensible plan choice, so a test keyed on "Index Scan not Seq
+// Scan" could be satisfied by a change that repairs nothing — and would also go green if
+// someone merely forced an index onto the tenant predicate. Row count is the only signal
+// that tracks the defect [spec-563 ac-2, ac-8].
+//
+// THE FIXTURE IS THE EMPTY-SPEC CASE ON PURPOSE. The Spec under read has ZERO test events.
+// Its footer returns nothing, and today it still costs the whole tenant's history. A
+// fixture where the target Spec owned rows would let a partial fix look total.
+//
+// ⚠ RED FIRST. Written before the index exists (std-52). It MUST fail on develop, and the
+// failure output belongs on t-1. A guard that has never been red proves nothing.
+//
+// ⚠ SCALE CAVEAT, STATED RATHER THAN HIDDEN. At fixture scale the planner may pick a
+// sequential scan even once the index exists, because scanning a few thousand rows is
+// cheaper than an index descent. That would make this test fail for a reason that is not
+// the defect. So the assertion runs with enable_seqscan OFF: it asks "is there an index
+// this predicate CAN use", which is exactly the coupling that rots silently when the view
+// text and the index expression drift apart. Whether the prod planner CHOOSES it is a
+// different claim, and ac-2's before/after EXPLAIN on the real tenant is what settles it.
+// Both are needed; neither substitutes for the other.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  testEvents,
+} from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-563/acs";
+
+// Enough rows that "the whole tenant" and "this Spec's own" are unmistakably different
+// numbers, and small enough that seeding stays fast.
+const NOISE_SPECS = 40;
+const EVENTS_PER_SPEC = 50;
+const TOTAL_NOISE = NOISE_SPECS * EVENTS_PER_SPEC; // 2000
+
+const created = {
+  users: [] as string[],
+  memexes: [] as string[],
+  docs: [] as string[],
+};
+
+let memexId: string;
+let nsSlug: string;
+let emptySpecDocId: string;
+
+beforeAll(async () => {
+  // std-37: per-worker-unique identifiers so parallel workers never collide.
+  const sub = `s563t1-${process.env.VITEST_WORKER_ID ?? "0"}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`.toLowerCase();
+
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${sub}@memex.ai`, name: "Fixture Actor" } as typeof users.$inferInsert)
+    .returning();
+  created.users.push(u.id);
+
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` })
+    .returning();
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+
+  memexId = mx.id;
+  nsSlug = ns.slug;
+  created.memexes.push(mx.id);
+
+  // NOISE: many Specs, each carrying test events. None of these is the one we read.
+  const rows: (typeof testEvents.$inferInsert)[] = [];
+  for (let i = 0; i < NOISE_SPECS; i++) {
+    const doc = await createDocDraft(memexId, `Noise ${i}`, `N${i}`, "spec");
+    created.docs.push(doc.id);
+    const [docRow] = await db.select().from(documents).where(eq(documents.id, doc.id));
+    for (let j = 0; j < EVENTS_PER_SPEC; j++) {
+      rows.push({
+        subjectRef: `${nsSlug}/main/specs/${docRow.handle}/acs/ac-1`,
+        memexId,
+        status: "pass",
+        testIdentifier: `noise-${i}-${j}`,
+        actor: "ci-bot",
+      } as typeof testEvents.$inferInsert);
+    }
+  }
+  // Chunked insert — one 2000-row VALUES list is a needlessly large statement.
+  for (let k = 0; k < rows.length; k += 250) {
+    await db.insert(testEvents).values(rows.slice(k, k + 250));
+  }
+
+  // THE SUBJECT: a Spec in the same Memex with NO test events of its own.
+  const empty = await createDocDraft(memexId, "The Empty Spec", "ES", "spec");
+  emptySpecDocId = empty.id;
+  created.docs.push(empty.id);
+
+  // Without stats the planner is guessing, and a plan-shaped assertion on a guess is noise.
+  await db.execute(sql`ANALYZE test_events`);
+});
+
+afterAll(async () => {
+  await db.delete(testEvents).where(eq(testEvents.memexId, memexId)).catch(() => {});
+  if (created.docs.length)
+    await db.delete(documents).where(inArray(documents.id, created.docs)).catch(() => {});
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+/** Sum `Actual Rows` across every plan node reading a test_events relation (the parent or
+ *  any partition). Walks the whole tree — the arm sits several levels down, under a Gather
+ *  and a Hash Join, and on a partitioned table it fans out across an Append. */
+function testEventRowsRead(node: Record<string, unknown>): number {
+  let total = 0;
+  const rel = node["Relation Name"];
+  if (typeof rel === "string" && rel.startsWith("test_events")) {
+    const actual = node["Actual Rows"];
+    const loops = node["Actual Loops"];
+    // Actual Rows is PER LOOP; a parallel node's loops are the leader plus its workers
+    // sharing ONE scan, so the product is the total read, not a scan repeated.
+    total += (typeof actual === "number" ? actual : 0) * (typeof loops === "number" ? loops : 1);
+  }
+  for (const key of ["Plans", "Plan"]) {
+    const child = node[key];
+    if (Array.isArray(child)) for (const c of child) total += testEventRowsRead(c as Record<string, unknown>);
+    else if (child && typeof child === "object") total += testEventRowsRead(child as Record<string, unknown>);
+  }
+  return total;
+}
+
+describe("activity footer: the spec filter must reach test_events [spec-563 t-1]", () => {
+  it("ac-8: reading one Spec's footer does not read the tenant's whole test_events history", async () => {
+    tagAc(`${AC}/ac-8`);
+
+    // ── Vacuity guard (std-45 cl-4) ─────────────────────────────────────────
+    // If the seed silently did nothing, every assertion below passes for the wrong
+    // reason. Prove the preconditions before proving the claim.
+    const [{ count: seeded }] = (await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(testEvents)
+      .where(eq(testEvents.memexId, memexId))) as { count: number }[];
+    expect(seeded).toBe(TOTAL_NOISE);
+
+    // postgres-js: db.execute resolves to the ROW ARRAY itself, not a { rows } wrapper.
+    // Getting this wrong made the first run of this test fail on `footer.some is not a
+    // function` — red, but for the test's own bug rather than for the defect. Exactly the
+    // misreading a red-first discipline exists to catch: "it failed" is not "it failed
+    // for the reason claimed".
+    const footer = (await db.execute(
+      sql`SELECT kind FROM activity_view WHERE memex_id = ${memexId} AND spec_ref = ${emptySpecDocId}`,
+    )) as unknown as { kind: string }[];
+    // The subject Spec owns no test events — that is the whole point of the fixture.
+    expect(footer.some((r) => r.kind === "test_event")).toBe(false);
+
+    // ── The measurement ─────────────────────────────────────────────────────
+    // enable_seqscan off: see the SCALE CAVEAT in this file's header. This asks whether
+    // an index exists that this predicate can use, which is the coupling that rots.
+    const explained = await db.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL enable_seqscan = off`);
+      const rows = (await tx.execute(
+        sql`EXPLAIN (ANALYZE, FORMAT JSON)
+            SELECT at, actor_user_id, actor_name, actor_raw, channel,
+                   spec_ref, kind, entity_id, action, narrative, memex_id
+              FROM activity_view
+             WHERE memex_id = ${memexId}
+               AND spec_ref = ${emptySpecDocId}
+             ORDER BY at DESC
+             LIMIT 200`,
+      )) as unknown as { "QUERY PLAN": unknown }[];
+      return rows[0]["QUERY PLAN"];
+    });
+
+    const plan = (Array.isArray(explained) ? explained[0] : explained) as Record<string, unknown>;
+    const rowsRead = testEventRowsRead(plan);
+
+    // ── The claim ───────────────────────────────────────────────────────────
+    // The subject Spec has ZERO test events, so a filter that reaches the table reads
+    // ~nothing. Today the probe side is the tenant's whole history, so this reads
+    // TOTAL_NOISE. The 10% bar is deliberately loose: it must not be satisfiable by a
+    // marginal improvement, and it must not go red over a handful of rows the planner
+    // touches while descending an index.
+    expect(rowsRead).toBeLessThan(TOTAL_NOISE * 0.1);
+  });
+});

--- a/packages/server/src/services/activity-view-tenant-identity.spec-563.integration.test.ts
+++ b/packages/server/src/services/activity-view-tenant-identity.spec-563.integration.test.ts
@@ -1,0 +1,205 @@
+// spec-563 t-3 (ac-4) — the repair changes which access path the planner takes, not which
+// rows qualify. That is a CLAIM, and this file is where it stops being an assumption.
+//
+// TWO OBLIGATIONS, and a third test whose only job is to prove the second one can fail.
+//
+//   1. OUTPUT IDENTITY. The rows a reader sees are the same with and without the index —
+//      same lines, same order, same attribution. Rather than compare across commits (which
+//      would need the fix reverted), both plans are produced in ONE run by toggling the
+//      planner: index paths off reproduces the pre-fix shape, index paths on is what ships.
+//      An index that changed the answer would show up here as a diff.
+//
+//   2. TENANT ISOLATION. Two Memexes are seeded with COLLIDING spec handles — both own a
+//      `spec-1`, because handles are per-Memex and collide across every Memex. That
+//      collision is not incidental: it is the exact shape of spec-396's cross-org bleed,
+//      where the arm joined on the handle ALONE and one Memex's test event matched every
+//      other Memex's same-numbered spec (~1.5 M rows misattributed). Reading tenant A must
+//      return nothing of B's.
+//
+//   3. ⚠ THE ISOLATION ASSERTION IS PROVEN NON-VACUOUS. A test that cannot fail proves
+//      nothing, and this Spec already contains one worked example of an assertion that
+//      stayed green with its subject removed. So the third test builds a scratch view
+//      carrying the PRE-0109 join (handle only, no memex_id equality), reads tenant A
+//      through it, and asserts the leak IS visible. If that test ever goes green, test 2's
+//      silence means nothing and both must be rewritten [std-45 cl-3, cl-4].
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq, inArray, sql } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  documents,
+  testEvents,
+} from "../db/schema.js";
+import { createDocDraft } from "./documents.js";
+import { listActivityView } from "./activity-view.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-563/acs";
+
+type Tenant = {
+  userId: string;
+  memexId: string;
+  nsSlug: string;
+  docId: string;
+  handle: string;
+};
+
+const created = { users: [] as string[], memexes: [] as string[] };
+
+async function seedTenant(tag: string, eventCount: number): Promise<Tenant> {
+  // std-37: per-worker-unique so parallel workers never collide.
+  const sub = `s563t3${tag}-${process.env.VITEST_WORKER_ID ?? "0"}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`.toLowerCase();
+
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${sub}@memex.ai`, name: `Actor ${tag}` } as typeof users.$inferInsert)
+    .returning();
+  created.users.push(u.id);
+
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` })
+    .returning();
+  created.memexes.push(mx.id);
+  await db.insert(orgMemberships).values({ userId: u.id, orgId: org.id, role: "administrator" });
+
+  const doc = await createDocDraft(mx.id, `Subject ${tag}`, `S${tag}`, "spec");
+  const [docRow] = await db.select().from(documents).where(eq(documents.id, doc.id));
+
+  // Distinct created_at per row. `ORDER BY at DESC` does not break ties, so identical
+  // timestamps would make the ORDER half of "same lines, same order" untestable — the
+  // comparison would flake on a detail that is not the claim.
+  const base = Date.UTC(2026, 0, 1);
+  await db.insert(testEvents).values(
+    Array.from({ length: eventCount }, (_, j) => ({
+      subjectRef: `${ns.slug}/main/specs/${docRow.handle}/acs/ac-1`,
+      memexId: mx.id,
+      status: "pass",
+      testIdentifier: `${tag}-${j}`,
+      actor: `ci-${tag}`,
+      createdAt: new Date(base + j * 1000),
+    })) as (typeof testEvents.$inferInsert)[],
+  );
+
+  return { userId: u.id, memexId: mx.id, nsSlug: ns.slug, docId: doc.id, handle: docRow.handle };
+}
+
+let tenantA: Tenant;
+let tenantB: Tenant;
+
+beforeAll(async () => {
+  tenantA = await seedTenant("a", 25);
+  tenantB = await seedTenant("b", 25);
+});
+
+afterAll(async () => {
+  for (const t of [tenantA, tenantB]) {
+    if (t) await db.delete(testEvents).where(eq(testEvents.memexId, t.memexId)).catch(() => {});
+  }
+  if (created.memexes.length)
+    await db.delete(documents).where(inArray(documents.memexId, created.memexes)).catch(() => {});
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length) await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+describe("activity view: the repair changes the path, not the answer [spec-563 t-3]", () => {
+  it("ac-4: the rows a reader sees are identical with and without the index path", async () => {
+    tagAc(`${AC}/ac-4`);
+
+    // Vacuity guard — if the fixture is empty, "identical" is trivially true (std-45 cl-4).
+    const withIndex = await listActivityView(tenantA.memexId, { specRef: tenantA.docId });
+    expect(withIndex.filter((r) => r.kind === "test_event").length).toBe(25);
+
+    // The pre-fix plan shape, reproduced in the same run: with index paths off the planner
+    // must fall back to scanning, which is what it did before 0146 existed.
+    const withoutIndex = await db.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL enable_indexscan = off`);
+      await tx.execute(sql`SET LOCAL enable_bitmapscan = off`);
+      await tx.execute(sql`SET LOCAL enable_indexonlyscan = off`);
+      return (await tx.execute(
+        sql`SELECT at, actor_user_id, actor_name, actor_raw, channel,
+                   spec_ref, kind, entity_id, action, narrative, memex_id
+              FROM activity_view
+             WHERE memex_id = ${tenantA.memexId}
+               AND spec_ref = ${tenantA.docId}
+             ORDER BY at DESC
+             LIMIT 200`,
+      )) as unknown as Record<string, unknown>[];
+    });
+
+    // Same lines, same order, same attribution.
+    expect(withoutIndex.length).toBe(withIndex.length);
+    withIndex.forEach((row, i) => {
+      const other = withoutIndex[i];
+      expect(other.entity_id).toBe(row.entityId);
+      expect(other.kind).toBe(row.kind);
+      expect(other.action).toBe(row.action);
+      expect(other.actor_raw).toBe(row.actorRaw);
+      expect(other.memex_id).toBe(row.memexId);
+      expect(new Date(other.at as string).getTime()).toBe(new Date(row.at).getTime());
+    });
+  });
+
+  it("ac-4: reading one tenant returns nothing belonging to another, despite colliding handles", async () => {
+    tagAc(`${AC}/ac-4`);
+
+    // The precondition that makes this test mean anything: both Memexes really do own a
+    // spec with the SAME handle. Without the collision there is nothing for a broken join
+    // to confuse, and the test would pass on a view with no tenancy at all.
+    expect(tenantA.handle).toBe(tenantB.handle);
+    expect(tenantA.memexId).not.toBe(tenantB.memexId);
+
+    const rowsA = await listActivityView(tenantA.memexId, { specRef: tenantA.docId });
+    const eventsA = rowsA.filter((r) => r.kind === "test_event");
+
+    expect(eventsA.length).toBe(25);
+    expect(eventsA.every((r) => r.memexId === tenantA.memexId)).toBe(true);
+    // B's events carry actor 'ci-b'. Not one of them may appear in A's feed.
+    expect(eventsA.some((r) => r.actorRaw === "ci-b")).toBe(false);
+  });
+
+  it("ac-4: that isolation assertion is not vacuous — the pre-0109 join DOES leak", async () => {
+    tagAc(`${AC}/ac-4`);
+
+    // A scratch view carrying the join spec-396 removed: handle only, no memex_id
+    // equality. This is not a hypothetical — it is what shipped in 0089 and what
+    // misattributed ~1.5 M rows in production.
+    const scratch = `spec563_leak_probe_${process.env.VITEST_WORKER_ID ?? "0"}`;
+    await db.execute(
+      sql.raw(`
+        CREATE OR REPLACE VIEW ${scratch} AS
+        SELECT te.created_at AS at, te.actor AS actor_raw, spec_doc.id AS spec_ref,
+               spec_doc.memex_id AS memex_id
+          FROM test_events te
+          JOIN documents spec_doc
+            ON spec_doc.handle = substring(te.subject_ref, 'specs/([^/]+)/')
+           AND spec_doc.doc_type = 'spec'`),
+    );
+
+    try {
+      const leaked = (await db.execute(
+        sql.raw(
+          `SELECT actor_raw FROM ${scratch} WHERE memex_id = '${tenantA.memexId}' AND spec_ref = '${tenantA.docId}'`,
+        ),
+      )) as unknown as { actor_raw: string }[];
+
+      // If THIS is false, the fixture cannot express a leak and test 2's silence is
+      // meaningless. The whole point of this file is that this line fails loudly rather
+      // than a green suite implying safety it never checked.
+      expect(leaked.some((r) => r.actor_raw === "ci-b")).toBe(true);
+    } finally {
+      await db.execute(sql.raw(`DROP VIEW IF EXISTS ${scratch}`));
+    }
+  });
+});

--- a/packages/server/src/services/clause-refs.spec-179.test.ts
+++ b/packages/server/src/services/clause-refs.spec-179.test.ts
@@ -161,7 +161,7 @@ describe("0076 backfill SQL — lock-step with the TS parser (ac-10)", () => {
     createdDocIds.push(doc.id);
     const [section] = await db
       .insert(docSections)
-      .values({
+      .values({ memexId: memex,
         docId: doc.id,
         sectionType: "rule",
         content: "It pairs with std-2.",

--- a/packages/server/src/services/documents.integration.test.ts
+++ b/packages/server/src/services/documents.integration.test.ts
@@ -172,6 +172,7 @@ describe("getDoc", () => {
   it("returns sections ordered by seq", async () => {
     await db.insert(docSections).values({
       docId: testDoc.id,
+      memexId,
       sectionType: "scope",
       title: "Scope",
       content: "Scope content",

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -306,7 +306,7 @@ export async function createDocDraft(
         rows.length > 0
           ? await db
               .insert(docSections)
-              .values(rows.map((r) => ({ ...r, position: r.seq, ...bornAttribution })))
+              .values(rows.map((r) => ({ ...r, memexId, position: r.seq, ...bornAttribution })))
               .returning()
           : [];
 

--- a/packages/server/src/services/execution_plans.ts
+++ b/packages/server/src/services/execution_plans.ts
@@ -113,6 +113,7 @@ export async function createExecutionPlan(
 
         const sectionRows = EXECUTION_PLAN_SECTION_TYPES.map((sectionType, idx) => ({
           docId: doc.id,
+          memexId,
           sectionType,
           title: SECTION_TITLES[sectionType],
           content: input.sections?.[sectionType] ?? "",

--- a/packages/server/src/services/facet-classifier.integration.test.ts
+++ b/packages/server/src/services/facet-classifier.integration.test.ts
@@ -57,7 +57,7 @@ beforeAll(async () => {
   docId = doc.id;
   const [section] = await db
     .insert(docSections)
-    .values({ docId, sectionType: "rule", content: "x", seq: 1, position: 1 })
+    .values({ memexId, docId, sectionType: "rule", content: "x", seq: 1, position: 1 })
     .returning();
   sectionId = section.id;
   await addClause("All database access must enforce row-level security per tenant.");

--- a/packages/server/src/services/facet-gap-backfill.integration.test.ts
+++ b/packages/server/src/services/facet-gap-backfill.integration.test.ts
@@ -50,7 +50,7 @@ beforeAll(async () => {
     .returning();
   const [sec] = await db
     .insert(docSections)
-    .values({ docId: doc.id, sectionType: "rule", content: "x", seq: 1, position: 1 })
+    .values({ memexId, docId: doc.id, sectionType: "rule", content: "x", seq: 1, position: 1 })
     .returning();
   for (let i = 0; i < 3; i++) {
     const [cl] = await db

--- a/packages/server/src/services/facet-routing-hybrid.integration.test.ts
+++ b/packages/server/src/services/facet-routing-hybrid.integration.test.ts
@@ -57,7 +57,7 @@ async function seedStandard(handle: string, title: string, clauseTags: string[][
     .returning();
   const [section] = await db
     .insert(docSections)
-    .values({ docId: doc.id, sectionType: "rule", content: title, seq: 1, position: 1 })
+    .values({ memexId, docId: doc.id, sectionType: "rule", content: title, seq: 1, position: 1 })
     .returning();
   for (let i = 0; i < clauseTags.length; i++) {
     const [cl] = await db

--- a/packages/server/src/services/facet-routing.integration.test.ts
+++ b/packages/server/src/services/facet-routing.integration.test.ts
@@ -46,7 +46,7 @@ async function seedStandard(handle: string, title: string, clauseTags: string[][
     .returning();
   const [section] = await db
     .insert(docSections)
-    .values({ docId: doc.id, sectionType: "rule", content: `${title} — ${clauseTags.flat().join(" ")}`, seq: 1, position: 1 })
+    .values({ memexId, docId: doc.id, sectionType: "rule", content: `${title} — ${clauseTags.flat().join(" ")}`, seq: 1, position: 1 })
     .returning();
   for (let i = 0; i < clauseTags.length; i++) {
     const [cl] = await db

--- a/packages/server/src/services/facets-schema.integration.test.ts
+++ b/packages/server/src/services/facets-schema.integration.test.ts
@@ -85,7 +85,7 @@ beforeAll(async () => {
   docId = doc.id;
   const [section] = await db
     .insert(docSections)
-    .values({ docId, sectionType: "rule", content: "x", seq: 1, position: 1 })
+    .values({ memexId: orgMemexId, docId, sectionType: "rule", content: "x", seq: 1, position: 1 })
     .returning();
   for (let i = 0; i < 3; i++) {
     const [cl] = await db

--- a/packages/server/src/services/mcp-latency-watch.spec-563.integration.test.ts
+++ b/packages/server/src/services/mcp-latency-watch.spec-563.integration.test.ts
@@ -1,0 +1,201 @@
+// spec-563 t-6 (dec-2) — the tail watcher, exercised against seeded shapes.
+//
+// The decisive test is the LAST one: it replays the shape of the window this Spec was
+// created by — a median that IMPROVED while the tail exploded — and asserts the watcher
+// trips on it. A rule evaluated only against healthy data has not been tested, and an
+// alert that would not have caught the incident it was built for is decoration.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { tagAc } from "@memex-ai-ac/vitest";
+import { db } from "../db/connection.js";
+import {
+  users,
+  namespaces,
+  orgs,
+  orgMemberships,
+  memexes,
+  mcpSessions,
+  mcpToolCalls,
+} from "../db/schema.js";
+import { readLatencyTail, reportBreaches } from "./mcp-latency-watch.js";
+
+const AC = "mindset-prod/memex-building-itself/specs/spec-563/acs";
+const TOOL = `s563_probe_${process.env.VITEST_WORKER_ID ?? "0"}`;
+
+const created = { users: [] as string[], memexes: [] as string[], sessions: [] as string[] };
+let noisyMemex: string;
+let quietMemex: string;
+let userId: string;
+
+async function seedTenant(tag: string): Promise<string> {
+  const sub = `s563t6${tag}-${process.env.VITEST_WORKER_ID ?? "0"}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`.toLowerCase();
+  const [ns] = await db.insert(namespaces).values({ slug: sub, kind: "org" }).returning();
+  const [org] = await db.insert(orgs).values({ namespaceId: ns.id, name: `Test ${sub}` }).returning();
+  await db.update(namespaces).set({ ownerOrgId: org.id }).where(eq(namespaces.id, ns.id));
+  const [mx] = await db
+    .insert(memexes)
+    .values({ namespaceId: ns.id, slug: "main", name: `Test ${sub}` })
+    .returning();
+  created.memexes.push(mx.id);
+  await db.insert(orgMemberships).values({ userId, orgId: org.id, role: "administrator" });
+  return mx.id;
+}
+
+/** Write N calls of the given durations under one tenant. */
+async function seedCalls(memexId: string, durations: number[]) {
+  const sessionId = `s563t6-${memexId}-${Math.random().toString(36).slice(2, 8)}`;
+  await db.insert(mcpSessions).values({ sessionId, userId } as typeof mcpSessions.$inferInsert);
+  created.sessions.push(sessionId);
+  await db.insert(mcpToolCalls).values(
+    durations.map((durationMs) => ({
+      sessionId,
+      userId,
+      memexId,
+      toolName: TOOL,
+      argsJson: {},
+      durationMs,
+    })) as (typeof mcpToolCalls.$inferInsert)[],
+  );
+}
+
+beforeAll(async () => {
+  const sub = `s563t6u-${process.env.VITEST_WORKER_ID ?? "0"}-${Date.now().toString(36)}`;
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${sub}@memex.ai`, name: "Watch probe" } as typeof users.$inferInsert)
+    .returning();
+  userId = u.id;
+  created.users.push(u.id);
+  noisyMemex = await seedTenant("noisy");
+  quietMemex = await seedTenant("quiet");
+});
+
+afterAll(async () => {
+  if (created.sessions.length)
+    await db.delete(mcpSessions).where(inArray(mcpSessions.sessionId, created.sessions)).catch(() => {});
+  if (created.memexes.length)
+    await db.delete(memexes).where(inArray(memexes.id, created.memexes)).catch(() => {});
+  if (created.users.length)
+    await db.delete(users).where(inArray(users.id, created.users)).catch(() => {});
+});
+
+describe("mcp latency tail watcher [spec-563 t-6]", () => {
+  it("ac-9: reads per tool AND per tenant, so one noisy Memex is not diluted by healthy ones", async () => {
+    tagAc(`${AC}/ac-9`);
+
+    // The noisy tenant: a healthy body with a fat tail. The quiet one: uniformly fast.
+    await seedCalls(noisyMemex, [...Array(38).fill(200), ...Array(4).fill(60_000)]);
+    await seedCalls(quietMemex, Array(40).fill(180));
+
+    const readings = await readLatencyTail({ tools: [TOOL], minCalls: 20 });
+
+    // Vacuity guard — without both tenants present the isolation claim is untested.
+    const byMemex = new Map(readings.map((r) => [r.memexId, r]));
+    expect(byMemex.has(noisyMemex)).toBe(true);
+    expect(byMemex.has(quietMemex)).toBe(true);
+
+    // THE CLAIM: the tenants are distinguished. A fleet-wide percentile over these same
+    // rows would be diluted — 4 slow calls in 82 — and is exactly what Cloud Run latency
+    // was rejected for being.
+    expect(byMemex.get(noisyMemex)!.breached).toBe(true);
+    expect(byMemex.get(quietMemex)!.breached).toBe(false);
+    expect(byMemex.get(quietMemex)!.slowCalls).toBe(0);
+  });
+
+  it("ac-10: a thin window is reported as nothing, not as a percentile of three calls", async () => {
+    tagAc(`${AC}/ac-10`);
+
+    const thin = await seedTenant("thin");
+    await seedCalls(thin, [200, 200, 90_000]); // 1 catastrophic call out of 3
+
+    const readings = await readLatencyTail({ tools: [TOOL], minCalls: 20 });
+    // A p95 over three calls is "that call". Alerting on it teaches people to mute the
+    // alert, which is how the next eleven-day window starts.
+    expect(readings.find((r) => r.memexId === thin)).toBeUndefined();
+
+    // And prove that suppression is the CALL COUNT and not the tenant being invisible:
+    // drop the floor and the same rows do report.
+    const unfiltered = await readLatencyTail({ tools: [TOOL], minCalls: 1 });
+    expect(unfiltered.find((r) => r.memexId === thin)).toBeDefined();
+  });
+
+  it("ac-10: replaying the observed window trips it — a mean would have stayed green", async () => {
+    tagAc(`${AC}/ac-10`);
+
+    // The shape of the eleven days this Spec was created by: p50 IMPROVED (1 222 → 579 ms)
+    // while p95 went 2 167 → 31 010 ms. Modelled as a fast body plus a heavy tail.
+    const replay = await seedTenant("replay");
+    const body = Array(95).fill(579); // the improving median
+    const tail = Array(5).fill(31_010); // the tail nobody watched
+    await seedCalls(replay, [...body, ...tail]);
+
+    const readings = await readLatencyTail({ tools: [TOOL], minCalls: 20 });
+    const r = readings.find((x) => x.memexId === replay);
+    expect(r).toBeDefined();
+
+    // THE POINT OF THIS ENTIRE SPEC. The mean of this window is ~2.1s and its median is
+    // 579ms — BOTH look healthy, and both were watched for eleven days while a tenant
+    // waited half a minute for a document.
+    const mean = [...body, ...tail].reduce((a, b) => a + b, 0) / 100;
+    expect(mean).toBeLessThan(10_000); // a mean-based alert: GREEN
+    expect(r!.breached).toBe(true); // this watcher: BREACHED
+
+    // ⚠ AND HERE IS WHY THE WATCHER CARRIES TWO SIGNALS RATHER THAN A PERCENTILE ALONE.
+    // This fixture is exactly 5 slow calls in 100, so `percentile_disc(0.95)` lands on the
+    // LAST FAST value and reports 579 ms — the p95 alone does NOT see this window. A
+    // percentile is blind to a tail that is exactly its own width, and that blindness is a
+    // knife edge: one more slow call and it fires, one fewer and it does not.
+    expect(r!.p95Ms).toBe(579);
+    // The slow-call count has no such edge. It is what actually catches this shape, and
+    // the reason `breached` is an OR rather than a threshold on p95.
+    expect(r!.slowCalls).toBe(5);
+
+    // Prove the p95 arm is not dead either — widen the tail past its own width and the
+    // percentile picks it up, so the OR is two live signals rather than one plus a prop.
+    const wider = await seedTenant("wider");
+    await seedCalls(wider, [...Array(90).fill(579), ...Array(10).fill(31_010)]);
+    const widened = (await readLatencyTail({ tools: [TOOL], minCalls: 20 })).find(
+      (x) => x.memexId === wider,
+    );
+    expect(widened!.p95Ms).toBe(31_010);
+  });
+
+  it("ac-9: what is reported carries aggregates only — never args, user, or row content", async () => {
+    tagAc(`${AC}/ac-9`);
+
+    const leaky = await seedTenant("leaky");
+    await seedCalls(leaky, [...Array(30).fill(200), ...Array(3).fill(70_000)]);
+
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+      lines.push(String(a[0]));
+    });
+    try {
+      const readings = await readLatencyTail({ tools: [TOOL], minCalls: 20 });
+      reportBreaches(readings);
+    } finally {
+      spy.mockRestore(); // std-37: restore global stubs
+    }
+
+    const ours = lines.filter((l) => l.includes(leaky));
+    expect(ours.length).toBeGreaterThan(0);
+
+    for (const line of ours) {
+      // WHOLLY-JSON, no `[domain]` prefix: a prefixed line stays an opaque textPayload in
+      // Cloud Logging and a log-based metric on field predicates matches NOTHING —
+      // reporting silence, which reads as health. That is the failure this watcher
+      // replaces, and it must not come back through the delivery mechanism.
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      expect(parsed.event).toBe("mcp_latency_tail_breach");
+      // Aggregates only. mcp_tool_calls also holds args_json and user_id; std-31 makes
+      // this sharper than usual, since this Memex is publicly readable.
+      expect(Object.keys(parsed).sort()).toEqual(
+        ["calls", "event", "memexId", "p95Ms", "slowCalls", "tool"].sort(),
+      );
+      expect(line).not.toContain(userId);
+    }
+  });
+});

--- a/packages/server/src/services/mcp-latency-watch.ts
+++ b/packages/server/src/services/mcp-latency-watch.ts
@@ -1,5 +1,35 @@
 // spec-563 t-6 (dec-2) — the tail watcher.
 //
+// ⚠⚠ NOTHING CALLS THIS. IT IS NOT DEPLOYED, AND THAT IS DELIBERATE. ⚠⚠
+//
+// This module is a reference implementation, not a running monitor. There is no Cloud
+// Scheduler job, no endpoint, no alert policy, no channel. If the defect recurs today,
+// nobody is told.
+//
+// WHY IT WAS BUILT AND THEN NOT WIRED. spec-332 (`MCP endpoint performance & scalability
+// hardening`) already owns this ground, and reading its ACs settled it:
+//   • its ac-1 sets **get_doc p95 < 1 s** — the same tool, the same metric, a threshold
+//     TEN TIMES stricter than the 10 s used here;
+//   • its ac-4 requires the signal to be emitted out-of-band and to land in the
+//     environment's Slack channel — the DESTINATION this watcher never had.
+// Deploying this alongside would have created a third observability path: one dead
+// (spec-412's OTEL, emitting nothing in either environment for months), one stopgap, one
+// planned — and the predictable outcome is someone reading "we have monitoring" and
+// believing all three work.
+//
+// WHAT SURVIVES, AND WHERE IT WENT. Two properties this incident PROVED necessary are
+// absent from spec-332's six ACs, and they were handed to it rather than kept here:
+//   1. PER-TENANT granularity. One Memex degraded while every other stayed healthy; a
+//      fleet-wide p95 dilutes exactly that shape below any threshold worth setting.
+//   2. CONTINUOUS reading of real traffic. spec-332 measures under a LOAD HARNESS, which
+//      validates an SLO at a moment; it does not watch what production is doing at 3am.
+// Recorded on spec-332 as an open decision, with this incident as its evidence.
+//
+// KEEP OR DELETE? Keep while spec-332 is unbuilt — the query, the call-count floor and the
+// two-armed breach rule are the parts that took measurement to get right, and re-deriving
+// them costs more than carrying them. Delete once spec-332 ships its own signal; carrying
+// two implementations is how the next reader ends up unsure which one is live.
+//
 // WHAT IT WATCHES AND WHY IT IS NOT A NEW SENSOR. `src/mcp/tools.ts` already times every
 // MCP tool invocation and `logToolCall` writes it to `mcp_tool_calls` — in production, on
 // every call, with `duration_ms`, `tool_name`, `memex_id` and `created_at`. dec-2 chose to

--- a/packages/server/src/services/mcp-latency-watch.ts
+++ b/packages/server/src/services/mcp-latency-watch.ts
@@ -1,0 +1,175 @@
+// spec-563 t-6 (dec-2) — the tail watcher.
+//
+// WHAT IT WATCHES AND WHY IT IS NOT A NEW SENSOR. `src/mcp/tools.ts` already times every
+// MCP tool invocation and `logToolCall` writes it to `mcp_tool_calls` — in production, on
+// every call, with `duration_ms`, `tool_name`, `memex_id` and `created_at`. dec-2 chose to
+// READ that rather than install anything, because every alternative built a sensor and the
+// one sensor this system already had (spec-412's OTEL metrics) has been emitting nothing
+// in both environments for months while continuing to look like a dependency.
+//
+// ── THE TWO RULES THIS EXISTS TO OBEY ──────────────────────────────────────────────────
+//
+// 1. WATCH THE TAIL, NEVER AN AVERAGE. Over the window this replaces, `get_doc`'s median
+//    IMPROVED — p50 1 222 ms → 579 ms — while p95 went 2 167 ms → 31 010 ms. An alert on a
+//    mean stayed green for eleven days and a dashboard on the median showed a win. So this
+//    computes a high percentile and a slow-call count, and never a mean.
+//
+// 2. NEVER KEY ON ERRORS. Nothing errors: the call completes, it is merely slow. Verified
+//    against prod — 2 responses ≥500 on /mcp in 7 days, both sub-second, so not slow calls
+//    timing out. An error-rate alert cannot see this defect at all.
+//
+// ── AGGREGATES ONLY, AND THAT IS A SECURITY CONSTRAINT ─────────────────────────────────
+//
+// `mcp_tool_calls` also carries `args_json` (tool arguments verbatim), `user_id`, and in
+// dev mode `result_text`. NOTHING from a row reaches a caller of this module: the shape
+// returned is counts and durations. std-31 sharpens this — this Memex builds itself in the
+// open, so an alert quoting a row could carry a real person's name into a public artifact.
+//
+// ── COST (std-39) ──────────────────────────────────────────────────────────────────────
+//
+// `mcp_tool_calls` has no retention, so it grows without bound and the scan target grows
+// with it. Every index on it is a (column, created_at) COMPOSITE — there is no standalone
+// `created_at` index — so a query filtered only by time cannot use one and degrades into a
+// full scan that gets slower every week. Filtering by `tool_name` is therefore not a
+// convenience: it is what lets this read stand on `mcp_tool_calls_tool_error_idx`
+// (tool_name, created_at). A watcher that degrades the database it watches is its own
+// incident.
+
+import { sql } from "drizzle-orm";
+import { db } from "../db/connection.js";
+
+/** Tools whose tail is worth watching. Each one is a separate index-backed read. */
+export const WATCHED_TOOLS = ["get_doc"] as const;
+
+export type TailBreach = {
+  toolName: string;
+  memexId: string | null;
+  calls: number;
+  p95Ms: number;
+  slowCalls: number;
+};
+
+export type TailReading = TailBreach & { breached: boolean };
+
+export type WatchOptions = {
+  /** How far back to look. */
+  windowMinutes?: number;
+  /** A call at or above this is "slow". */
+  slowMs?: number;
+  /** p95 at or above this trips the alert. */
+  p95ThresholdMs?: number;
+  /**
+   * Below this many calls in the window, a percentile is noise and NOTHING is reported.
+   * One slow call out of three is a p95 of "that call" — alerting on it teaches people to
+   * mute the alert, which is how the next eleven-day window starts.
+   */
+  minCalls?: number;
+  tools?: readonly string[];
+};
+
+const DEFAULTS = {
+  windowMinutes: 60,
+  slowMs: 10_000,
+  p95ThresholdMs: 10_000,
+  minCalls: 20,
+} as const;
+
+/**
+ * Read the tail of the watched tools over a rolling window, per tool AND per tenant.
+ *
+ * Per-tenant is load-bearing rather than decorative: the defect this watches degraded ONE
+ * Memex (4.1M rows) while every other tenant stayed healthy, so a fleet-wide percentile
+ * would have been diluted below any threshold worth setting. Grouping is what makes a
+ * single noisy tenant visible.
+ */
+export async function readLatencyTail(opts: WatchOptions = {}): Promise<TailReading[]> {
+  const windowMinutes = opts.windowMinutes ?? DEFAULTS.windowMinutes;
+  const slowMs = opts.slowMs ?? DEFAULTS.slowMs;
+  const p95ThresholdMs = opts.p95ThresholdMs ?? DEFAULTS.p95ThresholdMs;
+  const minCalls = opts.minCalls ?? DEFAULTS.minCalls;
+  const tools = opts.tools ?? WATCHED_TOOLS;
+
+  if (tools.length === 0) return [];
+
+  // percentile_disc returns an ACTUAL observed value rather than interpolating between
+  // two, so a reported p95 is always a duration some call really took — which matters when
+  // the number ends up in an incident note.
+  // Every value is BOUND, never interpolated — `tools` is a module constant today, but a
+  // query that would be injectable if its input ever came from elsewhere is a defect
+  // waiting for the day someone makes it configurable. `make_interval` takes the window as
+  // a parameter, so no interval literal is built by string concatenation either.
+  //
+  // ⚠ `= ANY(${array})` does NOT work here: drizzle's sql template flattens a JS array
+  // into ONE parameter, which Postgres then rejects as a malformed array literal
+  // (22P02). sql.join binds each element as its own parameter, which is both correct and
+  // still fully parameterised.
+  const rows = (await db.execute(sql`
+    SELECT tool_name                                                      AS "toolName",
+           memex_id                                                       AS "memexId",
+           count(*)::int                                                  AS "calls",
+           percentile_disc(0.95) WITHIN GROUP (ORDER BY duration_ms)::int AS "p95Ms",
+           count(*) FILTER (WHERE duration_ms >= ${slowMs})::int          AS "slowCalls"
+      FROM mcp_tool_calls
+     WHERE tool_name IN (${sql.join(
+       tools.map((t) => sql`${t}`),
+       sql`, `,
+     )})
+       AND created_at >= now() - make_interval(mins => ${windowMinutes})
+     GROUP BY tool_name, memex_id
+  `)) as unknown as TailBreach[];
+
+  // ⚠ THE OR IS LOAD-BEARING, AND IT WAS MEASURED RATHER THAN ASSUMED.
+  //
+  // A percentile is BLIND to a tail exactly its own width. Replaying this Spec's own
+  // window — 95 calls at 579 ms plus 5 at 31 010 ms — `percentile_disc(0.95)` lands on the
+  // last FAST value and reports 579 ms. The p95 arm alone does not see the very incident
+  // this watcher exists for, and it is a knife edge: one more slow call and it fires, one
+  // fewer and it does not.
+  //
+  // The slow-call count has no such edge, so it is what actually catches that shape. Both
+  // arms are live (the test proves the p95 arm fires on a wider tail) — neither is a prop,
+  // and removing either leaves a blind spot that looks exactly like health.
+  return rows
+    .filter((r) => r.calls >= minCalls)
+    .map((r) => ({ ...r, breached: r.p95Ms >= p95ThresholdMs || r.slowCalls > 0 }));
+}
+
+/**
+ * Emit one line per breach, as WHOLLY-JSON on stdout.
+ *
+ * ⚠ NO `[domain]` PREFIX, deliberately, and this is the difference between a working
+ * monitor and a silent one. Cloud Logging turns a wholly-JSON stdout line into a queryable
+ * `jsonPayload`; a prefixed line stays an opaque `textPayload` and a log-based metric
+ * built on field predicates matches NOTHING — reporting silence, which reads as health.
+ * That is precisely the failure mode dec-2 exists to end, so it must not be reintroduced
+ * by the delivery mechanism. It is the one sanctioned exception to std-14's per-domain
+ * prefix convention, and the reason is recorded here rather than left to be rediscovered.
+ *
+ * Only aggregates are emitted. No args, no user, no row content.
+ */
+export function reportBreaches(readings: TailReading[]): TailReading[] {
+  const breaches = readings.filter((r) => r.breached);
+  for (const b of breaches) {
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        event: "mcp_latency_tail_breach",
+        tool: b.toolName,
+        memexId: b.memexId,
+        calls: b.calls,
+        p95Ms: b.p95Ms,
+        slowCalls: b.slowCalls,
+      }),
+    );
+  }
+  return breaches;
+}
+
+/** One tick: read, then report. Returns what breached, for the caller's response body. */
+export async function runLatencyTailWatch(opts: WatchOptions = {}): Promise<{
+  readings: number;
+  breaches: TailReading[];
+}> {
+  const readings = await readLatencyTail(opts);
+  return { readings: readings.length, breaches: reportBreaches(readings) };
+}

--- a/packages/server/src/services/sections.ts
+++ b/packages/server/src/services/sections.ts
@@ -121,7 +121,7 @@ export async function addSection(
           try {
             const [row] = await db
               .insert(docSections)
-              .values({
+              .values({ memexId,
                 docId,
                 sectionType,
                 title: sectionTitle,
@@ -231,7 +231,7 @@ export async function splitSection(
         for (let i = 1; i < chunks.length; i++) {
           const [newSection] = await tx
             .insert(docSections)
-            .values({
+            .values({ memexId,
               docId: section.docId,
               sectionType: `${section.sectionType}_part_${i + 1}`,
               title: chunks[i].title ?? `${section.title ?? section.sectionType} (Part ${i + 1})`,

--- a/packages/server/src/services/spec-151-clause-coverage.integration.test.ts
+++ b/packages/server/src/services/spec-151-clause-coverage.integration.test.ts
@@ -120,7 +120,7 @@ beforeAll(async () => {
     .values({ memexId, handle: "std-1", title: "A standard", docType: "standard", status: "approved" })
     .returning();
   docId = std.id;
-  const [sec] = await db.insert(docSections).values({ docId, sectionType: "rule", content: "x", seq: 1, position: 1 }).returning();
+  const [sec] = await db.insert(docSections).values({ memexId, docId, sectionType: "rule", content: "x", seq: 1, position: 1 }).returning();
   sectionId = sec.id;
 
   // Six clauses spanning the matrix of (obligation, testable) + verification states.

--- a/packages/server/src/services/spec-151-poc.integration.test.ts
+++ b/packages/server/src/services/spec-151-poc.integration.test.ts
@@ -90,7 +90,7 @@ beforeAll(async () => {
     .values({ memexId, handle: "std-8", title: "Every mutation goes through mutate()", docType: "standard", status: "approved" })
     .returning();
   docId = std.id;
-  const [sec] = await db.insert(docSections).values({ docId, sectionType: "rule", content: "x", seq: 1, position: 1 }).returning();
+  const [sec] = await db.insert(docSections).values({ memexId, docId, sectionType: "rule", content: "x", seq: 1, position: 1 }).returning();
   await db.insert(standardClauses).values({
     memexId, docId, sectionId: sec.id, seq: 69, position: 1,
     body: "Every mutation of a tenancy-scoped resource MUST go through mutate(ctx, key, fn).",

--- a/packages/server/src/services/standards.ts
+++ b/packages/server/src/services/standards.ts
@@ -306,6 +306,7 @@ export async function createStandard(
       .values(
         allRows.map((row, idx) => ({
           docId: doc.id,
+          memexId,
           sectionType: row.sectionType,
           title: row.title,
           content: row.content,
@@ -959,6 +960,11 @@ export async function findStandardsAffectedByDecision(
     entry.matchingSections.push({
       id: row.sectionId,
       docId: row.sectionDocId,
+      // spec-563 (0147): doc_sections now carries its own memex_id. This projection
+      // reconstructs a partial DocSection and the match query is already scoped to one
+      // Memex, so the section's tenant is the caller's — read from the scope rather than
+      // re-selected, and never defaulted to something that could belong elsewhere.
+      memexId,
       sectionType: row.sectionType,
       title: row.sectionTitle,
       description: row.sectionDescription,

--- a/packages/server/src/services/whats-new-generation.spec-200.test.ts
+++ b/packages/server/src/services/whats-new-generation.spec-200.test.ts
@@ -80,7 +80,7 @@ async function seedSpec(opts: { status: string; handle: string }): Promise<{ mem
     .insert(documents)
     .values({ memexId, handle: opts.handle, title: "Adjustable left navigation drawer", docType: "spec", status: opts.status })
     .returning();
-  await db.insert(docSections).values({
+  await db.insert(docSections).values({ memexId,
     docId: doc.id,
     sectionType: "overview",
     title: "Overview",


### PR DESCRIPTION
Renders a document's activity footer in time proportional to what it returns, instead of to the tenant's whole history.

Prod, 2026-09-11: **4 155 275 rows read to return 0**, 9 343 ms of a 9 347 ms query, for a Spec that owns no test events at all. Worst case in `pg_stat_statements` is **109 734 ms** (same plan, cold cache) across 2 368 calls — roughly 4 hours of database time.

---

## ⚠ The Spec blamed the wrong thing, and that is half of what this PR is

spec-563 originally said `activity_view`'s `test_events` arm recovered `memex_id` through a join, so the **tenant** filter could not be pruned. That was true of `0089` and **has not been true since `0109`/`0111`** — spec-398 shipped that fix months ago. The authoring error was reading the migration that *created* the view and treating it as the view's definition.

Confirmed against the live catalogue with `pg_get_viewdef('activity_view'::regclass, true)`, not deduced from the migration chain — which also proves the chain is fully applied in prod (61 partitions, `subject_ref` renamed by `0119`, `te.memex_id` present).

The **measurements** always stood. Only the mechanism was misattributed.

**The real defect is the SPEC filter.** `spec_ref` *is* `spec_doc.id`, and the only link back to `test_events` is `substring(te.subject_ref, 'specs/([^/]+)/') = spec_doc.handle`, with nothing indexed on that expression. So Postgres builds a hash join whose probe side is every row the tenant owns, then discards everything that is not the requested Spec.

The sequential scan in the prod plan serves the **tenant** filter, is a defensible choice (the largest tenant owns ~73 % of the loaded partitions), and is **not touched here**.

## What changed

| | |
|---|---|
| `out-of-band/0145` | Builds the expression index `CONCURRENTLY`, per partition, then `ATTACH`es. **Applied by hand, before deploy.** |
| `0146` | The same index, self-sufficient for fresh databases, plus assertions on what it left behind. |
| `0147` | `doc_sections` gains its own `memex_id`; the view arm reads the column. |
| `0148` | A composite FK so a section's tenant **cannot** disagree with its document's. |
| tests | Five new suites — the regression guard, output identity + isolation, the all-arms invariant, the telemetry session gate, the tail watcher. |
| `mcp-latency-watch.ts` | A tail watcher, built and tested — and **deliberately not deployed**. See below. |

### `CREATE INDEX CONCURRENTLY` is refused on a partitioned parent

`0141`'s single-statement pattern predates `0142`'s partitioning. On the parent, Postgres errors outright:

```
ERROR: cannot create index on partitioned table "test_events" concurrently
```

`0145` uses the documented three-step form: `CREATE INDEX ON ONLY` the parent (invalid, catalogue-only), one `CREATE INDEX CONCURRENTLY` per partition via `\gexec`, then `ALTER INDEX … ATTACH PARTITION` for each. The parent becomes `VALID` automatically once the last partition attaches. **An interrupted run leaves it INVALID — safe, but useless, and the planner ignores it silently**, which is why `0146` asserts validity rather than assuming it.

### The migrations assert instead of trusting

`IF NOT EXISTS` matches on the **name alone**, and `0142`'s header records the near-miss where a taken name made the statement create nothing with only a scrolled-past `NOTICE`. `0146` raises on: index absent, index `INVALID`, name held by a different definition, or `activity_view` no longer containing the pattern the index is built on.

`0147` **captures and patches** rather than restating: six migrations define this view and `0142` recreates it dynamically without carrying its text, so retyping the body would silently revert whatever the author did not know about. It refuses to proceed if the regex matched nothing, and re-asserts `security_invoker` — which does **not** survive a `DROP VIEW`, and losing it would quietly disable the std-36 RLS posture.

### `doc_sections` — the surviving instance, and the constraint that followed

The one arm still recovering its tenant through a correlated subquery. Every sibling already carries the column [std-32].

**Measured before sizing.** `EXPLAIN` shows `actor_user_id` is an **index condition**, so the subplan only runs on rows that already survived it. **Consistency repair, not a latency fix** — and scoped as one. No index added: one serving no measured reader costs a tuple per insert forever [std-39].

**`0148` came from CI going red on this PR.** A test counting cross-table mismatches found one within an hour of `0147` landing — the right outcome by the wrong mechanism: the check ran late, in a suite, and only because another test shared the database. The invariant moved to a composite FK, so a wrong tenant now fails **at the insert**, naming the row. That test's own isolation violation is fixed too.

### The tail watcher is built and NOT deployed

dec-2 put the watcher on `mcp_tool_calls` — the per-call duration the server already records. Reading spec-332's ACs then settled that it should not ship: **its ac-1 sets `get_doc` p95 < 1 s** (same tool, same metric, ten times stricter) and **its ac-4 already requires the alert to land in the environment's Slack channel** — the destination this watcher never had.

Deploying alongside would have created a *third* observability path: one dead (spec-412's OTEL, emitting nothing in either environment for months), one stopgap, one planned — and someone would read "we have monitoring" and believe all three work.

So the endpoint was removed and the module carries a banner saying nothing calls it. Two properties this incident proved necessary, absent from spec-332's six ACs, were handed to it as **dec-14**: per-tenant granularity, and a continuous read of real traffic.

⚠ **Nothing watches this query's tail today.** That gap is accepted knowingly and recorded on ac-5, not implied away.

## Test plan

- [x] Full server suite — **741 files / 6782 tests green**
- [x] `make check` (offline battery, standards index)
- [x] The regression guard driven **red first**: `expected 2000 to be less than 200`, then `2000 → 0`. Probed for the exact count rather than trusting "under 200"
- [x] Output identity proven **without a revert** — both plan shapes produced in one run via planner toggles
- [x] Tenant isolation under **colliding spec handles** (spec-396's exact bleed shape), plus a scratch view carrying the pre-`0109` join proving the assertion **can** fail
- [x] All-arms invariant: the live definition contains no `AS memex_id`, plus a probe proving that guard can fail
- [x] The telemetry session gate exercised through the **real `/mcp` endpoint** with no session header
- [x] The watcher replayed against the observed window's shape
- [ ] **`make e2e-cold` NOT run locally** — the target is a documented local-environment failure (hardcodes `:5432`/pg14, dies on migration `0023`). No user-facing flow changes (ac-4 makes byte-identical output an obligation), and the suite is a required per-PR check, so CI covers it. Flagged rather than silently skipped [std-28]
- [ ] **`0145` must be applied BY HAND, int then prod, before this deploys.** Confirm `indisvalid` is true — verification query at the foot of the file
- [ ] **ac-2's AFTER plan on the largest tenant** — cannot be captured until the migrations are applied to prod. The BEFORE plan is recorded on the Spec
- [ ] **ac-7** — that a partition minted by `test-event-retention.ts` *after* the migration inherits the index. Verifying against the partitions the migration itself built would prove the wrong thing
- [ ] **ac-5 / ac-11** — carried to spec-332 dec-14 by design, not satisfied here

## Notes for the reviewer

**A clean typecheck was a false signal of completeness.** Making `doc_sections.memex_id` NOT NULL should have been fully caught by `tsc`. It surfaced in three layers: `tsc` named 27 files; the runtime NOT NULL violation then found fixtures cast with **`as any`** (removed here, not worked around); and a **raw SQL** insert survived both. One fixture typechecked green while resolving `memexId` to a module-level `let` that was `undefined` at run time. The seven remaining shorthand sites were audited by hand — a defined-but-wrong memex passes NOT NULL silently.

**A percentile is blind to a tail exactly its own width.** Replaying the real window — 95 calls at 579 ms plus 5 at 31 010 ms — `percentile_disc(0.95)` returns **579 ms**. The watcher therefore pairs the percentile with a slow-call count; both arms are proven live. Found by the test failing, not reasoned in advance.

**Rollback** is `DROP INDEX` for the index half. `0147`/`0148` are forward-only; reverting means restoring the correlated subquery in the view.

Refs: spec-563 (t-1 … t-7) · spec-332 dec-14 · spec-564 stamps the `SUPERSEDED` markers that would have prevented the original error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
