### PR TITLE
fix(spec-563): 0145 refuses to run after 0146, and psql now stops on it

### DIFF
--- a/packages/server/drizzle/out-of-band/0145_spec563_activity_footer_index_prep.sql
+++ b/packages/server/drizzle/out-of-band/0145_spec563_activity_footer_index_prep.sql
@@ -53,6 +53,50 @@
 -- A CONCURRENTLY build that fails leaves an INVALID index behind, which nothing will use
 -- and nothing will complain about. 0146 asserts this rather than trusting it.
 
+-- ⚠ ON_ERROR_STOP IS LOAD-BEARING, NOT HOUSEKEEPING. psql's DEFAULT is to keep going after
+-- an error, so without this the §0 guard below RAISES, is ignored, and the script cheerfully
+-- builds the orphan indexes it just refused to build. Measured: the first version of that
+-- guard printed its refusal and then created duplicates anyway.
+\set ON_ERROR_STOP on
+
+-- ── 0. ⚠ REFUSE TO RUN AFTER 0146. THIS ORDER IS NOT ADVICE. ────────────────────────────
+--
+-- MEASURED, not reasoned: this file was run against a database where 0146 had already
+-- created the parent index, to find out what happens. It is worse than a no-op.
+--
+-- `CREATE INDEX ... ON test_events` (0146, on the PARENT) automatically creates and
+-- ATTACHES an index on all 61 partitions. Running this file afterwards then:
+--   • skips §1 with a NOTICE (the parent name is taken),
+--   • SUCCEEDS at all 61 CONCURRENT per-partition builds — they use different names,
+--   • and FAILS every ATTACH with
+--       ERROR: cannot attach index "test_events_2026MMDD_mx_spec_created_idx" ...
+--       DETAIL: Another index is already attached for partition "test_events_2026MMDD".
+--
+-- The failures are the loud part. The damage is the quiet part: 61 orphan duplicate
+-- indexes are left behind, attached to nothing, each costing a tuple per insert forever on
+-- the hottest table in the system, serving no reader. psql keeps going after an error in a
+-- non-transactional script, so the operator sees a wall of red and a database that is
+-- worse than before.
+--
+-- This block makes that unreachable.
+DO $$
+DECLARE attached int;
+BEGIN
+  SELECT count(*) INTO attached
+    FROM pg_inherits pi
+    JOIN pg_class parent ON parent.oid = pi.inhparent
+   WHERE parent.relname = 'test_events_memex_spec_handle_created_idx';
+
+  IF attached > 0 THEN
+    RAISE EXCEPTION
+      'spec-563: 0146 has ALREADY run here — the parent index exists with % partition '
+      'indexes attached. This file is a PRE-deploy step only. Running it now would build '
+      '% orphan duplicate indexes that can never attach and would never be used. Nothing '
+      'to do: the index is already in place.', attached, attached;
+  END IF;
+END $$;
+--> only meaningful under psql; the runner never sees this file.
+
 -- ── 1. The parent index, ON ONLY — invalid until every partition is attached ────────────
 CREATE INDEX IF NOT EXISTS test_events_memex_spec_handle_created_idx
   ON ONLY test_events (memex_id, substring(subject_ref, 'specs/([^/]+)/'), created_at);


### PR DESCRIPTION
Follow-up to #713. One file, comment and guard only — no change to what the index is or does.

## What was rehearsed, and what it found

Before writing the runbook for applying `out-of-band/0145` by hand, I ran it against a database where **0146 had already created the parent index** — to find out what happens in the wrong order rather than assume it was a harmless no-op.

It is worse than a no-op.

`CREATE INDEX ... ON test_events` (0146, on the partitioned **parent**) automatically creates and **attaches** an index on all 61 partitions. Running 0145 afterwards:

- **skips** its own parent create — the name is taken, `NOTICE` only;
- **SUCCEEDS** at all 61 `CREATE INDEX CONCURRENTLY` per-partition builds, because they use different names;
- **FAILS** every `ATTACH`:

```
ERROR:  cannot attach index "test_events_20260911_mx_spec_created_idx" as a partition of
        index "test_events_memex_spec_handle_created_idx"
DETAIL:  Another index is already attached for partition "test_events_20260911".
```

The failures are the loud part. **The damage is the quiet part:** 61 orphan duplicate indexes are left behind, attached to nothing, each costing a tuple per insert forever on the hottest table in the system, serving no reader. The operator sees a wall of red and a database that is worse than before.

## The fix, in two parts

**§0 refuses** when the parent index already has partition indexes attached, naming the count and saying there is nothing to do.

**`\set ON_ERROR_STOP on`** — and this is load-bearing, not housekeeping. psql's default is to keep going after an error, so the first version of that guard **printed its refusal and then built the duplicates anyway**. Measured, not assumed.

## Verification

Both paths re-run end to end against a real 61-partition table:

| case | result |
|---|---|
| 0146 already applied | refuses, **0 orphans created** |
| clean database | `indisvalid = t`, 61 partitions, **61/61 attached** |
| 0146 run after 0145 | clean no-op, its assertions pass |

The dev database was restored to zero indexes afterwards.

## Test plan

- [x] Guard proven to refuse with no side effects
- [x] Nominal path proven to produce a VALID parent index with every partition attached
- [x] 0146 proven a clean no-op behind it
- [ ] No unit test — this is an out-of-band file the migration runner never sees, and the claim is about psql's behaviour against a partitioned table. Exercising the real artifact is the verification available [std-45 cl-5]

## Why this matters now

#713 is merged and the int deploy has applied 0146 there. **0145 must therefore NOT be run against int** — it is already too late, and this guard is what stops someone doing it anyway. On prod the order still holds: 0145 first, `indisvalid` confirmed, then the promotion.

Refs: spec-563 t-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
